### PR TITLE
WIP - Redo scoping rules to closer match CA65

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,7 +47,7 @@ class Arguments {
   patch : "ips" | "" = "";
 }
 
-const DEBUG_PRINT = false;
+const DEBUG_PRINT = true;
 
 const DEBUG = (...args : any) => {
   if (DEBUG_PRINT) {

--- a/src/linker.ts
+++ b/src/linker.ts
@@ -752,7 +752,9 @@ class Link {
           }
           e = this.symbols[imported].expr!;
         } else {
-          if (e.num == null) throw new Error(`Symbol not global`);
+          const name = e.sym!;
+          const at = Tokens.at(expr);
+          if (e.num == null) throw new Error(`Symbol not global ${name}${at}`);
           e = this.symbols[e.num].expr!;
         }
       }

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -405,12 +405,16 @@ export class Preprocessor implements Tokens.Source {
   evaluateConst(expr: Expr): number {
     // Attempt to look up a symbol and see if its a constant value
     const evalWrapper = (ex: Expr) => {
+      console.log(`evaluating const outer expr: ${JSON.stringify(ex)} `); // jroweboy
       if (ex.op === 'sym' && this.env.definedSymbol(ex.sym!)) {
+        console.log(`is a defined symbol `); // jroweboy
         // HACK? If its defined but not set, default it to zero?
         const num = this.env.evaluate(ex);
+        console.log(`evaluating const num: ${num} expr: ${JSON.stringify(ex)} `); // jroweboy
         if (num === undefined) throw new Error(`Symbol ${ex.sym} is undefined`);
         return Exprs.evaluate({op: 'num', num, meta: Exprs.size(num, undefined)});
       }
+      console.log(` not defined symbol `); // jroweboy
       return Exprs.evaluate(ex);
     }
     expr = Exprs.traversePost(expr, evalWrapper);

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -1,0 +1,160 @@
+import type { Expr } from "./expr";
+import * as Tokens from './token.ts';
+
+export class Symbol {
+  /**
+   * Index into the global symbol array.  Only applies to immutable
+   * symbols that need to be accessible at link time.  Mutable symbols
+   * and symbols with known values at use time are not added to the
+   * global list and are therefore have no id.  Mutability is tracked
+   * by storing a -1 here.
+   */
+  id?: number;
+  /** Whether the symbol has been explicitly scoped. */
+  scoped?: boolean;
+  /**
+   * The expression for the symbol.  Must be a statically-evaluatable constant
+   * for mutable symbols.  Undefined for forward-referenced symbols.
+   */
+  expr?: Expr;
+  /** Name this symbol is exported as. */
+  export?: string;
+  /** Token where this symbol was ref'd. */
+  ref?: {source?: Tokens.SourceInfo}; // TODO - plumb this through
+}
+
+interface ResolveOpts {
+  // Whether to create a forward reference for missing symbols.
+  allowForwardRef?: boolean;
+  // Reference Tokens.
+  ref?: {source?: Tokens.SourceInfo};
+}
+
+interface FwdRefResolveOpts extends ResolveOpts {
+  allowForwardRef: true;
+}
+
+export abstract class BaseScope {
+  //closed = false;
+  protected readonly syms = new Map<string, Symbol>();
+
+  protected pickScope(name: string): [string, BaseScope] {
+    return [name, this];
+  }
+
+  // TODO - may need additional options:
+  //   - lookup constant - won't return a mutable value or a value from
+  //     a parent scope, implies no forward ref
+  //   - shallow - don't recurse up the chain, for assignment only??
+  // Might just mean allowForwardRef is actually just a mode string?
+  //  * ca65's .definedsymbol is more permissive than .ifconst
+  resolve(name: string, opts: FwdRefResolveOpts): Symbol;
+  resolve(name: string, opts?: ResolveOpts): Symbol|undefined;
+  resolve(name: string, opts: ResolveOpts = {}):
+      Symbol|undefined {
+    const {allowForwardRef = false, ref} = opts;
+    const [tail, scope] = this.pickScope(name);
+    const sym = scope.syms.get(tail);
+//console.log('resolve:',name,'sym=',sym,'fwd?',allowForwardRef);
+    if (sym) {
+      if (tail !== name) sym.scoped = true;
+      return sym;
+    }
+    if (!allowForwardRef) return undefined;
+    // if (scope.closed) throw new Error(`Could not resolve symbol: ${name}`);
+    // make a new symbol - but only in an open scope
+    //const symbol = {id: this.symbolArray.length};
+//console.log('created:',symbol);
+    //this.symbolArray.push(symbol);
+    const symbol: Symbol = {ref};
+    scope.syms.set(tail, symbol);
+    if (tail !== name) symbol.scoped = true;
+    console.log(`setting scoped symbol: ${JSON.stringify(symbol)}`) // jroweboy
+    return symbol;
+  }
+  symbols(): Map<string, Symbol> {
+    return this.syms;
+  }
+  addSym(name: string, sym: Symbol) {
+    this.syms.set(name, sym);
+  }
+  getSym(name: string): Symbol|undefined {
+    return this.syms.get(name);
+  }
+  validate() {
+    for (const [name, sym] of this.syms) {
+      if (!sym.expr) 
+        throw new Error(`Symbol '${name}' undefined: ${JSON.stringify(sym)}`);
+    }
+  }
+}
+
+export class Scope extends BaseScope {
+  readonly global: Scope;
+  readonly children = new Map<string, Scope>();
+  readonly anonymousChildren: Scope[] = [];
+
+  constructor(readonly parent?: Scope, readonly kind?: 'scope'|'proc') {
+    super();
+    this.global = parent ? parent.global : this;
+  }
+
+  pickScope(name: string): [string, Scope] {
+    // TODO - plumb the source information through here?
+    // deno-lint-ignore no-this-alias
+    let scope: Scope = this;
+    const split = name.split(/::/g);
+    const tail = split.pop()!;
+    for (let i = 0; i < split.length; i++) {
+      if (!i && !split[i]) { // global
+        scope = scope.global;
+        continue;
+      }
+      let child = scope.children.get(split[i]);
+      while (!i && scope.parent && !child) {
+        child = (scope = scope.parent).children.get(split[i]);
+      }
+      // If the name has an explicit scope, this is an error?
+      if (!child) {
+        const scopeName = split.slice(0, i + 1).join('::');
+        throw new Error(`Could not resolve scope ${scopeName}`);
+      }
+      scope = child;
+    }
+    return [tail, scope];
+  }
+
+  getSym(name: string): Symbol|undefined {
+    // Recursively look through the symbol scopes until you find a match
+    // const sym = this.syms.get(name);
+    // if (sym === undefined || sym.ref) {
+    //   return this.parent?.getSym(name);
+    // }
+    return this.syms.get(name) ?? this.parent?.getSym(name);
+  }
+
+  // close() {
+  //   if (!this.parent) throw new Error(`Cannot close global scope`);
+  //   this.closed = true;
+  //   // Any undefined identifiers in the scope are automatically
+  //   // promoted to the parent scope.
+  //   for (const [name, sym] of this.symbols) {
+  //     if (sym.expr) continue; // if it's defined in the scope, do nothing
+  //     const parentSym = this.parent.symbols.get(sym);
+  //   }
+  // }
+}
+
+export class CheapScope extends BaseScope {
+
+  /** Clear everything out, making sure everything was defined. */
+  clear() {
+    for (const [name, sym] of this.syms) {
+      if (!sym.expr) {
+        const at = sym.ref ? Tokens.at(sym.ref) : '';
+        throw new Error(`Cheap local label never defined: ${name}${at}`);
+      }
+    }
+    this.syms.clear();
+  }
+}

--- a/test/assembler_test.ts
+++ b/test/assembler_test.ts
@@ -1103,7 +1103,7 @@ describe('Assembler', function() {
         }],
         symbols: [
           {expr: {op: 'num', num: 14, meta: {size: 1}}},
-          {expr: {op: 'sym', num: 0}},
+          {expr: {op: 'num', num: 14, meta: {size: 1}}},
         ],
         segments: [],
       });
@@ -1133,13 +1133,14 @@ describe('Assembler', function() {
       const a = new Assembler(Cpu.P02);
       a.assign('bar', 5);
       a.scope('foo');
-      await a.instruction([ident('sta'), ident('bar')]);
+      debugger;
+      await a.instruction([ident('lda'), ident('bar')]);
       a.endScope();
       expect(strip(a.module())).toEqual({
         chunks: [{
           overwrite: 'allow',
           segments: [],
-          data: Uint8Array.of(0xa5, 0x05),
+          data: Uint8Array.of(0xa5, 0xff),
           subs: [{offset: 1, size: 1, expr: {op: 'sym', num: 0}}],
         }],
         symbols: [{expr: {meta: {size: 1}, num: 5, op: "num"}}], segments: [],


### PR DESCRIPTION
The main goal is to fix cases where size isn't appropriately tracked for symbols, causing many locations to use $abs addressing when $zp addressing should be used.

As part of the changes, scope was moved into its own file, and direct access to the symbol table was limited. the new `addSym` method is intended to allow write access to the current scope, and `getSym` works as a "resolve this symbol from any viable scope" which is used to get the size of a declared symbol. 

The goal is to take that size information whenever a symbol created, and make sure its passed through any scopes, aliases, and references to this value. That way when is used in an `add` type address, we can check the size to see if it should be ZP or ABS addressing.

It currently fails a few tests and also doesn't build a project that I'm working on, so this code change isn't complete yet.