### PR TITLE
Frontend refactor to make hermes work as a library

### DIFF
--- a/.github/actions/hermes_compiler/action.yml
+++ b/.github/actions/hermes_compiler/action.yml
@@ -35,7 +35,7 @@ runs:
           hermes/build/tools/shermes
           hermes/build/jsi
           hermes/build/external/boost
-        key: shermes-${{ runner.os }}-${{ inputs.hermes-ref }}-lto-v2
+        key: shermes-${{ runner.os }}-${{ inputs.hermes-ref }}-lto-pic-v3
     - name: Build shermes (LTO)
       if: steps.shermes-cache.outputs.cache-hit != 'true'
       shell: bash
@@ -55,6 +55,7 @@ runs:
         cmake -S hermes -B hermes/build -G Ninja \
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
+          -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
           -DHERMES_ALLOW_BOOST_CONTEXT=1 \
           -DHERMES_ENABLE_DEBUGGER=OFF \
           -DHERMES_BUILD_SHARED_JSI=OFF \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  hermes:
-    # Compile the native js65 frontend (Static Hermes build) on every desktop platform. This produces
-    # both the default `js65` CLI binary and the shared library bundled into the js65.hermes NuGet package
+  build:
     strategy:
       fail-fast: false
       matrix:
@@ -41,6 +39,12 @@ jobs:
         # needs the -dev .so symlinks (the runtime package ships only .so.NN).
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libicu-dev
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
+      - name: Install WASM workload
+        run: dotnet workload restore
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: ".bun-version"
@@ -54,6 +58,24 @@ jobs:
           # Ninja is single-config, so there is no per-config output subdir.
           HERMES_CONFIG: ''
         run: bun run hermes-exe
+      - name: Run Test Cases
+        run: bun test
+      - name: Build Bun release (js65-bun)
+        run: bun run exe
+      - name: Build integration library
+        run: bun run lib
+      - name: Build desktop packages
+        # The Hermes engine loads build/{js65.dll|libjs65.so|libjs65.dylib} in-process; those were
+        # just produced by `bun run hermes-exe` above, so the example can run without staging.
+        run: |
+          dotnet build -c Release integrations/dotnet/js65.interop/js65.interop.csproj
+          dotnet build -c Release integrations/dotnet/js65.clearscript/js65.clearscript.csproj
+          dotnet build -c Release integrations/dotnet/js65.hermes/js65.hermes.csproj
+      - name: Run example project (ClearScript + Hermes engines)
+        run: |
+          dotnet run -c Release --project integrations/dotnet/example/example.csproj -f net8.0
+          dotnet run -c Release --project integrations/dotnet/example/example.csproj -f net8.0 -- --hermes
+          dotnet build -c Release integrations/dotnet/example/example.csproj -f net8.0-browser
       - name: Stage binaries with their RID
         shell: bash
         run: |
@@ -70,70 +92,13 @@ jobs:
           cp build/libjs65.so "dist/lib/${{ matrix.rid }}/" 2>/dev/null || true
           cp build/libjs65.dylib "dist/lib/${{ matrix.rid }}/" 2>/dev/null || true
       - name: Upload hermes binaries
+        # Consumed by the package job, which aggregates every platform's native shared library
+        # into the multi-RID js65.hermes NuGet.
         uses: actions/upload-artifact@v7
         with:
           name: hermes-${{ matrix.rid }}
           path: dist/*
           if-no-files-found: error
-
-  test:
-    # Build the TypeScript frontends, run the unit tests, and exercise the desktop example with BOTH
-    # the ClearScript and Hermes engines on the host platform. Needs the hermes job so the native
-    # js65 binary is available to drive the Hermes engine.
-    needs: hermes
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: windows-latest
-            rid: win-x64
-          - os: ubuntu-latest
-            rid: linux-x64
-          - os: macos-latest
-            rid: osx-arm64
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: '8.0.x'
-      - name: Install WASM workload
-        run: dotnet workload restore
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version-file: ".bun-version"
-      - name: Setup repo and install deps
-        run: bun install
-      - name: Run Test Cases
-        run: bun test
-      - name: Build Bun release (js65-bun)
-        run: bun run exe
-      - name: Build integration library
-        run: bun run lib
-      - name: Download native js65 (hermes) for this platform
-        uses: actions/download-artifact@v8
-        with:
-          name: hermes-${{ matrix.rid }}
-          path: hermes-bin
-      - name: Stage native js65 shared library for the example
-        shell: bash
-        run: |
-          # The Hermes engine loads the shared library in-process; js65.hermes.csproj copies
-          # build/{js65.dll|libjs65.so|libjs65.dylib} next to the example output.
-          mkdir -p build
-          cp hermes-bin/lib/${{ matrix.rid }}/* build/
-      - name: Build desktop packages
-        run: |
-          dotnet build -c Release integrations/dotnet/js65.interop/js65.interop.csproj
-          dotnet build -c Release integrations/dotnet/js65.clearscript/js65.clearscript.csproj
-          dotnet build -c Release integrations/dotnet/js65.hermes/js65.hermes.csproj
-      - name: Run example project (ClearScript + Hermes engines)
-        run: |
-          dotnet run -c Release --project integrations/dotnet/example/example.csproj -f net8.0
-          dotnet run -c Release --project integrations/dotnet/example/example.csproj -f net8.0 -- --hermes
-          dotnet build -c Release integrations/dotnet/example/example.csproj -f net8.0-browser
       - name: Upload bun artifact
         uses: actions/upload-artifact@v7
         with:
@@ -143,7 +108,7 @@ jobs:
 
   package:
     runs-on: ubuntu-latest
-    needs: [test, hermes]
+    needs: build
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,8 @@ concurrency:
 
 jobs:
   hermes:
-    # Compile the native js65 frontend (Static Hermes build) on every desktop platform. This is now
-    # the default `js65` binary, and it is also bundled into the js65.hermes NuGet package
+    # Compile the native js65 frontend (Static Hermes build) on every desktop platform. This produces
+    # both the default `js65` CLI binary and the shared library bundled into the js65.hermes NuGet package
     strategy:
       fail-fast: false
       matrix:
@@ -54,16 +54,22 @@ jobs:
           # Ninja is single-config, so there is no per-config output subdir.
           HERMES_CONFIG: ''
         run: bun run hermes-exe
-      - name: Stage binary with its RID
+      - name: Stage binaries with their RID
         shell: bash
         run: |
-          mkdir -p dist
+          mkdir -p dist "dist/lib/${{ matrix.rid }}"
+          # CLI executable.
           if [ -f build/js65.exe ]; then
             cp build/js65.exe "dist/js65-${{ matrix.rid }}.exe"
           else
             cp build/js65 "dist/js65-${{ matrix.rid }}"
           fi
-      - name: Upload hermes binary
+          # Shared library consumed in-process by the js65.hermes engine. Keep the
+          # platform filename (js65.dll | libjs65.so | libjs65.dylib) under a per-RID dir.
+          cp build/js65.dll "dist/lib/${{ matrix.rid }}/" 2>/dev/null || true
+          cp build/libjs65.so "dist/lib/${{ matrix.rid }}/" 2>/dev/null || true
+          cp build/libjs65.dylib "dist/lib/${{ matrix.rid }}/" 2>/dev/null || true
+      - name: Upload hermes binaries
         uses: actions/upload-artifact@v7
         with:
           name: hermes-${{ matrix.rid }}
@@ -111,16 +117,13 @@ jobs:
         with:
           name: hermes-${{ matrix.rid }}
           path: hermes-bin
-      - name: Stage native js65 for the example
+      - name: Stage native js65 shared library for the example
         shell: bash
         run: |
+          # The Hermes engine loads the shared library in-process; js65.hermes.csproj copies
+          # build/{js65.dll|libjs65.so|libjs65.dylib} next to the example output.
           mkdir -p build
-          if [ -f "hermes-bin/js65-${{ matrix.rid }}.exe" ]; then
-            cp "hermes-bin/js65-${{ matrix.rid }}.exe" build/js65.exe
-          else
-            cp "hermes-bin/js65-${{ matrix.rid }}" build/js65
-            chmod +x build/js65
-          fi
+          cp hermes-bin/lib/${{ matrix.rid }}/* build/
       - name: Build desktop packages
         run: |
           dotnet build -c Release integrations/dotnet/js65.interop/js65.interop.csproj
@@ -163,20 +166,18 @@ jobs:
           pattern: hermes-*
           path: hermes-bin
           merge-multiple: true
-      - name: Stage native executables into js65.hermes/runtimes
+      - name: Stage native shared libraries into js65.hermes/runtimes
         shell: bash
         run: |
-          for f in hermes-bin/js65-*; do
-            base=$(basename "$f")        # js65-win-x64.exe | js65-linux-x64
-            name=${base%.*}              # js65-win-x64    | js65-linux-x64 (no-op when no extension)
-            rid=${name#js65-}            # win-x64 | linux-x64 | osx-arm64
-            ext=""
-            [[ "$base" == *.exe ]] && ext=".exe"
+          # Each platform's shared library was staged under dist/lib/{rid}/{platform name};
+          # drop them into the NuGet RID layout keeping their platform filenames.
+          for d in hermes-bin/lib/*/; do
+            rid=$(basename "$d")         # win-x64 | linux-x64 | osx-arm64
             dest="integrations/dotnet/js65.hermes/runtimes/$rid/native"
             mkdir -p "$dest"
-            cp "$f" "$dest/js65-hermes$ext"
+            cp "$d"/* "$dest/"
           done
-          echo "Staged native executables:"
+          echo "Staged native shared libraries:"
           find integrations/dotnet/js65.hermes/runtimes -type f
       - name: Pack NuGet packages
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
           HERMES_CONFIG: ''
         run: bun run hermes-exe
       - name: Run Test Cases
-        run: bun test
+        run: bun test ${{ github.workspace }}/test
       - name: Build Bun release (js65-bun)
         run: bun run exe
       - name: Build integration library

--- a/integrations/dotnet/example/DesktopExample.cs
+++ b/integrations/dotnet/example/DesktopExample.cs
@@ -31,17 +31,15 @@ vanillaRom[0x10 + 0x1e000 + 5] = 0x60; // rts
 // The assembler is a C# container for the command list that will be passed to the assembler.
 // You can have as many of these as you want, and apply them to the rom in whatever order you want.
 //
-// js65 ships two desktop engines. Pass `--hermes` to drive the standalone Static Hermes executable
+// js65 ships two desktop engines. Pass `--hermes` to use the in-process Static Hermes shared library
 // otherwise the in-process ClearScript/V8 engine is used. You only need to use one or the other
 // in your application. Hermes is about 5x smaller but also 5x slower. So which one you use is up to you.
 var useHermes = args.Contains("--hermes");
 Console.WriteLine($"Using {(useHermes ? "Hermes" : "ClearScript")} engine");
 
-// Both engines derive from Assembler, so the rest of the demo is engine-agnostic. The Hermes engine
-// shells out to a native process, so file includes resolve against its working directory; point it at
-// the output folder where example.s is copied (mirrors how ClearScript resolves relative to the exe).
+// Both engines derive from Assembler, so the rest of the demo is engine-agnostic.
 Assembler asm = useHermes
-  ? new HermesEngine(workingDirectory: AppContext.BaseDirectory)
+  ? new HermesEngine()
   : new ClearScriptEngine();
 asm.Options.includePaths = ["./"];
 asm.Options.lineContinuations = true;
@@ -195,4 +193,73 @@ if (!result.success || result.romdata.Length < vanillaRom.Count)
 Console.WriteLine("Test patch to call the new armor subtract function");
 Console.WriteLine($"sbc,x instruction should be patched to jsr ($20): ${result.romdata[0x10 + 0x0005]:x2}");
 Console.WriteLine($"included file should write constant ($89) at address $8089: ${result.romdata[0x10 + 0x0089]:x2}");
+
+// Second mini-example demonstrating how to use Callbacks
+// Both desktop engines resolve .include / .incbin through Js65Callbacks.
+// The default load file callbacks will read from disk, but you can override them to load from where you want.
+// In this example, we serve one straight from memory with nothing on disk. Pass
+// useFileSystemCallbacks: false to opt out of the default disk loader, then supply your own.
+Console.WriteLine();
+Console.WriteLine("Custom callback demo: serving an include from memory");
+Assembler memAsm = useHermes
+  ? new HermesEngine(useFileSystemCallbacks: false)
+  : new ClearScriptEngine(useFileSystemCallbacks: false);
+memAsm.Options.includePaths = ["./"];
+memAsm.Callbacks = new Js65Callbacks
+{
+  OnFileReadText = (_, relPath) => relPath.EndsWith("constants.inc")
+    ? "CUSTOM_CONSTANT = $42\n"
+    : throw new FileNotFoundException(relPath),
+  OnFileReadBinary = (_, relPath) => throw new FileNotFoundException(relPath),
+};
+memAsm.Module().Code("""
+.segment "HEADER" :bank $00 :size $0010 :mem $0000 :off $00000
+.segment "PRG0"   :bank $00 :size $4000 :mem $8000 :off $00010
+.segment "CHR"    :size $20000 :off $20010 :out
+""", "header.s");
+memAsm.Module().Code("""
+.include "constants.inc"
+.segment "PRG0"
+.org $8050
+.byte CUSTOM_CONSTANT
+""", "patch.s");
+
+var memResult = await memAsm.Apply(vanillaRom.ToArray());
+foreach (var msg in memResult.messages)
+  Console.WriteLine($"  [{msg.level}] {msg.message}");
+Console.WriteLine($"in-memory constant ($42) written at $8050: ${memResult.romdata[0x10 + 0x0050]:x2}");
+if (!memResult.success || memResult.romdata[0x10 + 0x0050] != 0x42)
+{
+  Console.Error.WriteLine("Custom callback demo failed");
+  return 1;
+}
+
+// Cancellation demo: cancellation is cooperative inside the assembler.
+// Here we cancel up front; in practice you'd cancel a long compile
+// from another thread (or via CancellationTokenSource(timeout)).
+Console.WriteLine();
+Console.WriteLine("Cancellation demo: applying with an already-cancelled token");
+Assembler cancelAsm = useHermes
+  ? new HermesEngine(useFileSystemCallbacks: false)
+  : new ClearScriptEngine(useFileSystemCallbacks: false);
+cancelAsm.Options.lineContinuations = true;
+cancelAsm.Module().Code("""
+.segment "HEADER" :bank $00 :size $0010 :mem $0000 :off $00000
+.segment "PRG0"   :bank $00 :size $4000 :mem $8000 :off $00010
+.segment "CHR"    :size $20000 :off $20010 :out
+.org $8000
+lda #$01
+""", "cancel.s");
+using var cts = new CancellationTokenSource();
+cts.Cancel();
+try
+{
+  await cancelAsm.Apply(vanillaRom.ToArray(), cts.Token);
+  Console.Error.WriteLine("Cancellation demo failed: expected OperationCanceledException");
+  return 1;
+}
+catch (OperationCanceledException)
+{
+  Console.WriteLine("Apply correctly threw OperationCanceledException for a cancelled token");
+}
 return 0;

--- a/integrations/dotnet/example/example.csproj
+++ b/integrations/dotnet/example/example.csproj
@@ -9,6 +9,9 @@
     <!-- Only the browser target is WASM; the desktop net8.0 target builds for the host RID so it can
          run either desktop engine (ClearScript in-process, or the native Hermes subprocess). -->
     <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net8.0-browser'">browser-wasm</RuntimeIdentifier>
+    <!-- On a 64-bit Windows host the SDK defaults an Exe's PlatformTarget to x64, which is
+         incompatible with the browser-wasm RID so set it to AnyCPU here-->
+    <PlatformTarget Condition="'$(TargetFramework)' == 'net8.0-browser'">AnyCPU</PlatformTarget>
     <AllowUnsafeBlocks Condition="'$(TargetFramework)' == 'net8.0-browser'">true</AllowUnsafeBlocks>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
   </PropertyGroup>

--- a/integrations/dotnet/js65.browser/BrowserEngine.cs
+++ b/integrations/dotnet/js65.browser/BrowserEngine.cs
@@ -5,30 +5,6 @@ using System.Text.Json.Serialization;
 
 namespace js65;
 
-internal class BrowserAssemblerOptions
-{
-    [JsonPropertyName("includePaths")]
-    public string[] IncludePaths { get; set; } = [];
-
-    [JsonPropertyName("lineContinuations")]
-    public bool LineContinuations { get; set; }
-
-    [JsonPropertyName("numberSeparators")]
-    public bool NumberSeparators { get; set; }
-
-    [JsonPropertyName("generateDebugInfo")]
-    public bool GenerateDebugInfo { get; set; }
-}
-
-internal class BrowserLinkerOptions
-{
-    [JsonPropertyName("baseRom")]
-    public string BaseRom { get; set; } = "";
-
-    [JsonPropertyName("debugLevel")]
-    public int DebugLevel { get; set; }
-}
-
 // Browser-specific source info for JSON deserialization
 internal class BrowserSourceInfo
 {
@@ -64,17 +40,29 @@ internal class BrowserAssemblerMessage
     public string? Stack { get; set; }
 }
 
-// Browser-specific result class that matches the JS output (base64 strings)
+// Browser-specific output file for JSON deserialization (data is base64-encoded: the
+// result is an async JSImport return, where binary can only marshal as a boxed number
+// array, so a base64 blob is the pragmatic transport).
+internal class BrowserOutputFile
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = "";
+
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = "binary";
+
+    [JsonPropertyName("data")]
+    public string Data { get; set; } = "";
+}
+
+// Browser-specific result class that matches compileBrowser's JSON output (base64 strings).
 internal class BrowserCompileResult
 {
     [JsonPropertyName("success")]
     public bool Success { get; set; }
 
-    [JsonPropertyName("romdata")]
-    public string Romdata { get; set; } = "";
-
-    [JsonPropertyName("debugfile")]
-    public string Debugfile { get; set; } = "";
+    [JsonPropertyName("outputs")]
+    public BrowserOutputFile[] Outputs { get; set; } = [];
 
     [JsonPropertyName("messages")]
     public BrowserAssemblerMessage[] Messages { get; set; } = [];
@@ -84,8 +72,7 @@ internal class BrowserCompileResult
 [JsonSerializable(typeof(Js65Options))]
 [JsonSerializable(typeof(Js65Callbacks))]
 [JsonSerializable(typeof(Js65CompileResult))]
-[JsonSerializable(typeof(BrowserAssemblerOptions))]
-[JsonSerializable(typeof(BrowserLinkerOptions))]
+[JsonSerializable(typeof(BrowserOutputFile))]
 [JsonSerializable(typeof(BrowserCompileResult))]
 [JsonSerializable(typeof(BrowserSourceInfo))]
 [JsonSerializable(typeof(BrowserAssemblerMessage))]
@@ -119,18 +106,24 @@ public class JsFileCallbackConfig
 [SupportedOSPlatform("browser")]
 public partial class BrowserJsEngine : Assembler
 {
-    [JSImport("compileActionsBrowser", "js65.interop.libassembler.js")]
+    // Calls libassembler's compileBrowser. We have this strange entrypoint because of the JsInterop
+    // restrictions which prevent us from marshalling a raw list of bytes, so we work around it
+    // by stringifying pretty much everything.
+    [JSImport("compileBrowser", "js65.interop.libassembler.js")]
     [return: JSMarshalAs<JSType.Promise<JSType.String>>]
-    private static partial Task<string> CompileActionsBrowser(
-        string modulesJson,
-        string assemblerOptsJson,
-        string linkerOptsJson,
-        string outputFormat,
+    private static partial Task<string> CompileBrowser(
+        string requestJson,
         [JSMarshalAs<JSType.Function<JSType.String,JSType.String,JSType.String>>]
         Func<string, string, string> textCallback,
         [JSMarshalAs<JSType.Function<JSType.String,JSType.String,JSType.String>>]
         Func<string, string, string> binaryCallback,
-        bool useSourceContents
+        [JSMarshalAs<JSType.Array<JSType.Number>>]
+        byte[] baseRom,
+        // Polled by the core for cooperative cancellation. Best-effort under single-threaded
+        // WASM: the token only flips while .NET runs, so cancellation is observed at the
+        // file-callback await boundaries rather than mid pure-compute.
+        [JSMarshalAs<JSType.Function<JSType.Boolean>>]
+        Func<bool> shouldCancel
     );
 
     // Interop helper for dynamic module imports
@@ -164,7 +157,7 @@ public partial class BrowserJsEngine : Assembler
         _interopModule = JSHost.ImportAsync("js65.interop.js", "../js65/interop.js");
     }
 
-    public override async Task<Js65CompileResult> Apply(byte[] rom)
+    public override async Task<Js65CompileResult> Apply(byte[] rom, CancellationToken ct = default)
     {
         // Import required modules
         _ = await _module;
@@ -176,37 +169,22 @@ public partial class BrowserJsEngine : Assembler
             _fileCallbackModule = await ImportModule(_fileCallbackConfig.ModulePath);
         }
 
-        var modulesJson = SerializeModulesToJson();
+        var requestJson = BuildRequest();
 
-        // Construct assembler options
-        var assemblerOpts = new BrowserAssemblerOptions
-        {
-            IncludePaths = Options.includePaths.ToArray(),
-            LineContinuations = Options.lineContinuations,
-            NumberSeparators = Options.numberSeperators,
-            GenerateDebugInfo = Options.generateDebugInfo
-        };
-        var assemblerOptsJson = JsonSerializer.Serialize(assemblerOpts, AssmeblerContext.Default.BrowserAssemblerOptions);
-
-        // Construct linker options
-        var linkerOpts = new BrowserLinkerOptions
-        {
-            BaseRom = Convert.ToBase64String(rom),
-            DebugLevel = Options.debugLevel
-        };
-        var linkerOptsJson = JsonSerializer.Serialize(linkerOpts, AssmeblerContext.Default.BrowserLinkerOptions);
-
-        var output = await CompileActionsBrowser(
-            modulesJson,
-            assemblerOptsJson,
-            linkerOptsJson,
-            "binary",
+        // The base ROM crosses as a proper binary byte[] param; the result returns as a
+        // base64-encoded JSON string (see CompileBrowser for why these two differ).
+        var output = await CompileBrowser(
+            requestJson,
             LoadTextFileCallback,
             LoadBinaryFileCallback,
-            Options.generateDebugInfo
+            rom,
+            () => ct.IsCancellationRequested
         );
 
-        // Deserialize to browser-specific format (base64 strings) and convert to Js65CompileResult
+        // A cancelled compile returns a clean failure result; surface the .NET cancellation
+        // signal to the caller instead.
+        ct.ThrowIfCancellationRequested();
+
         var browserResult = JsonSerializer.Deserialize(Convert.FromBase64String(output), AssmeblerContext.Default.BrowserCompileResult);
         if (browserResult == null)
         {
@@ -219,8 +197,12 @@ public partial class BrowserJsEngine : Assembler
         return new Js65CompileResult
         {
             success = browserResult.Success,
-            romdata = Convert.FromBase64String(browserResult.Romdata),
-            debugfile = browserResult.Debugfile,
+            outputs = browserResult.Outputs.Select(o => new Js65OutputFile
+            {
+                name = o.Name,
+                type = o.Type,
+                data = Convert.FromBase64String(o.Data),
+            }).ToArray(),
             messages = ConvertMessages(browserResult.Messages)
         };
     }
@@ -267,6 +249,8 @@ public partial class BrowserJsEngine : Assembler
         return "";
     }
 
+    // Returns base64: this is a JSImport delegate callback, and .NET WASM cannot marshal
+    // arrays through callbacks, so include bytes have to cross as a string.
     private string LoadBinaryFileCallback(string basePath, string filePath)
     {
         // C# callbacks take precedence
@@ -275,7 +259,7 @@ public partial class BrowserJsEngine : Assembler
             return Convert.ToBase64String(Callbacks.OnFileReadBinary.Invoke(basePath, filePath));
         }
 
-        // Fall back to JS module callback if configured
+        // Fall back to JS module callback if configured (also returns base64).
         if (_fileCallbackModule != null && _fileCallbackConfig != null)
         {
             var fullPath = CombinePath(basePath, filePath);

--- a/integrations/dotnet/js65.clearscript/ClearScriptEngine.cs
+++ b/integrations/dotnet/js65.clearscript/ClearScriptEngine.cs
@@ -17,6 +17,12 @@ public class ClearScriptEngine : Assembler, IDisposable
 {
     private readonly V8ScriptEngine _engine;
 
+    /// <summary>
+    /// Initialize the Clearscript backed assembler engine.
+    /// </summary>
+    /// <param name="options"></param>
+    /// <param name="useFileSystemCallbacks"></param>
+    /// <param name="debugJavascript">Sets clearscript flags to debug the internal javascript</param>
     public ClearScriptEngine(Js65Options? options = null, bool useFileSystemCallbacks = true, bool debugJavascript = false) : base(options)
     {
         // If you need to debug the javascript, add these flags and connect to the debugger through vscode.
@@ -30,87 +36,147 @@ public class ClearScriptEngine : Assembler, IDisposable
 
         _engine.DocumentSettings.AccessFlags = DocumentAccessFlags.EnableAllLoading;
 
+        // Bare V8 ships no TextEncoder/TextDecoder, which the assembler uses to encode
+        // text outputs, so install a small polyfill
+        _engine.Execute(/* language=javascript */ TextCodecPolyfill);
+
         // Load the js65 code from the embedded resources
         var libassembler = ReadResource(typeof(ClearScriptEngine).Assembly, "js65.libassembler.js");
         _engine.DocumentSettings.AddSystemDocument("@system/libassembler", ModuleCategory.Standard,libassembler);
 
         // Setup the filesystem callbacks
         if (!useFileSystemCallbacks) return;
-        Callbacks = new();
-        Callbacks.OnFileReadText = LoadTextFileCallback;
-        Callbacks.OnFileReadBinary = LoadBinaryFileCallback;
+        Callbacks = new()
+        {
+            OnFileReadText = LoadTextFileCallback,
+            OnFileReadBinary = LoadBinaryFileCallback
+        };
     }
     
-    public override async Task<Js65CompileResult> Apply(byte[] rom)
+    public override async Task<Js65CompileResult> Apply(byte[] rom, CancellationToken ct = default)
     {
-        var data = (ITypedArray<byte>) _engine.Evaluate($"new Uint8Array({rom.Length});");
-        data.WriteBytes(rom, 0, data.Length, 0);
         _engine.AddHostTypes(typeof(Task), typeof(Console), typeof(JavaScriptExtensions), typeof(Js65Callbacks), typeof(Js65Options));
-        _engine.AddHostObject("Options", Options);
         _engine.AddHostObject("FileCallbacks", Callbacks);
-        _engine.Script.romdata = data;
-        _engine.Script.debugFile = "";
+        // The JS polls hostCancel.IsCancellationRequested; a boxed CancellationToken still
+        // reflects cancellation because the struct references the underlying token source.
+        _engine.AddHostObject("hostCancel", ct);
+        _engine.Script.requestJson = BuildRequest();
+
+        // Hand the base ROM to JS as a real Uint8Array (no base64). Allocates it in the
+        // engine, then copy the bytes in through a typed-array view.
+        var baseRomObj = _engine.Evaluate($"new Uint8Array({rom.Length})");
+        if (rom.Length > 0)
+            ((ITypedArray<byte>)baseRomObj).WriteBytes(rom, 0, (ulong)rom.Length, 0);
+        _engine.Script.baseRom = baseRomObj;
+
+        _engine.Script.compileOutputs = null;
         _engine.Script.compileSuccess = false;
         _engine.Script.compileMessages = "[]";
-        _engine.Script.modulesJson = SerializeModulesToJson();
         await Task.Run(() => {
             _engine.Execute(new DocumentInfo { Category = ModuleCategory.Standard },  /* language=javascript */ """
-import { Base64, compileActions, SourceContents } from '@system/libassembler'
+import { compileRequest } from '@system/libassembler'
 
-const modules = JSON.parse(modulesJson, (key, value) => {
-  // Deserialize any of the byte or word b64 arrays into a regular number array
-  if ((key === 'bytes' || key == 'words') && typeof value === 'string') {
-    return new Base64().decode(value);
-  }
-  return value;
-});
-
-const assemblerOpts = {
-    includePaths: [...Options.includePaths],
-    lineContinuations: !!Options.lineContinuations,
-    numberSeparators: !!Options.numberSeparators,
-    generateDebugInfo: !!Options.generateDebugInfo
-};
-
-const linkerOpts = {
-    baseRom: romdata,
-    debugLevel: Options.debugLevel
-};
-
+// ClearScript hands a .NET byte[] back as a host array (indexed access + .Length);
+// copy it into a real Uint8Array the assembler can slice/encode.
+function toU8(hostBytes) {
+    const n = hostBytes.Length;
+    const u8 = new Uint8Array(n);
+    for (let i = 0; i < n; i++) u8[i] = hostBytes[i];
+    return u8;
+}
 const callbacks = {
-    readText: FileCallbacks.OnFileReadText,
-    readBinary: FileCallbacks.OnFileReadBinary
+    readText: (basePath, relPath) => FileCallbacks.OnFileReadText(basePath, relPath),
+    readBinary: (basePath, relPath) => toU8(FileCallbacks.OnFileReadBinary(basePath, relPath)),
 };
+// Bare CancelSignal polling the host token (V8 ships no AbortController); the core reads
+// .aborted at per-line / per-chunk boundaries so a long compile cancels cooperatively.
+const signal = { get aborted() { return hostCancel.IsCancellationRequested; } };
+// compileRequest deserializes the request, and catches any errors to return a proper CompileResult
 (async () => {
-    let src = null;
-    if (assemblerOpts.generateDebugInfo) {
-        src = new SourceContents();
-    }
-    await compileActions(modules, assemblerOpts, linkerOpts, 'binary', callbacks, src).then(result => {
-        for (let i = 0; i < result.data.length; i++) {
-            romdata[i] = result.data[i];
-        }
-        debugFile = result.debugInfo || "";
+    await compileRequest(requestJson, callbacks, baseRom.length ? baseRom : undefined, signal).then(result => {
+        // Hand the whole outputs list (each { name, data:Uint8Array, type }) to the host;
+        // the debug sidecar is just a 'debug'-typed entry, no separate field.
+        compileOutputs = result.outputs;
         compileSuccess = result.success;
         compileMessages = JSON.stringify(result.messages || []);
     });
 })();
 """);
-        });
-        var outdata = new byte[rom.Length];
-        data.ReadBytes(0, (ulong)outdata.Length, outdata, 0);
-        var debugFileContents = (string)_engine.Script.debugFile;
+        }, ct).ConfigureAwait(true);
+        // A cancelled compile returns a clean failure result; surface the .NET cancellation
+        // signal to the caller instead.
+        ct.ThrowIfCancellationRequested();
         var success = (bool)_engine.Script.compileSuccess;
         var messagesJson = (string)_engine.Script.compileMessages;
         var messages = JsonSerializer.Deserialize(messagesJson, Js65JsonContext.Default.Js65AssemblerMessageArray) ?? [];
+
+        // Read each output's typed-array bytes back in C# types.
+        dynamic jsOutputs = _engine.Script.compileOutputs;
+        int count = (int)jsOutputs.length;
+        var outputs = new Js65OutputFile[count];
+        for (var i = 0; i < count; i++)
+        {
+            dynamic o = jsOutputs[i];
+            var ta = (ITypedArray<byte>)o.data;
+            var bytes = new byte[ta.Length];
+            if (ta.Length > 0) ta.ReadBytes(0, (ulong)bytes.Length, bytes, 0);
+            outputs[i] = new Js65OutputFile
+            {
+                name = (string)o.name,
+                type = (string)o.type,
+                data = bytes,
+            };
+        }
         return new Js65CompileResult
         {
             success = success,
-            romdata = outdata,
-            debugfile = debugFileContents,
+            outputs = outputs,
             messages = messages
         };
     }
+
+    // Minimal UTF-8 TextEncoder/TextDecoder for bare V8 (mirrors the Hermes host polyfill).
+    // A bit annoying we need this in two places, but it shouldn't need to change ever.
+    private const string TextCodecPolyfill = /* language=javascript */ """
+if (typeof globalThis.TextEncoder === 'undefined') {
+    globalThis.TextEncoder = class {
+        encode(str) {
+            const out = [];
+            for (let i = 0; i < str.length; i++) {
+                let cp = str.charCodeAt(i);
+                if (cp >= 0xd800 && cp <= 0xdbff && i + 1 < str.length) {
+                    const lo = str.charCodeAt(i + 1);
+                    if (lo >= 0xdc00 && lo <= 0xdfff) { cp = 0x10000 + ((cp - 0xd800) << 10) + (lo - 0xdc00); i++; }
+                }
+                if (cp < 0x80) out.push(cp);
+                else if (cp < 0x800) out.push(0xc0 | (cp >> 6), 0x80 | (cp & 0x3f));
+                else if (cp < 0x10000) out.push(0xe0 | (cp >> 12), 0x80 | ((cp >> 6) & 0x3f), 0x80 | (cp & 0x3f));
+                else out.push(0xf0 | (cp >> 18), 0x80 | ((cp >> 12) & 0x3f), 0x80 | ((cp >> 6) & 0x3f), 0x80 | (cp & 0x3f));
+            }
+            return new Uint8Array(out);
+        }
+    };
+}
+if (typeof globalThis.TextDecoder === 'undefined') {
+    globalThis.TextDecoder = class {
+        decode(input) {
+            const bytes = input instanceof Uint8Array ? input : new Uint8Array(input);
+            let out = '';
+            for (let i = 0; i < bytes.length;) {
+                const b = bytes[i++];
+                let cp;
+                if (b < 0x80) cp = b;
+                else if (b < 0xe0) cp = ((b & 0x1f) << 6) | (bytes[i++] & 0x3f);
+                else if (b < 0xf0) cp = ((b & 0x0f) << 12) | ((bytes[i++] & 0x3f) << 6) | (bytes[i++] & 0x3f);
+                else cp = ((b & 0x07) << 18) | ((bytes[i++] & 0x3f) << 12) | ((bytes[i++] & 0x3f) << 6) | (bytes[i++] & 0x3f);
+                if (cp > 0xffff) { cp -= 0x10000; out += String.fromCharCode(0xd800 + (cp >> 10), 0xdc00 + (cp & 0x3ff)); }
+                else out += String.fromCharCode(cp);
+            }
+            return out;
+        }
+    };
+}
+""";
 
     private static string ReadResource(Assembly assembly, string name)
     {

--- a/integrations/dotnet/js65.clearscript/ClearScriptEngine.cs
+++ b/integrations/dotnet/js65.clearscript/ClearScriptEngine.cs
@@ -56,7 +56,8 @@ public class ClearScriptEngine : Assembler, IDisposable
     public override async Task<Js65CompileResult> Apply(byte[] rom, CancellationToken ct = default)
     {
         _engine.AddHostTypes(typeof(Task), typeof(Console), typeof(JavaScriptExtensions), typeof(Js65Callbacks), typeof(Js65Options));
-        _engine.AddHostObject("FileCallbacks", Callbacks);
+        // Clearscript doesn't handle null objects, so just default if its missing.
+        _engine.AddHostObject("FileCallbacks", Callbacks ?? new Js65Callbacks());
         // The JS polls hostCancel.IsCancellationRequested; a boxed CancellationToken still
         // reflects cancellation because the struct references the underlying token source.
         _engine.AddHostObject("hostCancel", ct);

--- a/integrations/dotnet/js65.hermes/HermesEngine.cs
+++ b/integrations/dotnet/js65.hermes/HermesEngine.cs
@@ -1,215 +1,327 @@
 
-using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Text;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace js65;
 
-/// Assembler frontend backed by the Static Hermes (shermes) native build of js65.
-/// If you need a smaller but slower engine for desktop, you can use this instead of ClearScript
-///
-/// Unlike ClearScriptEngine, which hosts V8 in-process, this engine shells out to a
-/// standalone js65-hermes executable. The modules/options are serialized to a single JSON
-/// envelope, piped to the process' stdin together with the --json flag, and the base64
-/// result is read back from stdout.
+/// Assembler frontend backed by the Static Hermes (shermes) native build of js65: a
+/// smaller but slower alternative to ClearScript for desktop use.
+
+[SupportedOSPlatform("windows")]
+[SupportedOSPlatform("linux")]
+[SupportedOSPlatform("macos")]
 public partial class HermesEngine : Assembler, IDisposable
 {
-    private readonly string _executablePath;
-    private readonly string _workingDirectory;
+    // Base name passed to [LibraryImport]; the resolver below maps it to the per-platform
+    // file under the app directory or runtimes/{rid}/native.
+    private const string LibraryName = "js65";
 
-    /// Environment variable that, when set to an existing file, overrides executable discovery.
-    /// Useful for development against a locally built js65-hermes
-    public const string ExecutablePathEnvVar = "JS65_HERMES_PATH";
+    /// Environment variable that, when set to an existing file, overrides library discovery.
+    /// Useful for development against a locally built shared library.
+    public const string LibraryPathEnvVar = "JS65_HERMES_PATH";
 
-    public HermesEngine(Js65Options? options = null, string? executablePath = null, string? workingDirectory = null)
+    // js65_compile re-inits the single-threaded Hermes runtime, so calls must not overlap. A
+    // SemaphoreSlim (rather than lock) lets a queued compile honor its CancellationToken while
+    // it waits for an in-flight compile to release the gate.
+    private static readonly SemaphoreSlim CompileGate = new(1, 1);
+
+    private readonly Js65ReadFn _readText;
+    private readonly Js65ReadFn _readBinary;
+    private readonly IntPtr _readTextPtr;
+    private readonly IntPtr _readBinaryPtr;
+
+    // Pins the buffer most recently handed to the native side until it has been copied
+    // (the native read binding copies synchronously before the next callback / return).
+    private GCHandle _pinned;
+
+    static HermesEngine()
+    {
+        NativeLibrary.SetDllImportResolver(typeof(HermesEngine).Assembly, ResolveLibrary);
+    }
+
+    public HermesEngine(Js65Options? options = null, bool useFileSystemCallbacks = true)
         : base(options)
     {
-        _executablePath = executablePath ?? ResolveExecutablePath();
-        _workingDirectory = workingDirectory ?? Environment.CurrentDirectory;
-    }
+        _readText = ReadTextThunk;
+        _readBinary = ReadBinaryThunk;
+        _readTextPtr = Marshal.GetFunctionPointerForDelegate(_readText);
+        _readBinaryPtr = Marshal.GetFunctionPointerForDelegate(_readBinary);
 
-    public override async Task<Js65CompileResult> Apply(byte[] rom)
-    {
-        var envelope = BuildCompileRequest(rom);
-
-        var psi = new ProcessStartInfo
+        // Default to filesystem-backed callbacks (resolving relative to the executable).
+        // Consumers can replace Callbacks for custom loading.
+        if (!useFileSystemCallbacks) return;
+        Callbacks = new()
         {
-            FileName = _executablePath,
-            WorkingDirectory = _workingDirectory,
-            RedirectStandardInput = true,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            StandardOutputEncoding = Encoding.UTF8,
-            StandardErrorEncoding = Encoding.UTF8,
+            OnFileReadText = LoadTextFileCallback,
+            OnFileReadBinary = LoadBinaryFileCallback
         };
-        psi.ArgumentList.Add("--json");
-
-        using var process = new Process { StartInfo = psi };
-        if (!process.Start())
-            throw new InvalidOperationException($"Failed to start hermes executable: {_executablePath}");
-
-        // Write the request envelope as UTF-8 to stdin, then close it so the process can proceed.
-        // Read stdout/stderr concurrently to avoid pipe-buffer deadlocks on large ROMs.
-        var stdoutTask = process.StandardOutput.ReadToEndAsync();
-        var stderrTask = process.StandardError.ReadToEndAsync();
-        await using (var stdin = process.StandardInput)
-        {
-            await stdin.BaseStream.WriteAsync(Encoding.UTF8.GetBytes(envelope));
-        }
-
-        var stdout = await stdoutTask;
-        var stderr = await stderrTask;
-        await process.WaitForExitAsync();
-
-        if (process.ExitCode != 0)
-            throw new InvalidOperationException(
-                $"js65-hermes exited with code {process.ExitCode}.{(stderr.Length > 0 ? $" stderr: {stderr}" : "")}");
-
-        return DecodeResult(stdout.Trim(), stderr);
     }
 
-    // Serialize the modules and options for js65 in the actions list so we don't need to fiddle with
-    // compile flags and such
-    private string BuildCompileRequest(byte[] rom)
+    public override async Task<Js65CompileResult> Apply(byte[] rom, CancellationToken ct = default)
     {
-        using var modules = JsonDocument.Parse(SerializeModulesToJson());
-        var request = new HermesRequest
-        {
-            modules = modules.RootElement,
-            assemblerOpts = new HermesAssemblerOpts
-            {
-                includePaths = Options.includePaths,
-                lineContinuations = Options.lineContinuations,
-                numberSeparators = Options.numberSeperators,
-                generateDebugInfo = Options.generateDebugInfo,
-            },
-            linkerOpts = new HermesLinkerOpts
-            {
-                baseRom = Convert.ToBase64String(rom),
-                debugLevel = Options.debugLevel,
-            },
-            outputFormat = "binary",
-            useSourceContents = Options.generateDebugInfo,
-        };
-        return JsonSerializer.Serialize(request, HermesJsonContext.Default.HermesRequest);
-    }
+        var req = BuildRequest();
 
-    private static Js65CompileResult DecodeResult(string base64Stdout, string stderr)
-    {
-        byte[] jsonBytes;
+        // Cancellable even while queued: a serialized runtime means a long compile holds the
+        // gate, so waiting callers must be able to bail before they ever start.
+        await CompileGate.WaitAsync(ct).ConfigureAwait(false);
         try
         {
-            jsonBytes = Convert.FromBase64String(base64Stdout);
+            return await Task.Run(() =>
+            {
+                // Host-owned cancel flag the native side polls (via __js65_cancelled). Pinned so
+                // its address stays valid for the whole call; the registration flips it from
+                // whichever thread requests cancellation while the compile runs.
+                var cancel = new int[1];
+                var cancelHandle = GCHandle.Alloc(cancel, GCHandleType.Pinned);
+                using var reg = ct.Register(() => Volatile.Write(ref cancel[0], 1));
+                try
+                {
+                    var resultPtr = js65_compile(
+                        IntPtr.Zero, req, rom, rom.Length, _readTextPtr, _readBinaryPtr,
+                        cancelHandle.AddrOfPinnedObject());
+                    FreePinned();
+                    if (resultPtr == IntPtr.Zero)
+                        throw new InvalidOperationException("The js65 shared library failed to run the compile.");
+                    try
+                    {
+                        // On cancel the native side still returned a clean failure result; surface
+                        // the idiomatic .NET cancellation signal to the caller instead.
+                        ct.ThrowIfCancellationRequested();
+                        return MarshalResult(resultPtr);
+                    }
+                    finally
+                    {
+                        js65_free_result(resultPtr);
+                    }
+                }
+                finally
+                {
+                    cancelHandle.Free();
+                }
+            }, ct).ConfigureAwait(false);
         }
-        catch (FormatException)
+        finally
         {
-            throw new InvalidOperationException(
-                $"js65-hermes produced unexpected (non-base64) output.{(stderr.Length > 0 ? $" stderr: {stderr}" : "")}");
+            CompileGate.Release();
         }
-
-        var result = JsonSerializer.Deserialize(jsonBytes, HermesJsonContext.Default.HermesJsonResult)
-                     ?? throw new InvalidOperationException("js65-hermes returned an empty result.");
-
-        return new Js65CompileResult
-        {
-            success = result.success,
-            romdata = result.romdata.Length > 0 ? Convert.FromBase64String(result.romdata) : [],
-            debugfile = result.debugfile,
-            messages = result.messages,
-        };
     }
 
-    // Locate the js65 executable in the current path. The user can provide an override with JS65_HERMES_PATH
-    // but the default behavior is to check in the current folder.
-    private static string ResolveExecutablePath()
+    [LibraryImport(LibraryName, StringMarshalling = StringMarshalling.Utf8)]
+    private static partial IntPtr js65_compile(
+        IntPtr ctx,
+        string requestJson,
+        [In] byte[] baseRom,
+        int baseRomLen,
+        IntPtr readText,
+        IntPtr readBinary,
+        IntPtr cancelFlag);
+
+    [LibraryImport(LibraryName)]
+    private static partial void js65_free_result(IntPtr result);
+
+    // Mirrors of the C ABI structs in js65.h: pointers first, then int32s, so the field
+    // offsets match the native side on 64-bit targets with no padding.
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Js65ResultNative
     {
-        var exeName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "js65-hermes.exe" : "js65-hermes";
-
-        var overridePath = Environment.GetEnvironmentVariable(ExecutablePathEnvVar);
-        if (!string.IsNullOrEmpty(overridePath) && File.Exists(overridePath))
-            return overridePath;
-
-        var baseDir = AppContext.BaseDirectory;
-        var rid = RuntimeInformation.RuntimeIdentifier;
-        var candidates = new[]
-        {
-            Path.Combine(baseDir, exeName),
-            Path.Combine(baseDir, "runtimes", rid, "native", exeName),
-        };
-        foreach (var candidate in candidates)
-            if (File.Exists(candidate))
-                return EnsureExecutable(candidate);
-
-        throw new FileNotFoundException(
-            $"Could not locate the '{exeName}' native executable for runtime '{rid}'. " +
-            $"Searched: {string.Join(", ", candidates)}. " +
-            $"Set the {ExecutablePathEnvVar} environment variable to override.");
+        public IntPtr outputs;
+        public IntPtr messages;
+        public int success;
+        public int messageCount;
+        public int outputCount;
     }
 
-    // Its possible that the js65-hermes exe is missing the executable bit on Unix. If so, try and make it executable.
-    private static string EnsureExecutable(string path)
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Js65OutputFileNative
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            return path;
+        public IntPtr name;
+        public IntPtr type;
+        public IntPtr data;
+        public int dataLength;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Js65MessageNative
+    {
+        public IntPtr level;
+        public IntPtr message;
+        public IntPtr stack;
+        public IntPtr source;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Js65SourceInfoNative
+    {
+        public IntPtr parent;
+        public IntPtr ident;
+        public IntPtr file;
+        public int line;
+        public int column;
+    }
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate int Js65ReadFn(IntPtr ctx, IntPtr basePath, IntPtr relPath, out IntPtr outData, out int outLen);
+
+    private int ReadTextThunk(IntPtr ctx, IntPtr basePath, IntPtr relPath, out IntPtr outData, out int outLen)
+        => Read(text: true, basePath, relPath, out outData, out outLen);
+
+    private int ReadBinaryThunk(IntPtr ctx, IntPtr basePath, IntPtr relPath, out IntPtr outData, out int outLen)
+        => Read(text: false, basePath, relPath, out outData, out outLen);
+
+    // Invoke the managed callback and hand the bytes to the native side as a pinned buffer
+    // (valid until the next callback or until js65_compile returns). Returns 0 on success,
+    // -1 on a missing file / no callback / exception, which the assembler reports.
+    private int Read(bool text, IntPtr basePath, IntPtr relPath, out IntPtr outData, out int outLen)
+    {
+        outData = IntPtr.Zero;
+        outLen = 0;
         try
         {
-            var mode = File.GetUnixFileMode(path);
-            File.SetUnixFileMode(path, mode | UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute);
+            FreePinned();
+            var basePathStr = Marshal.PtrToStringUTF8(basePath) ?? "";
+            var relPathStr = Marshal.PtrToStringUTF8(relPath) ?? "";
+
+            byte[]? bytes;
+            if (text)
+            {
+                var s = Callbacks?.OnFileReadText?.Invoke(basePathStr, relPathStr);
+                bytes = s is null ? null : Encoding.UTF8.GetBytes(s);
+            }
+            else
+            {
+                bytes = Callbacks?.OnFileReadBinary?.Invoke(basePathStr, relPathStr);
+            }
+
+            if (bytes is null) return -1;
+            if (bytes.Length == 0) return 0; // outData stays null; native treats len 0 as empty.
+
+            _pinned = GCHandle.Alloc(bytes, GCHandleType.Pinned);
+            outData = _pinned.AddrOfPinnedObject();
+            outLen = bytes.Length;
+            return 0;
         }
         catch
         {
-            // Non-fatal error: the file may already be executable, or the FS may not support mode bits.
-            // Either way, just try to continue.
+            return -1;
         }
-        return path;
+    }
+
+    private void FreePinned()
+    {
+        if (_pinned.IsAllocated) _pinned.Free();
+    }
+
+    private static Js65CompileResult MarshalResult(IntPtr resultPtr)
+    {
+        var native = Marshal.PtrToStructure<Js65ResultNative>(resultPtr);
+
+        var outputs = new Js65OutputFile[native.outputCount];
+        var outputSize = Marshal.SizeOf<Js65OutputFileNative>();
+        for (var i = 0; i < native.outputCount; i++)
+        {
+            var output = Marshal.PtrToStructure<Js65OutputFileNative>(native.outputs + i * outputSize);
+            var data = output.dataLength > 0 ? new byte[output.dataLength] : [];
+            if (output.dataLength > 0)
+                Marshal.Copy(output.data, data, 0, output.dataLength);
+            outputs[i] = new Js65OutputFile
+            {
+                name = Marshal.PtrToStringUTF8(output.name) ?? "",
+                type = Marshal.PtrToStringUTF8(output.type) ?? "binary",
+                data = data,
+            };
+        }
+
+        var messages = new Js65AssemblerMessage[native.messageCount];
+        var messageSize = Marshal.SizeOf<Js65MessageNative>();
+        for (var i = 0; i < native.messageCount; i++)
+        {
+            var msg = Marshal.PtrToStructure<Js65MessageNative>(native.messages + i * messageSize);
+            messages[i] = new Js65AssemblerMessage
+            {
+                level = Marshal.PtrToStringUTF8(msg.level) ?? "error",
+                message = Marshal.PtrToStringUTF8(msg.message) ?? "",
+                stack = Marshal.PtrToStringUTF8(msg.stack),
+                source = MarshalSource(msg.source),
+            };
+        }
+
+        return new Js65CompileResult
+        {
+            success = native.success != 0,
+            outputs = outputs,
+            messages = messages,
+        };
+    }
+
+    private static Js65SourceInfo? MarshalSource(IntPtr sourcePtr)
+    {
+        if (sourcePtr == IntPtr.Zero) return null;
+        var native = Marshal.PtrToStructure<Js65SourceInfoNative>(sourcePtr);
+        return new Js65SourceInfo
+        {
+            ident = Marshal.PtrToStringUTF8(native.ident),
+            file = Marshal.PtrToStringUTF8(native.file) ?? "",
+            line = native.line,
+            column = native.column,
+            parent = MarshalSource(native.parent),
+        };
+    }
+
+    // Search order: an env override, the app directory, then runtimes/{rid}/native (the
+    // NuGet layout). Falls back to the platform's default search if none match.
+    private static IntPtr ResolveLibrary(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
+    {
+        if (libraryName != LibraryName) return IntPtr.Zero;
+        foreach (var candidate in CandidatePaths())
+            if (File.Exists(candidate) && NativeLibrary.TryLoad(candidate, out var handle))
+                return handle;
+        return IntPtr.Zero;
+    }
+
+    private static IEnumerable<string> CandidatePaths()
+    {
+        var fileName = NativeFileName();
+
+        var overridePath = Environment.GetEnvironmentVariable(LibraryPathEnvVar);
+        if (!string.IsNullOrEmpty(overridePath))
+            yield return overridePath;
+
+        var baseDir = AppContext.BaseDirectory;
+        var rid = RuntimeInformation.RuntimeIdentifier;
+        yield return Path.Combine(baseDir, fileName);
+        yield return Path.Combine(baseDir, "runtimes", rid, "native", fileName);
+    }
+
+    private static string NativeFileName()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return "js65.dll";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return "libjs65.dylib";
+        return "libjs65.so";
+    }
+
+    private static string? ExeBasePath => Path.GetDirectoryName(Assembly.GetEntryAssembly()!.Location);
+
+    private static string LoadTextFileCallback(string basePath, string relPath)
+    {
+        var fullPath = Path.GetFullPath(Path.Combine(ExeBasePath!, basePath, relPath));
+        if (!File.Exists(fullPath))
+            throw new FileNotFoundException($"Could not find file {fullPath}");
+        return File.ReadAllText(fullPath);
+    }
+
+    private static byte[] LoadBinaryFileCallback(string basePath, string relPath)
+    {
+        var fullPath = Path.GetFullPath(Path.Combine(ExeBasePath!, basePath, relPath));
+        if (!File.Exists(fullPath))
+            throw new FileNotFoundException($"Could not find file {fullPath}");
+        return File.ReadAllBytes(fullPath);
     }
 
     public override void Dispose()
     {
+        FreePinned();
         GC.SuppressFinalize(this);
-    }
-
-    /// <summary>The request envelope written to the hermes process' stdin in <c>--json</c> mode.</summary>
-    private record HermesRequest
-    {
-        // Pre-serialized action modules (see BuildCompileRequest).
-        public JsonElement modules { get; init; }
-        public HermesAssemblerOpts assemblerOpts { get; init; } = new();
-        public HermesLinkerOpts linkerOpts { get; init; } = new();
-        public string outputFormat { get; init; } = "binary";
-        public bool useSourceContents { get; init; }
-    }
-
-    private record HermesAssemblerOpts
-    {
-        public IEnumerable<string> includePaths { get; init; } = [];
-        public bool lineContinuations { get; init; }
-        public bool numberSeparators { get; init; }
-        public bool generateDebugInfo { get; init; }
-    }
-
-    private record HermesLinkerOpts
-    {
-        public string baseRom { get; init; } = "";
-        public int debugLevel { get; init; }
-    }
-
-    private record HermesJsonResult
-    {
-        public bool success { get; init; }
-        public string romdata { get; init; } = "";
-        public string debugfile { get; init; } = "";
-        public Js65AssemblerMessage[] messages { get; init; } = [];
-    }
-
-    [JsonSourceGenerationOptions(WriteIndented = false)]
-    [JsonSerializable(typeof(HermesRequest))]
-    [JsonSerializable(typeof(HermesJsonResult))]
-    private partial class HermesJsonContext : JsonSerializerContext
-    {
     }
 }

--- a/integrations/dotnet/js65.hermes/js65.hermes.csproj
+++ b/integrations/dotnet/js65.hermes/js65.hermes.csproj
@@ -9,14 +9,12 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- Embedded name HermesEngine looks for. Deliberately not plain `js65`: the native exe sits next
-         to the consuming app, and a host app could itself be named `js65`. -->
-    <_Js65HermesExeName Condition="$([MSBuild]::IsOsPlatform('Windows'))">js65-hermes.exe</_Js65HermesExeName>
-    <_Js65HermesExeName Condition="'$(_Js65HermesExeName)' == ''">js65-hermes</_Js65HermesExeName>
-    <!-- The default js65 binary produced by `bun run hermes-exe` is the Hermes build (repo build/ folder). -->
-    <_Js65HermesBuildName Condition="$([MSBuild]::IsOsPlatform('Windows'))">js65.exe</_Js65HermesBuildName>
-    <_Js65HermesBuildName Condition="'$(_Js65HermesBuildName)' == ''">js65</_Js65HermesBuildName>
-    <_Js65HermesLocalExe>$(MSBuildProjectDirectory)/../../../build/$(_Js65HermesBuildName)</_Js65HermesLocalExe>
+    <!-- Per-platform shared library produced by `bun run hermes-exe`, loaded in-process by
+         HermesEngine via P/Invoke. The name matches what HermesEngine.NativeFileName() looks for. -->
+    <_Js65LibName Condition="$([MSBuild]::IsOsPlatform('Windows'))">js65.dll</_Js65LibName>
+    <_Js65LibName Condition="$([MSBuild]::IsOsPlatform('OSX'))">libjs65.dylib</_Js65LibName>
+    <_Js65LibName Condition="'$(_Js65LibName)' == ''">libjs65.so</_Js65LibName>
+    <_Js65LocalLib>$(MSBuildProjectDirectory)/../../../build/$(_Js65LibName)</_Js65LocalLib>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,15 +22,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Package layout: every platform's executable lives under runtimes/{rid}/native/. NuGet's
+    <!-- Package layout: every platform's shared library lives under runtimes/{rid}/native/. NuGet's
          RID asset selection then deploys only the consumer's target platform at publish time,
          exactly like the ClearScript native V8 packages. CI populates runtimes/{rid}/native/ with
          the per-platform builds before `dotnet pack`; the folder is git-ignored (see .gitignore). -->
     <None Include="runtimes/**/*" Pack="true" PackagePath="runtimes/%(RecursiveDir)" />
-    <!-- Local build / ProjectReference: copy the host executable produced by `bun run hermes-exe`
-         next to the output (flattened), so HermesEngine can find and launch it without publishing. -->
-    <None Include="$(_Js65HermesLocalExe)" Condition="Exists('$(_Js65HermesLocalExe)')"
-          Pack="false" Link="$(_Js65HermesExeName)" CopyToOutputDirectory="PreserveNewest" />
+    <!-- Local build / ProjectReference: copy the shared library produced by `bun run hermes-exe`
+         next to the output (keeping its platform name), so HermesEngine can load it without publishing. -->
+    <None Include="$(_Js65LocalLib)" Condition="Exists('$(_Js65LocalLib)')"
+          Pack="false" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/integrations/dotnet/js65.interop/Assembler.cs
+++ b/integrations/dotnet/js65.interop/Assembler.cs
@@ -61,6 +61,18 @@ public record Js65AssemblerMessage
     public string? stack { get; init; }
 }
 
+/// <summary>
+/// One named output produced by a compile. <c>type</c> tags the artifact kind:
+/// "binary" (linked ROM / IPS), "object" (serialized .o), "debug" (debug info such as
+/// MLB labels), "source", and more in future (e.g. "listing").
+/// </summary>
+public record Js65OutputFile
+{
+    public string name { get; init; } = "";
+    public string type { get; init; } = "binary";
+    public byte[] data { get; init; } = [];
+}
+
 public record Js65CompileResult
 {
     /// <summary>
@@ -69,19 +81,58 @@ public record Js65CompileResult
     public bool success { get; init; }
 
     /// <summary>
-    /// Binary output data
+    /// Named outputs produced by the compile. The linked ROM/IPS is a "binary" entry;
+    /// debug info ("debug") and serialized .o modules ("object") ride in the same list.
     /// </summary>
-    public byte[] romdata { get; init; } = [];
+    public Js65OutputFile[] outputs { get; init; } = [];
 
     /// <summary>
-    /// Debug file contents
+    /// Binary output data. Back-compat convenience for the common single-output case;
+    /// the first non-debug output's bytes.
     /// </summary>
-    public string debugfile { get; init; } = "";
+    public byte[] romdata =>
+        Array.Find(outputs, o => o.type != "debug")?.data ?? (outputs.Length > 0 ? outputs[0].data : []);
+
+    /// <summary>
+    /// Debug file contents (the "debug"-typed output decoded as UTF-8 text), or "" if none.
+    /// </summary>
+    public string debugfile =>
+        Array.Find(outputs, o => o.type == "debug") is { } d ? System.Text.Encoding.UTF8.GetString(d.data) : "";
 
     /// <summary>
     /// All messages (errors, warnings, info) from compilation
     /// </summary>
     public Js65AssemblerMessage[] messages { get; init; } = [];
+}
+
+/// <summary>
+/// One input in the Js65Request. Engines only ever send action-list modules.
+/// </summary>
+public record Js65ActionsInput
+{
+    public string type { get; init; } = "actions";
+    public List<Dictionary<string, object>> actions { get; init; } = [];
+}
+
+public record Js65RequestOptions
+{
+    public IEnumerable<string> includePaths { get; init; } = [];
+    public bool lineContinuations { get; init; }
+    public bool numberSeparators { get; init; }
+    public bool generateDebugInfo { get; init; }
+    public int debugLevel { get; init; }
+    public string outputFormat { get; init; } = "binary";
+}
+
+/// <summary>
+/// The Js65Request data ({ inputs, options })
+/// These are the untrusted inputs that are validated before being passed to the
+/// js65 compile task.
+/// </summary>
+public record Js65RequestData
+{
+    public List<Js65ActionsInput> inputs { get; init; } = [];
+    public Js65RequestOptions options { get; init; } = new();
 }
 
 public abstract class Assembler(Js65Options? options = null, Js65Callbacks? callbacks = null) : IDisposable
@@ -102,12 +153,36 @@ public abstract class Assembler(Js65Options? options = null, Js65Callbacks? call
         return mod;
     }
 
-    public abstract Task<Js65CompileResult> Apply(byte[] rom);
+    /// <summary>
+    /// Assemble and link the added modules against the given base ROM. Pass a
+    /// <paramref name="ct"/> to cancel a long compile: cancellation is cooperative (observed at
+    /// the assembler's per-line / linker per-chunk boundaries) and surfaces as an
+    /// <see cref="OperationCanceledException"/>.
+    /// </summary>
+    public abstract Task<Js65CompileResult> Apply(byte[] rom, CancellationToken ct = default);
 
     protected string SerializeModulesToJson()
     {
         var modules = Modules.Select(module => module.Actions).ToList();
         return JsonSerializer.Serialize(modules, Js65JsonContext.Default.ListListDictionaryStringObject);
+    }
+
+    protected string BuildRequest()
+    {
+        var request = new Js65RequestData
+        {
+            inputs = Modules.Select(module => new Js65ActionsInput { actions = module.Actions }).ToList(),
+            options = new Js65RequestOptions
+            {
+                includePaths = Options.includePaths,
+                lineContinuations = Options.lineContinuations,
+                numberSeparators = Options.numberSeperators,
+                generateDebugInfo = Options.generateDebugInfo,
+                debugLevel = Options.debugLevel,
+                outputFormat = "binary",
+            },
+        };
+        return JsonSerializer.Serialize(request, Js65JsonContext.Default.Js65RequestData);
     }
 
     public abstract void Dispose();
@@ -127,6 +202,9 @@ public abstract class Assembler(Js65Options? options = null, Js65Callbacks? call
 [JsonSerializable(typeof(Js65SourceInfo))]
 [JsonSerializable(typeof(Js65AssemblerMessage))]
 [JsonSerializable(typeof(Js65AssemblerMessage[]))]
+[JsonSerializable(typeof(Js65OutputFile))]
+[JsonSerializable(typeof(Js65OutputFile[]))]
+[JsonSerializable(typeof(Js65RequestData))]
 public partial class Js65JsonContext : JsonSerializerContext
 {
 }

--- a/integrations/hermes/hermes-build.ts
+++ b/integrations/hermes/hermes-build.ts
@@ -89,6 +89,13 @@ const CRT = isWin ? ['-fms-runtime-lib=dll'] : [];
 const LTO = ['-flto=thin'];
 const LINKER = isMac ? [] : ['-fuse-ld=lld'];
 
+// The shared library link (-shared) needs position-independent code; the same PIC
+// objects link fine into the executable, so build PIC once and reuse for both. On
+// Windows PIC is the default / not a concept, so these are no-ops. Hidden visibility
+// keeps everything but the JS65_EXPORT-marked C ABI out of the .so/.dylib symbol table.
+const PIC = isWin ? [] : ['-fPIC'];
+const VISIBILITY = isWin ? [] : ['-fvisibility=hidden'];
+
 // boost_context lives under external/boost/<version>/libs/context; the version
 // is pinned by the Hermes build, so locate it rather than hard-code it. Fail
 // loudly if it can't be found so the error is actionable, instead of guessing a
@@ -138,23 +145,37 @@ run('shermes unit', SHERMES, [
   '-exported-unit', 'js65', '-c',
   `-Wc,-I${HERMES_BUILD}/lib/config`, `-Wc,-I${HERMES_SRC}/include`,
   ...LTO.map((f) => `-Wc,${f}`),
+  ...PIC.map((f) => `-Wc,${f}`),
   '-o', 'build/hermes.unit.o', 'build/hermes.bundle.js',
 ], { CC: CLANG });
 
-// 3. compile the C++ host (basically the code that acts as a small OS runtime for the CLI)
-run('clang++ host', CLANGXX, [
-  '-c', '-std=c++17', '-O2', ...CRT, ...LTO,
-  ...INC.map((i) => `-I${i}`),
-  'integrations/hermes/hermes_host.cpp', '-o', 'build/hermes_host.o',
-]);
+// 3. compile the C++ host sources. hermes_core.cpp is the shared runtime/bindings core;
+// hermes_host.cpp is the CLI entry (main + stdin/stdout); hermes_lib.cpp is the shared
+// library entry (the js65_compile C ABI). All share one set of flags.
+const compile = (src: string, obj: string) =>
+  run(`clang++ ${src}`, CLANGXX, [
+    '-c', '-std=c++17', '-O2', ...CRT, ...LTO, ...PIC, ...VISIBILITY,
+    ...INC.map((i) => `-I${i}`),
+    `integrations/hermes/${src}`, '-o', `build/${obj}`,
+  ]);
+compile('hermes_core.cpp', 'hermes_core.o');
+compile('hermes_host.cpp', 'hermes_host.o');
+compile('hermes_lib.cpp', 'hermes_lib.o');
 
-// 4. link
-run('link', CLANGXX, [
-  ...CRT, ...LTO, ...LINKER,
-  'build/hermes.unit.o', 'build/hermes_host.o', '-o', OUT,
-  ...LIBDIRS.map((d) => `-L${d}`),
-  ...LIBS.map((l) => `-l${l}`),
-  ...MAC_FRAMEWORKS,
-]);
+// 4. link the unit + core + an entry object against the static Hermes VM libs.
+const link = (out: string, entryObj: string, extra: string[]) =>
+  run(`link ${out}`, CLANGXX, [
+    ...CRT, ...LTO, ...LINKER, ...extra,
+    'build/hermes.unit.o', 'build/hermes_core.o', `build/${entryObj}`, '-o', out,
+    ...LIBDIRS.map((d) => `-L${d}`),
+    ...LIBS.map((l) => `-l${l}`),
+    ...MAC_FRAMEWORKS,
+  ]);
 
-process.stderr.write(`\nBuilt ${OUT}\n`);
+// The CLI executable...
+link(OUT, 'hermes_host.o', []);
+// ...and the shared library used by the in-process .NET js65.hermes engine.
+const DLL = `build/${isWin ? 'js65.dll' : isMac ? 'libjs65.dylib' : 'libjs65.so'}`;
+link(DLL, 'hermes_lib.o', ['-shared']);
+
+process.stderr.write(`\nBuilt ${OUT}\nBuilt ${DLL}\n`);

--- a/integrations/hermes/hermes.ts
+++ b/integrations/hermes/hermes.ts
@@ -11,20 +11,35 @@
 // A UTF-8 TextEncoder/TextDecoder polyfill is provided since Hermes ships none.
 
 import { Cli } from '../../src/cli.ts';
-import { Base64, compileActionsBrowser } from '../../src/libassembler.ts';
+import { compileRequest } from '../../src/libassembler.ts';
 
-// Host functions installed by hermes_host.cpp.
+// Host functions installed by the C++ host (hermes_core.cpp + the active entry).
 declare const __js65_args: () => string[];
-declare const __js65_readText: (fullpath: string) => string;
-declare const __js65_readBytes: (fullpath: string) => Uint8Array;
+// Reads take the include base and requested file separately so the host resolves them:
+// the CLI joins them and reads disk; the shared library forwards to the caller's pointers.
+declare const __js65_cbReadText: (basePath: string, relPath: string) => string;
+declare const __js65_cbReadBinary: (basePath: string, relPath: string) => Uint8Array;
 declare const __js65_writeText: (fullpath: string, data: string) => void;
 declare const __js65_writeBytes: (fullpath: string, data: Uint8Array) => void;
+declare const __js65_listFiles: (dir: string) => string[];
+declare const __js65_exit: (code: number) => void;
+// CLI-only I/O.
 declare const __js65_stdinText: () => string;
 declare const __js65_stdinBytes: () => Uint8Array;
 declare const __js65_stdoutText: (data: string) => void;
 declare const __js65_stdoutBytes: (data: Uint8Array) => void;
-declare const __js65_listFiles: (dir: string) => string[];
-declare const __js65_exit: (code: number) => void;
+// Shared-library result building: the host assembles a typed Js65Result struct from these
+// calls rather than parsing a serialized string. __js65_resultAddMessage returns the new
+// message's index; source frames are pushed innermost-first up the include/macro stack.
+declare const __js65_request: () => string;
+declare const __js65_baseRom: () => Uint8Array;
+// Polled by the assembler core; reads the host-owned cancel flag set from another thread.
+declare const __js65_cancelled: () => boolean;
+declare const __js65_resultBegin: (success: boolean) => void;
+declare const __js65_resultAddOutput: (name: string, data: Uint8Array, type: string) => void;
+declare const __js65_resultAddMessage: (level: string, message: string, stack: string | null) => number;
+declare const __js65_resultAddSourceFrame: (
+  messageIndex: number, ident: string | null, file: string, line: number, column: number) => void;
 
 // --- UTF-8 TextEncoder / TextDecoder polyfill ----------------------------
 class Utf8Encoder {
@@ -101,10 +116,10 @@ function resolvePath(base: string, file: string): string {
 const cli = new Cli({
   fsReadString: async (path: string, filename: string): Promise<string> => {
     if (filename === Cli.STDIN) return __js65_stdinText();
-    return stripBom(__js65_readText(resolvePath(path, filename)));
+    return stripBom(__js65_cbReadText(path, filename));
   },
   fsReadBytes: async (path: string, filename: string): Promise<Uint8Array> => {
-    return (filename === Cli.STDIN) ? __js65_stdinBytes() : __js65_readBytes(resolvePath(path, filename));
+    return (filename === Cli.STDIN) ? __js65_stdinBytes() : __js65_cbReadBinary(path, filename);
   },
   fsWriteString: async (path: string, filename: string, data: string): Promise<void> => {
     if (filename === Cli.STDOUT) { __js65_stdoutText(data); return; }
@@ -123,35 +138,39 @@ const cli = new Cli({
   exit: (code: number) => __js65_exit(code),
 });
 
-// `--json` mode: read one request envelope from stdin, forward it to the
-// existing compileActionsBrowser, and write the base64 result to stdout. This
-// backs the js65.desktop subprocess engine.
-async function runJsonMode(): Promise<void> {
-  const env = JSON.parse(__js65_stdinText());
-
-  const readText = (basePath: string, filePath: string): string => {
-    return stripBom(__js65_readText(resolvePath(basePath, filePath)));
-  };
-  const readBinary = (basePath: string, filePath: string): string => {
-    return new Base64().encode(__js65_readBytes(resolvePath(basePath, filePath)));
+// `--lib` mode: backs the in-process .NET js65.hermes engine. The result is handed to the
+// host as a typed struct (built via the __js65_result* calls) rather than a serialized
+// string, so the ABI in js65.h stays explicit.
+async function runLibraryMode(): Promise<void> {
+  const callbacks = {
+    readText: async (basePath: string, filePath: string): Promise<string> =>
+      stripBom(__js65_cbReadText(basePath, filePath)),
+    readBinary: async (basePath: string, filePath: string): Promise<Uint8Array> =>
+      __js65_cbReadBinary(basePath, filePath),
   };
 
-  const result = await compileActionsBrowser(
-    JSON.stringify(env.modules ?? []),
-    JSON.stringify(env.assemblerOpts ?? {}),
-    JSON.stringify(env.linkerOpts ?? {}),
-    env.outputFormat ?? 'binary',
-    readText,
-    readBinary,
-    env.useSourceContents ?? false,
-  );
+  // Bare CancelSignal that polls the host cancel flag (Hermes ships no AbortController). The
+  // core reads .aborted at per-line / per-chunk boundaries; another thread flips the flag.
+  const signal = { get aborted() { return __js65_cancelled(); } };
 
-  __js65_stdoutText(result);
+  const baseRom = __js65_baseRom();
+  const result = await compileRequest(__js65_request(), callbacks, baseRom.length ? baseRom : undefined, signal);
+
+  __js65_resultBegin(result.success);
+  for (const output of result.outputs) {
+    __js65_resultAddOutput(output.name, output.data, output.type);
+  }
+  for (const m of result.messages) {
+    const index = __js65_resultAddMessage(m.level, m.message, m.stack ?? null);
+    for (let s = m.source; s; s = s.parent) {
+      __js65_resultAddSourceFrame(index, s.ident ?? null, s.file, s.line, s.column);
+    }
+  }
 }
 
 async function main(args: string[]) {
-  if (args.includes('--json')) {
-    await runJsonMode();
+  if (args.includes('--lib')) {
+    await runLibraryMode();
     return;
   }
   await cli.run(args);

--- a/integrations/hermes/hermes_core.cpp
+++ b/integrations/hermes/hermes_core.cpp
@@ -1,0 +1,235 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+// Implementation of the shared host core (see hermes_core.h).
+
+#include "hermes_core.h"
+
+#include "hermes/VM/static_h.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+
+namespace js65core {
+
+// symbols supplied by the compiled js65 unit + ConsoleBindings
+extern "C" SHUnit *sh_export_js65(void);
+
+typedef struct SHConsoleContext SHConsoleContext;
+extern "C" SHConsoleContext *
+init_console_bindings(SHRuntime *shr, int scriptArgc, const char *const *scriptArgv);
+extern "C" void free_console_context(SHConsoleContext *consoleContext);
+extern "C" bool run_event_loop(SHRuntime *shr, SHConsoleContext *consoleContext);
+
+namespace {
+
+// A jsi::MutableBuffer backed by a std::vector<uint8_t>.
+// The idea for this class came from hermes internal code somewhere, but it lets us
+// create a buffer for 
+class VectorMutableBuffer : public jsi::MutableBuffer {
+ public:
+  explicit VectorMutableBuffer(std::vector<uint8_t> data) : data_(std::move(data)) {}
+  size_t size() const override { return data_.size(); }
+  uint8_t *data() override { return data_.data(); }
+
+ private:
+  std::vector<uint8_t> data_;
+};
+
+// Holds the bytes returned by the filesystem Js65ReadFn until the read binding copies
+// them into a JS value. Overwritten each call, which is safe because the binding copies
+// immediately and synchronously before the next read.
+thread_local std::vector<uint8_t> g_fsScratch;
+
+} // namespace
+
+[[noreturn]] void throwError(jsi::Runtime &rt, std::string_view msg) {
+  auto str = jsi::String::createFromUtf8(rt, reinterpret_cast<const uint8_t *>(msg.data()), msg.size());
+  auto ctor = rt.global().getPropertyAsFunction(rt, "Error");
+  auto err = ctor.callAsConstructor(rt, std::move(str)).asObject(rt);
+  throw jsi::JSError(rt, std::move(err));
+}
+
+jsi::Value makeUint8Array(jsi::Runtime &rt, std::vector<uint8_t> data) {
+  auto buf = std::make_shared<VectorMutableBuffer>(std::move(data));
+  jsi::ArrayBuffer ab{rt, std::move(buf)};
+  auto ctor = rt.global().getPropertyAsFunction(rt, "Uint8Array");
+  return ctor.callAsConstructor(rt, std::move(ab));
+}
+
+std::vector<uint8_t> getBytes(jsi::Runtime &rt, const jsi::Value &v) {
+  if (!v.isObject())
+    throwError(rt, "expected a Uint8Array argument");
+  jsi::Object obj = v.getObject(rt);
+  if (obj.isArrayBuffer(rt)) {
+    jsi::ArrayBuffer ab = obj.getArrayBuffer(rt);
+    return std::vector<uint8_t>(ab.data(rt), ab.data(rt) + ab.size(rt));
+  }
+  auto bufProp = obj.getProperty(rt, "buffer");
+  if (!bufProp.isObject() || !bufProp.asObject(rt).isArrayBuffer(rt))
+    throwError(rt, "expected a Uint8Array argument");
+  jsi::ArrayBuffer ab = bufProp.asObject(rt).getArrayBuffer(rt);
+  auto off = obj.getProperty(rt, "byteOffset");
+  auto len = obj.getProperty(rt, "byteLength");
+  size_t offset = off.isNumber() ? (size_t)off.getNumber() : 0;
+  size_t length = len.isNumber() ? (size_t)len.getNumber() : ab.size(rt);
+  return std::vector<uint8_t>(ab.data(rt) + offset, ab.data(rt) + offset + length);
+}
+
+void setFn(jsi::Runtime &rt, const char *name, unsigned argc, jsi::HostFunctionType fn) {
+  rt.global().setProperty(
+      rt,
+      name,
+      jsi::Function::createFromHostFunction(
+          rt, jsi::PropNameID::forAscii(rt, name), argc, std::move(fn)));
+}
+
+bool readFileInto(const std::filesystem::path &path, std::vector<uint8_t> &out) {
+  std::error_code ec;
+  auto size = std::filesystem::file_size(path, ec);
+  if (ec)
+    return false;
+  std::ifstream in(path, std::ios::binary);
+  if (!in)
+    return false;
+  std::vector<uint8_t> data(static_cast<size_t>(size));
+  if (size > 0 && !in.read(reinterpret_cast<char *>(data.data()), static_cast<std::streamsize>(size)))
+    return false;
+  out = std::move(data);
+  return true;
+}
+
+void writeFileBytes(jsi::Runtime &rt, const std::filesystem::path &path, const std::vector<uint8_t> &data) {
+  std::ofstream out(path, std::ios::binary);
+  if (!out)
+    throwError(rt, "Could not open file for writing: " + path.string());
+  out.write(reinterpret_cast<const char *>(data.data()), static_cast<std::streamsize>(data.size()));
+  if (!out)
+    throwError(rt, "Short write on file: " + path.string());
+}
+
+std::filesystem::path resolvePath(std::string_view base, std::string_view file) {
+  std::filesystem::path filePath(file);
+  if (file.empty() || base.empty() || base == ".")
+    return filePath;
+  // path::operator/ replaces the base when filePath is absolute (POSIX root or Windows
+  // drive/UNC) and otherwise joins under it, matching hermes.ts resolvePath.
+  return std::filesystem::path(base) / filePath;
+}
+
+int32_t fsReadText(void *, const char *basePath, const char *relPath,
+                   const uint8_t **outData, int32_t *outLen) {
+  if (!readFileInto(resolvePath(basePath ? basePath : "", relPath ? relPath : ""), g_fsScratch))
+    return -1;
+  *outData = g_fsScratch.data();
+  *outLen = static_cast<int32_t>(g_fsScratch.size());
+  return 0;
+}
+
+int32_t fsReadBinary(void *ctx, const char *basePath, const char *relPath,
+                     const uint8_t **outData, int32_t *outLen) {
+  // Text and binary reads are byte-identical on the filesystem side.
+  return fsReadText(ctx, basePath, relPath, outData, outLen);
+}
+
+void installCommonBindings(jsi::Runtime &rt, HostContext &ctx) {
+  setFn(rt, "__js65_args", 0,
+      [&ctx](jsi::Runtime &rt, const jsi::Value &, const jsi::Value *, size_t) -> jsi::Value {
+        auto arr = jsi::Array(rt, ctx.args.size());
+        for (size_t i = 0; i < ctx.args.size(); ++i)
+          arr.setValueAtIndex(rt, i, jsi::String::createFromUtf8(rt, ctx.args[i]));
+        return arr;
+      });
+
+  setFn(rt, "__js65_cbReadText", 2,
+      [&ctx](jsi::Runtime &rt, const jsi::Value &, const jsi::Value *args, size_t count) -> jsi::Value {
+        if (count < 2 || !args[0].isString() || !args[1].isString())
+          throwError(rt, "__js65_cbReadText: (basePath, relPath) expected");
+        if (!ctx.readText) throwError(rt, "__js65_cbReadText: no readText callback");
+        std::string base = args[0].getString(rt).utf8(rt);
+        std::string rel = args[1].getString(rt).utf8(rt);
+        const uint8_t *data = nullptr;
+        int32_t len = 0;
+        if (ctx.readText(ctx.readCtx, base.c_str(), rel.c_str(), &data, &len) != 0)
+          throwError(rt, "Could not read file: " + rel);
+        return jsi::String::createFromUtf8(rt, data ? data : (const uint8_t *)"", len > 0 ? (size_t)len : 0);
+      });
+
+  setFn(rt, "__js65_cbReadBinary", 2,
+      [&ctx](jsi::Runtime &rt, const jsi::Value &, const jsi::Value *args, size_t count) -> jsi::Value {
+        if (count < 2 || !args[0].isString() || !args[1].isString())
+          throwError(rt, "__js65_cbReadBinary: (basePath, relPath) expected");
+        if (!ctx.readBinary) throwError(rt, "__js65_cbReadBinary: no readBinary callback");
+        std::string base = args[0].getString(rt).utf8(rt);
+        std::string rel = args[1].getString(rt).utf8(rt);
+        const uint8_t *data = nullptr;
+        int32_t len = 0;
+        if (ctx.readBinary(ctx.readCtx, base.c_str(), rel.c_str(), &data, &len) != 0)
+          throwError(rt, "Could not read file: " + rel);
+        return makeUint8Array(rt, std::vector<uint8_t>(data, data + (len > 0 ? len : 0)));
+      });
+
+  setFn(rt, "__js65_writeText", 2,
+      [](jsi::Runtime &rt, const jsi::Value &, const jsi::Value *args, size_t count) -> jsi::Value {
+        if (count < 2 || !args[0].isString() || !args[1].isString())
+          throwError(rt, "__js65_writeText: (path, string) expected");
+        std::string s = args[1].getString(rt).utf8(rt);
+        writeFileBytes(rt, args[0].getString(rt).utf8(rt),
+                       std::vector<uint8_t>(s.begin(), s.end()));
+        return jsi::Value::undefined();
+      });
+
+  setFn(rt, "__js65_writeBytes", 2,
+      [](jsi::Runtime &rt, const jsi::Value &, const jsi::Value *args, size_t count) -> jsi::Value {
+        if (count < 2 || !args[0].isString()) throwError(rt, "__js65_writeBytes: (path, bytes) expected");
+        writeFileBytes(rt, args[0].getString(rt).utf8(rt), getBytes(rt, args[1]));
+        return jsi::Value::undefined();
+      });
+
+  setFn(rt, "__js65_listFiles", 1,
+      [](jsi::Runtime &rt, const jsi::Value &, const jsi::Value *args, size_t count) -> jsi::Value {
+        if (count < 1 || !args[0].isString()) throwError(rt, "__js65_listFiles: dir expected");
+        std::string dir = args[0].getString(rt).utf8(rt);
+        std::vector<std::string> files;
+        std::error_code ec;
+        for (auto it = std::filesystem::recursive_directory_iterator(dir, ec);
+             !ec && it != std::filesystem::recursive_directory_iterator(); it.increment(ec)) {
+          if (it->is_regular_file(ec)) files.push_back(it->path().string());
+        }
+        auto arr = jsi::Array(rt, files.size());
+        for (size_t i = 0; i < files.size(); ++i)
+          arr.setValueAtIndex(rt, i, jsi::String::createFromUtf8(rt, files[i]));
+        return arr;
+      });
+
+  setFn(rt, "__js65_exit", 1,
+      [](jsi::Runtime &, const jsi::Value &, const jsi::Value *args, size_t count) -> jsi::Value {
+        std::fflush(stdout);
+        std::exit(count >= 1 && args[0].isNumber() ? (int)args[0].getNumber() : 0);
+      });
+}
+
+bool runJs65Core(HostContext &ctx,
+             const std::function<void(jsi::Runtime &rt, HostContext &ctx)> &installEntryBindings) {
+  // Hand _sh_init only a program name so it never tries to parse user/CLI flags as
+  // Hermes VM options.
+  char prog[] = "js65";
+  char *argv[] = {prog};
+  SHRuntime *shr = _sh_init(1, argv);
+  SHConsoleContext *consoleContext = init_console_bindings(shr, 0, nullptr);
+  jsi::Runtime &rt = *_sh_get_hermes_runtime(shr);
+  installCommonBindings(rt, ctx);
+  installEntryBindings(rt, ctx);
+  bool success = _sh_initialize_units(shr, 1, sh_export_js65) &&
+      run_event_loop(shr, consoleContext);
+  free_console_context(consoleContext);
+  _sh_done(shr);
+  return success;
+}
+
+} // namespace js65core

--- a/integrations/hermes/hermes_core.h
+++ b/integrations/hermes/hermes_core.h
@@ -1,0 +1,91 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+// Shared host core for the Static Hermes js65 frontend. The CLI executable
+// (hermes_host.cpp) and the shared library (hermes_lib.cpp) are thin entry points over
+// this core. They differ only in which Js65ReadFn pair they register (filesystem vs.
+// host-supplied function pointers) and in their entry-specific bindings (stdin/stdout vs.
+// the request/result protocol). The JSI helpers, the read bindings and the runtime
+// bootstrap live here as the single source of truth.
+
+#ifndef JS65_HERMES_CORE_H
+#define JS65_HERMES_CORE_H
+
+#include "js65.h"
+
+#include "hermes/hermes.h"
+#include "jsi/jsi.h"
+
+#include <cstdint>
+#include <filesystem>
+#include <functional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace js65core {
+
+// This header file is only used internally, so its fine to `using namespace` here.
+using namespace facebook;
+
+// Host state shared with the JS bindings for one runJs65Core call. Lives on the entry's stack
+// and outlives the runtime created inside runJs65Core.
+struct HostContext {
+  // Backs __js65_cbReadText / __js65_cbReadBinary.
+  Js65ReadFn readText = nullptr;
+  Js65ReadFn readBinary = nullptr;
+  void *readCtx = nullptr;
+
+  // Backs __js65_cancelled: host-owned flag flipped from another thread to cancel the
+  // in-flight compile. Passing in null means "never cancelled".
+  // I'm not a huge fan of using volatile here, but it works well enough.
+  const volatile int32_t *cancelFlag = nullptr;
+
+  // The library entry's request data (returned by __js65_request). Empty for the CLI.
+  std::string request;
+
+  // The library entry's base ROM bytes (returned by __js65_baseRom). Empty for the CLI.
+  std::vector<uint8_t> baseRom;
+
+  // Values returned by __js65_args (the CLI's argv, or {"--lib"} for the library).
+  std::vector<std::string> args;
+};
+
+[[noreturn]] void throwError(jsi::Runtime &rt, std::string_view msg);
+jsi::Value makeUint8Array(jsi::Runtime &rt, std::vector<uint8_t> data);
+std::vector<uint8_t> getBytes(jsi::Runtime &rt, const jsi::Value &v);
+void setFn(jsi::Runtime &rt, const char *name, unsigned argc, jsi::HostFunctionType fn);
+
+// Read a whole file into out; returns false (leaving out untouched) if it cannot be read.
+bool readFileInto(const std::filesystem::path &path, std::vector<uint8_t> &out);
+// Write data to path; throws a JS error on failure.
+void writeFileBytes(jsi::Runtime &rt, const std::filesystem::path &path, const std::vector<uint8_t> &data);
+// Join an include base directory with a requested file. An absolute file replaces the
+// base, matching the resolvePath in hermes.ts so the CLI and the in-process callbacks
+// resolve includes to the same target.
+std::filesystem::path resolvePath(std::string_view base, std::string_view file);
+
+// Filesystem-backed Js65ReadFn implementations: read a file relative to the include base.
+// The CLI registers these as its read callbacks.
+int32_t fsReadText(void *ctx, const char *basePath, const char *relPath,
+                   const uint8_t **outData, int32_t *outLen);
+int32_t fsReadBinary(void *ctx, const char *basePath, const char *relPath,
+                     const uint8_t **outData, int32_t *outLen);
+
+// Install the bindings both entries share: __js65_args, the read callbacks
+// (__js65_cbReadText / __js65_cbReadBinary), __js65_writeText / __js65_writeBytes,
+// __js65_listFiles, and __js65_exit.
+void installCommonBindings(jsi::Runtime &rt, HostContext &ctx);
+
+// Init the runtime + console bindings, install the common bindings plus the entry's own
+// (via installEntryBindings), run the compiled unit and the event loop, then tear down.
+// Returns true on success.
+bool runJs65Core(HostContext &ctx,
+             const std::function<void(jsi::Runtime &rt, HostContext &ctx)> &installEntryBindings);
+
+} // namespace js65core
+
+#endif // JS65_HERMES_CORE_H

--- a/integrations/hermes/hermes_host.cpp
+++ b/integrations/hermes/hermes_host.cpp
@@ -4,25 +4,17 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-// C++ host for the Static Hermes js65 frontend (integrations/hermes.ts).
-//
-// Static Hermes exposes no fs / argv / stdin / stdout / process to JS, so this
-// host installs the __js65_* functions that integrations/hermes.ts relies on,
-// using the JSI runtime reachable from the SHRuntime (the same mechanism the
-// shermes ConsoleBindings use for print/console). The js65 frontend is compiled
-// separately with `-exported-unit js65`, which emits the unit creator
-// `sh_export_js65` but no main(); this file supplies the main() that wires
-// everything together and runs the unit.
+// CLI entry point for the Static Hermes js65 frontend (build/js65[.exe]). It is a thin
+// wrapper over the shared host core (hermes_core.cpp): it registers the filesystem
+// read handlers, installs the stdin/stdout bindings the CLI needs, and runs the unit.
+// Everything else (JSI helpers, read/write/listFiles bindings, runtime bootstrap)
+// lives in the core and is shared with the shared-library entry (hermes_lib.cpp).
 
 #define _CRT_SECURE_NO_WARNINGS 1
 
-#include "hermes/VM/static_h.h"
-#include "hermes/hermes.h"
-#include "jsi/jsi.h"
+#include "hermes_core.h"
 
 #include <cstdio>
-#include <cstdlib>
-#include <filesystem>
 #include <string>
 #include <vector>
 
@@ -32,92 +24,9 @@
 #endif
 
 using namespace facebook;
-
-// --- symbols supplied by the compiled js65 unit + ConsoleBindings ---------
-extern "C" SHUnit *sh_export_js65(void);
-
-typedef struct SHConsoleContext SHConsoleContext;
-extern "C" SHConsoleContext *
-init_console_bindings(SHRuntime *shr, int scriptArgc, const char *const *scriptArgv);
-extern "C" void free_console_context(SHConsoleContext *consoleContext);
-extern "C" bool run_event_loop(SHRuntime *shr, SHConsoleContext *consoleContext);
+using js65core::HostContext;
 
 namespace {
-
-// The user CLI args (everything after argv[0]); returned to JS by __js65_args.
-std::vector<std::string> g_args;
-
-/// A jsi::MutableBuffer backed by a std::vector<uint8_t>.
-class VectorMutableBuffer : public jsi::MutableBuffer {
- public:
-  explicit VectorMutableBuffer(std::vector<uint8_t> data) : data_(std::move(data)) {}
-  size_t size() const override { return data_.size(); }
-  uint8_t *data() override { return data_.data(); }
-
- private:
-  std::vector<uint8_t> data_;
-};
-
-[[noreturn]] void throwError(jsi::Runtime &rt, const std::string &msg) {
-  auto ctor = rt.global().getPropertyAsFunction(rt, "Error");
-  auto err = ctor.callAsConstructor(rt, jsi::String::createFromUtf8(rt, msg)).asObject(rt);
-  throw jsi::JSError(rt, std::move(err));
-}
-
-/// Build a JS Uint8Array that owns a copy of \p data.
-jsi::Value makeUint8Array(jsi::Runtime &rt, std::vector<uint8_t> data) {
-  auto buf = std::make_shared<VectorMutableBuffer>(std::move(data));
-  jsi::ArrayBuffer ab{rt, std::move(buf)};
-  auto ctor = rt.global().getPropertyAsFunction(rt, "Uint8Array");
-  return ctor.callAsConstructor(rt, std::move(ab));
-}
-
-/// Copy the bytes out of a JS Uint8Array / TypedArray / ArrayBuffer argument.
-std::vector<uint8_t> getBytes(jsi::Runtime &rt, const jsi::Value &v) {
-  if (!v.isObject())
-    throwError(rt, "expected a Uint8Array argument");
-  jsi::Object obj = v.getObject(rt);
-  if (obj.isArrayBuffer(rt)) {
-    jsi::ArrayBuffer ab = obj.getArrayBuffer(rt);
-    return std::vector<uint8_t>(ab.data(rt), ab.data(rt) + ab.size(rt));
-  }
-  auto bufProp = obj.getProperty(rt, "buffer");
-  if (!bufProp.isObject() || !bufProp.asObject(rt).isArrayBuffer(rt))
-    throwError(rt, "expected a Uint8Array argument");
-  jsi::ArrayBuffer ab = bufProp.asObject(rt).getArrayBuffer(rt);
-  auto off = obj.getProperty(rt, "byteOffset");
-  auto len = obj.getProperty(rt, "byteLength");
-  size_t offset = off.isNumber() ? (size_t)off.getNumber() : 0;
-  size_t length = len.isNumber() ? (size_t)len.getNumber() : ab.size(rt);
-  return std::vector<uint8_t>(ab.data(rt) + offset, ab.data(rt) + offset + length);
-}
-
-std::vector<uint8_t> readFileBytes(jsi::Runtime &rt, const std::string &path) {
-  FILE *f = std::fopen(path.c_str(), "rb");
-  if (!f)
-    throwError(rt, "Could not read file: " + path);
-  std::fseek(f, 0, SEEK_END);
-  long len = std::ftell(f);
-  std::fseek(f, 0, SEEK_SET);
-  std::vector<uint8_t> data(len > 0 ? (size_t)len : 0);
-  if (len > 0 && std::fread(data.data(), 1, (size_t)len, f) != (size_t)len) {
-    std::fclose(f);
-    throwError(rt, "Short read on file: " + path);
-  }
-  std::fclose(f);
-  return data;
-}
-
-void writeFileBytes(jsi::Runtime &rt, const std::string &path, const std::vector<uint8_t> &data) {
-  FILE *f = std::fopen(path.c_str(), "wb");
-  if (!f)
-    throwError(rt, "Could not open file for writing: " + path);
-  if (!data.empty() && std::fwrite(data.data(), 1, data.size(), f) != data.size()) {
-    std::fclose(f);
-    throwError(rt, "Short write on file: " + path);
-  }
-  std::fclose(f);
-}
 
 std::vector<uint8_t> readAllStdin() {
   std::vector<uint8_t> out;
@@ -128,108 +37,35 @@ std::vector<uint8_t> readAllStdin() {
   return out;
 }
 
-void setFn(
-    jsi::Runtime &rt,
-    const char *name,
-    unsigned argc,
-    jsi::HostFunctionType fn) {
-  rt.global().setProperty(
-      rt,
-      name,
-      jsi::Function::createFromHostFunction(
-          rt, jsi::PropNameID::forAscii(rt, name), argc, std::move(fn)));
-}
-
-void installJs65Bindings(SHRuntime *shr) {
-  jsi::Runtime &rt = *_sh_get_hermes_runtime(shr);
-
-  setFn(rt, "__js65_args", 0,
-      [](jsi::Runtime &rt, const jsi::Value &, const jsi::Value *, size_t) -> jsi::Value {
-        auto arr = jsi::Array(rt, g_args.size());
-        for (size_t i = 0; i < g_args.size(); ++i)
-          arr.setValueAtIndex(rt, i, jsi::String::createFromUtf8(rt, g_args[i]));
-        return arr;
-      });
-
-  setFn(rt, "__js65_readText", 1,
-      [](jsi::Runtime &rt, const jsi::Value &, const jsi::Value *args, size_t count) -> jsi::Value {
-        if (count < 1 || !args[0].isString()) throwError(rt, "__js65_readText: path expected");
-        auto data = readFileBytes(rt, args[0].getString(rt).utf8(rt));
-        return jsi::String::createFromUtf8(rt, data.data(), data.size());
-      });
-
-  setFn(rt, "__js65_readBytes", 1,
-      [](jsi::Runtime &rt, const jsi::Value &, const jsi::Value *args, size_t count) -> jsi::Value {
-        if (count < 1 || !args[0].isString()) throwError(rt, "__js65_readBytes: path expected");
-        return makeUint8Array(rt, readFileBytes(rt, args[0].getString(rt).utf8(rt)));
-      });
-
-  setFn(rt, "__js65_writeText", 2,
-      [](jsi::Runtime &rt, const jsi::Value &, const jsi::Value *args, size_t count) -> jsi::Value {
-        if (count < 2 || !args[0].isString() || !args[1].isString())
-          throwError(rt, "__js65_writeText: (path, string) expected");
-        std::string s = args[1].getString(rt).utf8(rt);
-        writeFileBytes(rt, args[0].getString(rt).utf8(rt),
-                       std::vector<uint8_t>(s.begin(), s.end()));
-        return jsi::Value::undefined();
-      });
-
-  setFn(rt, "__js65_writeBytes", 2,
-      [](jsi::Runtime &rt, const jsi::Value &, const jsi::Value *args, size_t count) -> jsi::Value {
-        if (count < 2 || !args[0].isString()) throwError(rt, "__js65_writeBytes: (path, bytes) expected");
-        writeFileBytes(rt, args[0].getString(rt).utf8(rt), getBytes(rt, args[1]));
-        return jsi::Value::undefined();
-      });
-
-  setFn(rt, "__js65_stdinText", 0,
+// stdin/stdout bindings are CLI-only: the library entry uses request/result instead.
+void installCliBindings(jsi::Runtime &rt, HostContext &) {
+  js65core::setFn(rt, "__js65_stdinText", 0,
       [](jsi::Runtime &rt, const jsi::Value &, const jsi::Value *, size_t) -> jsi::Value {
         auto data = readAllStdin();
         return jsi::String::createFromUtf8(rt, data.data(), data.size());
       });
 
-  setFn(rt, "__js65_stdinBytes", 0,
+  js65core::setFn(rt, "__js65_stdinBytes", 0,
       [](jsi::Runtime &rt, const jsi::Value &, const jsi::Value *, size_t) -> jsi::Value {
-        return makeUint8Array(rt, readAllStdin());
+        return js65core::makeUint8Array(rt, readAllStdin());
       });
 
-  setFn(rt, "__js65_stdoutText", 1,
+  js65core::setFn(rt, "__js65_stdoutText", 1,
       [](jsi::Runtime &rt, const jsi::Value &, const jsi::Value *args, size_t count) -> jsi::Value {
-        if (count < 1 || !args[0].isString()) throwError(rt, "__js65_stdoutText: string expected");
+        if (count < 1 || !args[0].isString()) js65core::throwError(rt, "__js65_stdoutText: string expected");
         std::string s = args[0].getString(rt).utf8(rt);
         std::fwrite(s.data(), 1, s.size(), stdout);
         std::fflush(stdout);
         return jsi::Value::undefined();
       });
 
-  setFn(rt, "__js65_stdoutBytes", 1,
+  js65core::setFn(rt, "__js65_stdoutBytes", 1,
       [](jsi::Runtime &rt, const jsi::Value &, const jsi::Value *args, size_t count) -> jsi::Value {
-        if (count < 1) throwError(rt, "__js65_stdoutBytes: bytes expected");
-        auto data = getBytes(rt, args[0]);
+        if (count < 1) js65core::throwError(rt, "__js65_stdoutBytes: bytes expected");
+        auto data = js65core::getBytes(rt, args[0]);
         std::fwrite(data.data(), 1, data.size(), stdout);
         std::fflush(stdout);
         return jsi::Value::undefined();
-      });
-
-  setFn(rt, "__js65_listFiles", 1,
-      [](jsi::Runtime &rt, const jsi::Value &, const jsi::Value *args, size_t count) -> jsi::Value {
-        if (count < 1 || !args[0].isString()) throwError(rt, "__js65_listFiles: dir expected");
-        std::string dir = args[0].getString(rt).utf8(rt);
-        std::vector<std::string> files;
-        std::error_code ec;
-        for (auto it = std::filesystem::recursive_directory_iterator(dir, ec);
-             !ec && it != std::filesystem::recursive_directory_iterator(); it.increment(ec)) {
-          if (it->is_regular_file(ec)) files.push_back(it->path().string());
-        }
-        auto arr = jsi::Array(rt, files.size());
-        for (size_t i = 0; i < files.size(); ++i)
-          arr.setValueAtIndex(rt, i, jsi::String::createFromUtf8(rt, files[i]));
-        return arr;
-      });
-
-  setFn(rt, "__js65_exit", 1,
-      [](jsi::Runtime &, const jsi::Value &, const jsi::Value *args, size_t count) -> jsi::Value {
-        std::fflush(stdout);
-        std::exit(count >= 1 && args[0].isNumber() ? (int)args[0].getNumber() : 0);
       });
 }
 
@@ -237,22 +73,17 @@ void installJs65Bindings(SHRuntime *shr) {
 
 int main(int argc, char **argv) {
 #if defined(_WIN32)
-  // ROM/IPS output and module envelopes are binary; keep them byte-exact.
   _setmode(_fileno(stdin), _O_BINARY);
   _setmode(_fileno(stdout), _O_BINARY);
 #endif
 
+  HostContext ctx;
+  // The CLI reads includes straight off the filesystem relative to the include base.
+  ctx.readText = &js65core::fsReadText;
+  ctx.readBinary = &js65core::fsReadBinary;
   for (int i = 1; i < argc; ++i)
-    g_args.emplace_back(argv[i]);
+    ctx.args.emplace_back(argv[i]);
 
-  // Hand _sh_init only the program name so it never tries to parse the user's
-  // assembler flags (e.g. -o) as Hermes VM options.
-  SHRuntime *shr = _sh_init(1, argv);
-  SHConsoleContext *consoleContext = init_console_bindings(shr, 0, nullptr);
-  installJs65Bindings(shr);
-  bool success = _sh_initialize_units(shr, 1, sh_export_js65) &&
-      run_event_loop(shr, consoleContext);
-  free_console_context(consoleContext);
-  _sh_done(shr);
+  bool success = js65core::runJs65Core(ctx, installCliBindings);
   return success ? 0 : 1;
 }

--- a/integrations/hermes/hermes_lib.cpp
+++ b/integrations/hermes/hermes_lib.cpp
@@ -1,0 +1,268 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+// Shared-library entry point for the Static Hermes js65 frontend. Implements the C ABI
+// in js65.h over the shared host core (hermes_core.cpp): it forwards the caller's read
+// function pointers into the assembler and translates the compile result into the typed
+// Js65Result tree the ABI exposes. The frontend pushes the result through the
+// __js65_result* host functions (see integrations/hermes/hermes.ts) so the structure is
+// built field-by-field here rather than parsed from a serialized blob.
+
+#include "js65.h"
+#include "hermes_core.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <vector>
+
+using namespace facebook;
+using js65core::HostContext;
+
+// Pin the ABI layout (pointers first, then int32s) so consumers in other languages can
+// hard-code offsets.
+static_assert(offsetof(Js65Result, messages) == 8, "Js65Result layout");
+static_assert(offsetof(Js65Result, success) == 16, "Js65Result layout");
+static_assert(offsetof(Js65Message, source) == 24, "Js65Message layout");
+static_assert(offsetof(Js65SourceInfo, line) == 24, "Js65SourceInfo layout");
+static_assert(offsetof(Js65OutputFile, data) == 16, "Js65OutputFile layout");
+static_assert(offsetof(Js65OutputFile, dataLength) == 24, "Js65OutputFile layout");
+
+namespace {
+
+// Mutable accumulator the JS frontend fills via the __js65_result* bindings; converted to
+// the immutable Js65Result tree once the run completes.
+struct SourceFrameBuilder {
+  bool hasIdent = false;
+  std::string ident;
+  std::string file;
+  int32_t line = 0;
+  int32_t column = 0;
+};
+struct MessageBuilder {
+  std::string level;
+  std::string message;
+  bool hasStack = false;
+  std::string stack;
+  std::vector<SourceFrameBuilder> frames; // innermost first, up the include/macro stack
+};
+struct OutputFileBuilder {
+  std::string name;
+  std::string type;
+  std::vector<uint8_t> data;
+};
+struct ResultBuilder {
+  int32_t success = 0;
+  std::vector<OutputFileBuilder> outputs;
+  std::vector<MessageBuilder> messages;
+};
+
+// The runtime is single-threaded and js65_compile re-inits it per call, so we
+// guard access through a compile mutex.
+std::mutex g_compileMutex;
+
+char *dupString(std::string_view s) {
+  char *p = static_cast<char *>(std::malloc(s.size() + 1));
+  std::memcpy(p, s.data(), s.size());
+  p[s.size()] = '\0';
+  return p;
+}
+
+// Link a message's source frames into a parent chain: source == frames.front(), each
+// frame's parent the next-outer one. Returns the head, or nullptr when there are none.
+const Js65SourceInfo *buildSourceChain(const std::vector<SourceFrameBuilder> &frames) {
+  const Js65SourceInfo *parent = nullptr;
+  for (size_t i = frames.size(); i-- > 0;) {
+    auto *node = static_cast<Js65SourceInfo *>(std::calloc(1, sizeof(Js65SourceInfo)));
+    node->ident = frames[i].hasIdent ? dupString(frames[i].ident) : nullptr;
+    node->file = dupString(frames[i].file);
+    node->line = frames[i].line;
+    node->column = frames[i].column;
+    node->parent = parent;
+    parent = node;
+  }
+  return parent;
+}
+
+const Js65Result *buildResult(const ResultBuilder &b) {
+  auto *result = static_cast<Js65Result *>(std::calloc(1, sizeof(Js65Result)));
+  result->success = b.success;
+  result->outputCount = static_cast<int32_t>(b.outputs.size());
+  if (!b.outputs.empty()) {
+    auto *outputs = static_cast<Js65OutputFile *>(std::calloc(b.outputs.size(), sizeof(Js65OutputFile)));
+    for (size_t i = 0; i < b.outputs.size(); ++i) {
+      const OutputFileBuilder &ob = b.outputs[i];
+      outputs[i].name = dupString(ob.name);
+      outputs[i].type = dupString(ob.type);
+      outputs[i].dataLength = static_cast<int32_t>(ob.data.size());
+      if (!ob.data.empty()) {
+        auto *data = static_cast<uint8_t *>(std::malloc(ob.data.size()));
+        std::memcpy(data, ob.data.data(), ob.data.size());
+        outputs[i].data = data;
+      }
+    }
+    result->outputs = outputs;
+  }
+  result->messageCount = static_cast<int32_t>(b.messages.size());
+  if (!b.messages.empty()) {
+    auto *messages = static_cast<Js65Message *>(std::calloc(b.messages.size(), sizeof(Js65Message)));
+    for (size_t i = 0; i < b.messages.size(); ++i) {
+      const MessageBuilder &mb = b.messages[i];
+      messages[i].level = dupString(mb.level);
+      messages[i].message = dupString(mb.message);
+      messages[i].stack = mb.hasStack ? dupString(mb.stack) : nullptr;
+      messages[i].source = buildSourceChain(mb.frames);
+    }
+    result->messages = messages;
+  }
+  return result;
+}
+
+void freeSourceChain(const Js65SourceInfo *node) {
+  while (node) {
+    const Js65SourceInfo *parent = node->parent;
+    std::free(const_cast<char *>(node->ident));
+    std::free(const_cast<char *>(node->file));
+    std::free(const_cast<void *>(static_cast<const void *>(node)));
+    node = parent;
+  }
+}
+
+std::string_view utf8Arg(jsi::Runtime &rt, const jsi::Value *args, size_t count, size_t i, std::string &storage) {
+  if (i < count && args[i].isString()) {
+    storage = args[i].getString(rt).utf8(rt);
+    return storage;
+  }
+  return {};
+}
+
+// request + result-building bindings, specific to the library entry.
+void installLibBindings(jsi::Runtime &rt, HostContext &ctx, ResultBuilder &builder) {
+  js65core::setFn(rt, "__js65_request", 0,
+      [&ctx](jsi::Runtime &rt, const jsi::Value &, const jsi::Value *, size_t) -> jsi::Value {
+        return jsi::String::createFromUtf8(rt, ctx.request);
+      });
+
+  js65core::setFn(rt, "__js65_baseRom", 0,
+      [&ctx](jsi::Runtime &rt, const jsi::Value &, const jsi::Value *, size_t) -> jsi::Value {
+        return js65core::makeUint8Array(rt, ctx.baseRom);
+      });
+
+  // Polled by the TS core at per-line / per-chunk boundaries; reads the host-owned cancel
+  // flag, which another thread may flip while this compile is running under the lock.
+  js65core::setFn(rt, "__js65_cancelled", 0,
+      [&ctx](jsi::Runtime &, const jsi::Value &, const jsi::Value *, size_t) -> jsi::Value {
+        return jsi::Value(ctx.cancelFlag != nullptr && *ctx.cancelFlag != 0);
+      });
+
+  js65core::setFn(rt, "__js65_resultBegin", 1,
+      [&builder](jsi::Runtime &rt, const jsi::Value &, const jsi::Value *args, size_t count) -> jsi::Value {
+        builder.success = (count >= 1 && args[0].isBool() && args[0].getBool()) ? 1 : 0;
+        return jsi::Value::undefined();
+      });
+
+  // resultAdd functions are used to pass the result data from JS -> C++. We don't have a generalized
+  // serialization for this, so we just loop over it in JS and call these "create" methods to add
+  // to the current result buffer basically. 
+  js65core::setFn(rt, "__js65_resultAddOutput", 3,
+      [&builder](jsi::Runtime &rt, const jsi::Value &, const jsi::Value *args, size_t count) -> jsi::Value {
+        if (count < 3 || !args[0].isString() || !args[2].isString())
+          js65core::throwError(rt, "__js65_resultAddOutput: (name, data, type) expected");
+        OutputFileBuilder ob;
+        ob.name = args[0].getString(rt).utf8(rt);
+        ob.data = js65core::getBytes(rt, args[1]);
+        ob.type = args[2].getString(rt).utf8(rt);
+        builder.outputs.push_back(std::move(ob));
+        return jsi::Value::undefined();
+      });
+
+  js65core::setFn(rt, "__js65_resultAddMessage", 3,
+      [&builder](jsi::Runtime &rt, const jsi::Value &, const jsi::Value *args, size_t count) -> jsi::Value {
+        if (count < 2 || !args[0].isString() || !args[1].isString())
+          js65core::throwError(rt, "__js65_resultAddMessage: (level, message, stack?) expected");
+        MessageBuilder mb;
+        mb.level = args[0].getString(rt).utf8(rt);
+        mb.message = args[1].getString(rt).utf8(rt);
+        mb.hasStack = count >= 3 && args[2].isString();
+        if (mb.hasStack) mb.stack = args[2].getString(rt).utf8(rt);
+        builder.messages.push_back(std::move(mb));
+        return jsi::Value(static_cast<double>(builder.messages.size() - 1));
+      });
+
+  js65core::setFn(rt, "__js65_resultAddSourceFrame", 5,
+      [&builder](jsi::Runtime &rt, const jsi::Value &, const jsi::Value *args, size_t count) -> jsi::Value {
+        if (count < 5 || !args[0].isNumber())
+          js65core::throwError(rt, "__js65_resultAddSourceFrame: (messageIndex, ident, file, line, column) expected");
+        auto index = static_cast<size_t>(args[0].getNumber());
+        if (index >= builder.messages.size())
+          js65core::throwError(rt, "__js65_resultAddSourceFrame: message index out of range");
+        SourceFrameBuilder frame;
+        frame.hasIdent = args[1].isString();
+        if (frame.hasIdent) frame.ident = args[1].getString(rt).utf8(rt);
+        std::string scratch;
+        frame.file = utf8Arg(rt, args, count, 2, scratch);
+        frame.line = args[3].isNumber() ? static_cast<int32_t>(args[3].getNumber()) : 0;
+        frame.column = args[4].isNumber() ? static_cast<int32_t>(args[4].getNumber()) : 0;
+        builder.messages[index].frames.push_back(std::move(frame));
+        return jsi::Value::undefined();
+      });
+}
+
+} // namespace
+
+extern "C" JS65_EXPORT const Js65Result *js65_compile(
+    void *ctx,
+    const char *requestJson,
+    const uint8_t *baseRom,
+    int32_t baseRomLen,
+    Js65ReadFn readText,
+    Js65ReadFn readBinary,
+    const int32_t *cancelFlag) {
+  std::lock_guard<std::mutex> lock(g_compileMutex);
+
+  HostContext host;
+  host.readText = readText;
+  host.readBinary = readBinary;
+  host.readCtx = ctx;
+  host.cancelFlag = cancelFlag;
+  host.request = requestJson ? requestJson : "";
+  if (baseRom && baseRomLen > 0)
+    host.baseRom.assign(baseRom, baseRom + baseRomLen);
+  host.args = {"--lib"};
+
+  ResultBuilder builder;
+  bool ok = js65core::runJs65Core(host, [&builder](jsi::Runtime &rt, HostContext &c) {
+    installLibBindings(rt, c, builder);
+  });
+  if (!ok)
+    return nullptr;
+  return buildResult(builder);
+}
+
+extern "C" JS65_EXPORT void js65_free_result(const Js65Result *result) {
+  if (!result)
+    return;
+  for (int32_t i = 0; i < result->outputCount; ++i) {
+    const Js65OutputFile &o = result->outputs[i];
+    std::free(const_cast<char *>(o.name));
+    std::free(const_cast<char *>(o.type));
+    std::free(const_cast<uint8_t *>(o.data));
+  }
+  std::free(const_cast<Js65OutputFile *>(result->outputs));
+  for (int32_t i = 0; i < result->messageCount; ++i) {
+    const Js65Message &m = result->messages[i];
+    std::free(const_cast<char *>(m.level));
+    std::free(const_cast<char *>(m.message));
+    std::free(const_cast<char *>(m.stack));
+    freeSourceChain(m.source);
+  }
+  std::free(const_cast<Js65Message *>(result->messages));
+  std::free(const_cast<Js65Result *>(result));
+}

--- a/integrations/hermes/js65.h
+++ b/integrations/hermes/js65.h
@@ -1,0 +1,118 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+// Stable C ABI for the js65 shared library (js65.dll / libjs65.so / libjs65.dylib).
+// A native host (e.g. the .NET js65.hermes engine) calls js65_compile to assemble and
+// link a request, supplying two function pointers that service .include / .incbin reads
+// so includes can come from anywhere the host chooses, not just disk.
+//
+// The result is an explicit struct tree, not an opaque blob: every field has a fixed
+// offset so any language can marshal it directly. Explicit padding members pin the
+// layout so it does not shift with compiler alignment choices. All pointers below are
+// owned by the library and remain valid until js65_free_result; strings are UTF-8 and
+// NUL-terminated; a pointer documented as nullable is NULL when the value is absent.
+
+#ifndef JS65_H
+#define JS65_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(_WIN32)
+#define JS65_EXPORT __declspec(dllexport)
+#else
+#define JS65_EXPORT __attribute__((visibility("default")))
+#endif
+
+// User provided File-read callback. Return 0 on success and set *outData/*outLen to a buffer that
+// stays valid until the next callback call or until js65_compile returns; the library
+// copies it before either happens. Return nonzero for not-found/error, which the
+// assembler reports as a diagnostic. Text is UTF-8 bytes (no NUL terminator required).
+//
+//   userData  - the opaque pointer passed as ctx to js65_compile
+//   basePath  - the include base directory being searched (may be empty)
+//   relPath   - the file requested by the directive
+typedef int32_t (*Js65ReadFn)(
+    void *userData,
+    const char *basePath,
+    const char *relPath,
+    const uint8_t **outData,
+    int32_t *outLen);
+
+// For the following types, we order each of the fields by pointers first then data second
+// so that way we don't need to deal with differences betweeen 32bit and 64bit struct alignments.
+// On 64bit, all pointers will be aligned to 8 byte boundaries.
+
+// A source location, with parent pointing up the include / macro-expansion stack.
+typedef struct Js65SourceInfo {
+  const struct Js65SourceInfo *parent;  // nullable: next-outer frame
+  const char *ident;                    // nullable: symbol/macro name at this frame
+  const char *file;
+  int32_t line;
+  int32_t column;
+} Js65SourceInfo;
+
+// One diagnostic produced during assembly/linking.
+typedef struct Js65Message {
+  const char *level;            // "error" | "warning" | "info"
+  const char *message;
+  const char *stack;            // nullable: JS stack trace when captured
+  const Js65SourceInfo *source; // nullable: where it originated
+} Js65Message;
+
+// One named output produced by a compile. `type` tags the artifact kind.
+// "binary" (linked ROM / IPS), "object" (serialized .o), "debug" (debug info,
+// e.g. MLB labels), "source", and more in future (e.g. "listing").
+typedef struct Js65OutputFile {
+  const char *name;
+  const char *type;     // artifact kind: "binary" | "object" | "debug" | "source" | ...
+  const uint8_t *data;  // dataLength bytes (NULL when empty)
+  int32_t dataLength;
+} Js65OutputFile;
+
+// The outcome of one js65_compile call.
+typedef struct Js65Result {
+  const Js65OutputFile *outputs; // nullable list of output files (length in outputCount)
+  const Js65Message *messages;   // nullable list of messages (length in messageCount)
+  int32_t success;               // nonzero if assembly produced no errors
+  int32_t messageCount;
+  int32_t outputCount;
+} Js65Result;
+
+// Assemble and link one request. Only returns NULL if the js runtime init fails.
+// * ctx is a user provided opaque pointer that will be passed into the callbacks.
+// * requestJson is the combined input/action + options serialized as a string so that js65
+// can validate the inputs as if they are untrusted (so you don't have to)
+// For more details on the requestJson structure, see what the `Assembler.cs` class builds
+// * baseRom is the image we are patching, it can be NULL if you aren't patching anything.
+// * cancelFlag (nullable) points to host-owned memory that, when set to a nonzero value from
+// another thread, cooperatively cancels the in-flight compile: the assembler observes it at
+// per-line / per-chunk boundaries and returns a normal failure result (a "Compilation
+// cancelled" message). Pass NULL to disable cancellation. The pointed-to int
+// must stay valid for the duration of the call; the library only reads it.
+//
+// Not thread-safe: the call re-inits the single-threaded Hermes runtime, so callers must
+// serialize concurrent js65_compile calls.
+JS65_EXPORT const Js65Result *js65_compile(
+    void *ctx,
+    const char *requestJson,
+    const uint8_t *baseRom,
+    int32_t baseRomLen,
+    Js65ReadFn readText,
+    Js65ReadFn readBinary,
+    const int32_t *cancelFlag);
+
+// Free a result returned by js65_compile.
+JS65_EXPORT void js65_free_result(const Js65Result *result);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // JS65_H

--- a/integrations/quickjs.ts
+++ b/integrations/quickjs.ts
@@ -4,8 +4,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+// This is a quickjs based frontend which pretty much only exists for
+// benchmarks and showing why we aren't using it for anything serious.
+
 import { Cli } from '../src/cli.ts';
-import { Base64, compileActionsBrowser } from '../src/libassembler.ts';
 // @ts-expect-error quickjs builtin module
 import * as std from 'qjs:std';
 // @ts-expect-error quickjs builtin module
@@ -103,40 +105,7 @@ const cli = new Cli({
   exit: (code: number) => std.exit(code),
 });
 
-// `--json` mode: read one request envelope from stdin, forward it to the
-// existing compileActionsBrowser, and write the base64 result to stdout. This
-// backs the js65.desktop subprocess engine.
-async function runJsonMode(): Promise<void> {
-  const env = JSON.parse(std.in.readAsString());
-
-  const readText = (basePath: string, filePath: string): string => {
-    const s = std.loadFile(resolvePath(basePath, filePath));
-    if (s === null) throw new Error(`Could not read file: ${resolvePath(basePath, filePath)}`);
-    return stripBom(s);
-  };
-  const readBinary = (basePath: string, filePath: string): string => {
-    return new Base64().encode(readFileBytes(resolvePath(basePath, filePath)));
-  };
-
-  const result = await compileActionsBrowser(
-    JSON.stringify(env.modules ?? []),
-    JSON.stringify(env.assemblerOpts ?? {}),
-    JSON.stringify(env.linkerOpts ?? {}),
-    env.outputFormat ?? 'binary',
-    readText,
-    readBinary,
-    env.useSourceContents ?? false,
-  );
-
-  std.out.puts(result);
-  std.out.flush();
-}
-
 export async function main(args: string[]) {
-  if (args.includes('--json')) {
-    await runJsonMode();
-    return;
-  }
   await cli.run(args);
 }
 

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -651,16 +651,14 @@ export class Assembler {
     }
   }
 
-  // Assemble from a token source
-  async tokens(source: Tokens.Source) {
+  // Assemble from a token source. The optional signal is polled once per line so a long
+  // assembly can be cancelled cooperatively; an aborted signal throws, which the caller
+  // (compile) turns into an ordinary failure result.
+  async tokens(source: Tokens.Source, signal?: { readonly aborted: boolean }) {
     let line;
     while ((line = await source.next())) {
-      // console.log(`running line:`);
-      // console.log(`${JSON.stringify(line)}`);
+      if (signal?.aborted) throw new Error('Compilation cancelled');
       await this.line(line);
-      // console.log(`checking output:`);
-      // console.log(`${JSON.stringify(this.currentScope.global.symbols)}`);
-      // console.log(`\n\n`);
     }
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,8 +9,7 @@ import { Cpu } from './cpu.ts';
 import { clean, smudge } from './smudge.ts';
 import { sha1 } from "./sha1";
 import { Base64 } from './base64.ts';
-import { assemble, link, type AssemblyInput, type AssemblerOptions, type LinkerOptions, type OutputFormat, type FileCallbacks } from './libassembler.ts';
-import { SourceContents } from './tokenstream.ts';
+import { compile, findOutput, type AssemblyInput, type Js65Options, type FileCallbacks } from './libassembler.ts';
 import * as Tokens from './token.ts';
 
 export interface CompileOptions {
@@ -37,12 +36,15 @@ class Arguments {
   op: ((src: string, cpu: Cpu, prg: Uint8Array) => string) | undefined = undefined;
   rom = "";
   files : string[] = [];
-  target = '';
-  debugLevel = 0; // -1 = disabled, 0 = comments/labels only, 1 = full source
   dbgfile = "";
   compileonly = false;
-  includePaths : string[] = [];
   patch : "ips" | "" = "";
+  options: Js65Options = {
+    includePaths: [],
+    lineContinuations: true,
+    debugLevel: 0, // -1 = disabled, 0 = comments/labels only, 1 = full source
+    generateDebugInfo: true,
+  };
 }
 
 const DEBUG_PRINT = false;
@@ -57,8 +59,6 @@ export class Cli {
   public static readonly STDIN : string = "//stdin";
   public static readonly STDOUT : string = "//stdout";
 
-  sourceContents: SourceContents = new SourceContents();
-
   constructor(readonly callbacks: Callbacks) {
     this.callbacks = callbacks;
   }
@@ -68,7 +68,6 @@ export class Cli {
     for (let i = 0; i < args.length; i++) {
       const arg = args[i];
       if (arg === '-h' || arg === '--help') {
-        DEBUG("test help");
         this.usage(0);
       } else if (arg === '-o' || arg === '--outfile' || arg === '--output') {
         if (out.outfile) this.usage();
@@ -77,13 +76,17 @@ export class Cli {
         if (out.dbgfile) this.usage();
         out.dbgfile = args[++i];
       } else if (arg === '-g' || arg === '-g0') {
-        out.debugLevel = 0; // Comments and labels only
+        out.options.debugLevel = 0; // Comments and labels only
+        out.options.generateDebugInfo = true;
       } else if (arg === '-g1') {
-        out.debugLevel = 1; // Full source code
+        out.options.debugLevel = 1; // Full source code
+        out.options.generateDebugInfo = true;
       } else if (arg === '--no-debuginfo') {
-        out.debugLevel = -1; // Disable debug info generation
+        out.options.debugLevel = -1; // Disable debug info generation
+        out.options.generateDebugInfo = false;
       } else if (arg === '-c' || arg === '--compileonly') {
         out.compileonly = true;
+        out.options.outputFormat = 'object';
       } else if (arg.startsWith('--output=')) {
         if (out.outfile) this.usage();
         out.outfile = arg.substring('--output='.length);
@@ -98,17 +101,18 @@ export class Cli {
       } else if (arg.startsWith('--rom=')) {
         out.rom = arg.substring('--rom='.length);
       } else if (arg === '-I' || arg === '--include-dir') {
-        out.includePaths.push(args[++i]);
+        out.options.includePaths!.push(args[++i]);
       } else if (arg === '--ips') {
         out.patch = "ips";
+        out.options.outputFormat = 'ips';
       } else if (arg.startsWith('-I')) {
-        out.includePaths.push(arg.substring('-I'.length));
+        out.options.includePaths!.push(arg.substring('-I'.length));
       } else if (arg.startsWith('--include-dir')) {
-        out.includePaths.push(arg.substring('--include-dir'.length));
+        out.options.includePaths!.push(arg.substring('--include-dir'.length));
       } else if (arg === '--target') {
-        out.target = args[++i];
+        out.options.target = args[++i];
       } else if (arg.startsWith('--target=')) {
-        out.target = arg.substring('--target='.length);
+        out.options.target = arg.substring('--target='.length);
       } else {
         out.files.push(arg);
       }
@@ -117,11 +121,8 @@ export class Cli {
   }
 
   public async run(argv: string[]) {
-    DEBUG(`run: argv ${argv}`);
-
     const args = this.parseArgs(argv);
 
-    DEBUG(`parsed args: ${JSON.stringify(args)}`);
     if (args.files.length === 0) {
       return this.usage(1, [new Error("No input files provided")]);
     }
@@ -148,7 +149,6 @@ export class Cli {
 
         args.outfile = `${filename}${ext}`;
     }
-    DEBUG(`outfile: ${args.outfile}`);
 
     try {
       if (args.op !== undefined) {
@@ -162,84 +162,29 @@ export class Cli {
         inputs.push({ type: 'source', code, name: file });
       }
 
-      // Prepare options
-      const assemblerOpts: AssemblerOptions = {
-        includePaths: args.files[0] ? [
-          args.files[0].substring(0, args.files[0].lastIndexOf("/")),
-          ...args.includePaths
-        ] : args.includePaths,
-        lineContinuations: true,
-        generateDebugInfo: args.debugLevel >= 0,
-      };
+      // Seed the include path with the first file's directory
+      args.options.includePaths = args.files[0] ? [
+        args.files[0].substring(0, args.files[0].lastIndexOf("/")),
+        ...(args.options.includePaths ?? [])
+      ] : (args.options.includePaths ?? []);
+
+      // Load base ROM if specified
+      let baseRom: Uint8Array | undefined;
+      if (args.rom) {
+        let romData = await this.callbacks.fsReadBytes("", args.rom);
+        if (typeof romData === "string") romData = new Base64().decode(romData);
+        baseRom = romData;
+      }
 
       const callbacks: FileCallbacks = {
         readText: this.callbacks.fsReadString,
         readBinary: this.callbacks.fsReadBytes
       };
 
-      if (args.compileonly) {
-        DEBUG("stopping before linking cause --compileonly");
-        // Assemble only, no linking
-        const { modules, messages } = await assemble(inputs, assemblerOpts, callbacks, this.sourceContents);
+      const result = await compile(inputs, args.options, callbacks, baseRom);
 
-        // Print any messages
-        if (messages.length > 0) {
-          this.printMessages(messages);
-        }
-
-        // Check for errors
-        const hasErrors = messages.some(m => m.level === 'error');
-        if (hasErrors) {
-          this.callbacks.exit(1);
-          return;
-        }
-
-        const module = JSON.stringify(modules[0], (k, v) => {
-          if (k === "data" && typeof v === "object") {
-            // v == Uint8Array
-            return v.toString('base64');
-          }
-          return v;
-        }, "  ");
-        await this.callbacks.fsWriteString("", args.outfile, module);
-        return;
-      }
-
-      const linkerOpts: LinkerOptions = {
-        target: args.target,
-        debugLevel: args.debugLevel
-      };
-
-      // Load base ROM if specified
-      if (args.rom) {
-        let romData = await this.callbacks.fsReadBytes("", args.rom);
-        if (typeof romData === "string") romData = new Base64().decode(romData);
-        linkerOpts.baseRom = romData;
-      }
-
-      const outputFormat: OutputFormat = args.patch === "ips" ? "ips" : "binary";
-
-      // Assemble and link with debug info
-      const { modules, messages } = await assemble(inputs, assemblerOpts, callbacks, this.sourceContents);
-
-      // Print any assembly messages
-      if (messages.length > 0) {
-        this.printMessages(messages);
-      }
-
-      // Check for assembly errors
-      const hasAssemblyErrors = messages.some(m => m.level === 'error');
-      if (hasAssemblyErrors) {
-        this.callbacks.exit(1);
-        return;
-      }
-
-      const result = link(modules, linkerOpts, outputFormat, this.sourceContents, messages);
-
-      // Print any additional link messages
-      const newMessages = result.messages.slice(messages.length);
-      if (newMessages.length > 0) {
-        this.printMessages(newMessages);
+      if (result.messages.length > 0) {
+        this.printMessages(result.messages);
       }
 
       if (!result.success) {
@@ -247,11 +192,14 @@ export class Cli {
         return;
       }
 
-      await this.callbacks.fsWriteBytes("", args.outfile, result.data);
+      // The linked ROM / first artifact goes to outfile for now
+      const primary = result.outputs.find(o => o.type !== 'debug') ?? result.outputs[0];
+      await this.callbacks.fsWriteBytes("", args.outfile, primary.data);
 
       // Write debug info if requested
-      if (args.dbgfile && result.debugInfo) {
-        await this.callbacks.fsWriteString("", args.dbgfile, result.debugInfo);
+      const debug = findOutput(result, 'debug');
+      if (args.dbgfile && debug) {
+        await this.callbacks.fsWriteBytes("", args.dbgfile, debug.data);
       }
     } catch (e) {
       this.printerrors(e);
@@ -260,28 +208,19 @@ export class Cli {
   }
 
   async smudge(args: Arguments) {
-    DEBUG(`op ${args.op}`);
     if (args.files.length > 1) this.usage(1, [new Error('rehydrate and dehydrate only allow one input')]);
-    DEBUG("test8");
     const src = await this.callbacks.fsReadString("",args.files[0]);
     // if (err) this.usage(3, [err]);
-    DEBUG("test9");
     let fullRom: Uint8Array|undefined = undefined;
     if (args.rom) {
-      DEBUG("test10");
       let inbytes = await this.callbacks.fsReadBytes("",args.rom);
       fullRom = (typeof inbytes === 'string') ? new Base64().decode(inbytes) : inbytes;
       // if (err) this.usage(4, [err]);
     } else {
-      DEBUG("test11");
       const match = /smudge sha1 ([0-9a-f]{40})/.exec(src!);
-      DEBUG("test12");
       if (match === undefined) this.usage(1, [new Error('no sha1 tag, must specify rom')]);
-      DEBUG("test13");
       const shaTag = match![1];
-      DEBUG("test14");
       await this.callbacks.fsWalk('.', async(filename) => {
-        DEBUG("test callback");
         if (/\.nes$/.test(filename)) {
           let inbytes = await this.callbacks.fsReadBytes("",filename);
           inbytes = (typeof inbytes === 'string') ? new Base64().decode(inbytes) : inbytes;
@@ -298,11 +237,9 @@ export class Cli {
         return false;
       }
       );
-      DEBUG("test15");
       if (!fullRom) this.usage(1, [new Error(`could not find rom with sha ${shaTag}`)]);
     }
 
-    DEBUG("test16");
     // TODO - read the header properly
     const prg = fullRom!.subarray(0x10, 0x40010);
     await this.callbacks.fsWriteString("", args.outfile, args.op!(src!, Cpu.P02, prg));

--- a/src/libassembler.ts
+++ b/src/libassembler.ts
@@ -13,7 +13,7 @@ import { Preprocessor } from './preprocessor.ts';
 import { Tokenizer } from './tokenizer.ts';
 import { TokenStream, SourceContents } from './tokenstream.ts';
 import { type Module, type Segment } from "./module.ts";
-import { parseModule, parseActionModules } from "./validate_modules.ts";
+import { parseModule, parseRequest } from "./validate_modules.ts";
 import type { Expr } from './expr.ts';
 import type { SourceInfo, AssemblerMessage } from './token.ts';
 
@@ -22,11 +22,47 @@ export { Assembler, Cpu, SourceContents, Base64 };
 export type { Expr, Module, Segment };
 
 /**
- * Assembly input - supports source code or pre-compiled modules
+ * Source location for an action (from the caller's code)
+ */
+export interface ActionSource {
+  file: string;
+  line: number;
+}
+
+/**
+ * Action types for programmatic assembly
+ */
+export type AssemblyAction =
+  | { action: 'code', code: string, name?: string, source?: ActionSource }
+  | { action: 'label', label: string, source?: ActionSource }
+  | { action: 'byte', bytes: Array<number | { op: 'sym', sym: string }>, source?: ActionSource }
+  | { action: 'word', words: Array<number | { op: 'sym', sym: string }>, source?: ActionSource }
+  | { action: 'org', addr: number, name?: string, source?: ActionSource }
+  | { action: 'segment', name: string | string[], source?: ActionSource }
+  | { action: 'reloc', name?: string, source?: ActionSource }
+  | { action: 'export', name: string, source?: ActionSource }
+  | { action: 'assign', name: string, value: number | string, source?: ActionSource }
+  | { action: 'set', name: string, value: number | string, source?: ActionSource }
+  | { action: 'free', size: number, source?: ActionSource };
+
+/**
+ * Assembly input - supports source code, pre-compiled modules, or a list of
+ * programmatic actions (a way to build a module without writing source text).
  */
 export type AssemblyInput =
   | { type: 'source', code: string, name: string }
-  | { type: 'module', module: Module };
+  | { type: 'module', module: Module }
+  | { type: 'actions', actions: AssemblyAction[], name?: string };
+
+/**
+ * Cooperative cancellation primitive. Designed to look like AbortSignal so it can be used
+ * in environments that have it and in envs that don't.
+ */
+export type CancelSignal = { readonly aborted: boolean };
+
+function throwIfCancelled(signal?: CancelSignal): void {
+  if (signal?.aborted) throw new Error('Compilation cancelled');
+}
 
 /**
  * Options for assembly phase
@@ -57,7 +93,50 @@ export interface LinkerOptions {
 /**
  * Output format control
  */
-export type OutputFormat = 'binary' | 'ips';
+export type OutputFormat = 'binary' | 'ips' | 'object';
+
+/**
+ * The flat options bag every frontend speaks. The textual fields cross the JSON
+ * boundary as part of a Js65Request.
+ */
+export interface Js65Options {
+  includePaths?: string[];
+  lineContinuations?: boolean;
+  numberSeparators?: boolean;
+  generateDebugInfo?: boolean;
+  debugLevel?: number;
+  target?: string;
+  baseRomOffset?: number;
+  outputFormat?: OutputFormat;
+}
+
+/**
+ * Contains the post-validated data used for compilation.
+ */
+export interface Js65Request {
+  inputs: AssemblyInput[];
+  options: Js65Options;
+}
+
+/**
+ * The kind of artifact an OutputFile holds. Kept open-ended (a plain string union)
+ * so new kinds - e.g. 'listing' - can be added without churning every transport:
+ *   - 'binary' : a linked ROM image or IPS patch
+ *   - 'object' : a serialized .o module
+ *   - 'debug'  : debug info (currently MLB labels)
+ *   - 'source' : generated source text
+ */
+export type OutputType = 'source' | 'binary' | 'object' | 'debug';
+
+/**
+ * One named output produced by a compile. `type` distinguishes the binary ROM/IPS
+ * from sidecar artifacts (debug info, .o modules) that travel in the same list.
+ */
+export interface OutputFile {
+  name: string;
+  data: Uint8Array;
+  type: OutputType;
+}
 
 /**
  * File system callbacks for .include/.incbin directives
@@ -79,10 +158,17 @@ export interface AssembleResult {
   messages: AssemblerMessage[];
 }
 
+// Helper to convert ActionSource to SourceInfo
+function toSourceInfo(source?: ActionSource): SourceInfo | undefined {
+  if (!source) return undefined;
+  return { file: source.file, line: source.line, column: 0 };
+}
+
 /**
- * Assemble source files into Module objects
+ * Assemble source files, pre-compiled modules, and/or action lists into
+ * Module objects.
  *
- * @param inputs - Array of source code or modules to assemble
+ * @param inputs - Array of source code, modules, or action lists to assemble
  * @param options - Assembler configuration
  * @param callbacks - File system callbacks for .include/.incbin
  * @param sourceContents - Optional SourceContents to store source for debug info
@@ -92,30 +178,123 @@ export async function assemble(
   inputs: AssemblyInput[],
   options?: AssemblerOptions,
   callbacks?: FileCallbacks,
-  sourceContents?: SourceContents
+  sourceContents?: SourceContents,
+  signal?: CancelSignal
 ): Promise<AssembleResult> {
   const modules: Module[] = [];
   const allMessages: AssemblerMessage[] = [];
 
-  for (const input of inputs) {
+  const opts = {
+    includePaths: options?.includePaths || [],
+    lineContinuations: options?.lineContinuations ?? true,
+    numberSeparators: options?.numberSeparators,
+    generateDebugInfo: options?.generateDebugInfo
+  };
+  const asmOpts = {
+    generateDebugInfo: options?.generateDebugInfo
+  };
+
+  for (let i = 0; i < inputs.length; i++) {
+    throwIfCancelled(signal);
+    const input = inputs[i];
+
     if (input.type === 'module') {
       // Already compiled module, just add it
       modules.push(input.module);
       continue;
     }
 
-    // Process source code
-    const asmOpts = {
-      generateDebugInfo: options?.generateDebugInfo
-    };
-    const asm = new Assembler(Cpu.P02, asmOpts);
-    const opts = {
-      includePaths: options?.includePaths || [],
-      lineContinuations: options?.lineContinuations ?? true,
-      numberSeparators: options?.numberSeparators,
-      generateDebugInfo: options?.generateDebugInfo
-    };
+    if (input.type === 'actions') {
+      const asm = new Assembler(Cpu.P02, asmOpts);
+      let module_name = input.name ?? `module_${i}`;
+      const original_module_name = module_name;
 
+      for (const action of input.actions) {
+        // Set source info for debug purposes before processing each action
+        asm.setSource(toSourceInfo(action.source));
+
+        switch (action.action) {
+          case 'code': {
+            // For code actions, we need to tokenize and process through the full pipeline
+            const toks = new TokenStream(
+              callbacks?.readText,
+              callbacks?.readBinary,
+              opts,
+              sourceContents
+            );
+            // Use the first name provided through a code action as the outer module name
+            if (module_name === original_module_name && action.name) {
+              module_name = action.name;
+            }
+            const tokenizer = new Tokenizer(action.code, module_name, opts, sourceContents, asm.errorCollector);
+            toks.enter(tokenizer);
+            const pre = new Preprocessor(toks, asm, undefined, asm.errorCollector);
+            await asm.tokens(pre, signal);
+            break;
+          }
+
+          case 'label':
+            asm.label(action.label);
+            break;
+
+          case 'byte':
+            asm.byte(...action.bytes);
+            break;
+
+          case 'word':
+            asm.word(...action.words);
+            break;
+
+          case 'org':
+            asm.org(action.addr, action.name);
+            break;
+
+          case 'segment':
+            asm.segment(...action.name);
+            break;
+
+          case 'reloc':
+            asm.reloc(action.name);
+            break;
+
+          case 'export':
+            asm.export(action.name);
+            break;
+
+          case 'assign': {
+            const value = typeof action.value === 'string'
+              ? parseInt(action.value, 10)
+              : action.value;
+            asm.assign(action.name, value);
+            break;
+          }
+
+          case 'set': {
+            const value = typeof action.value === 'string'
+              ? parseInt(action.value, 10)
+              : action.value;
+            asm.set(action.name, value);
+            break;
+          }
+
+          case 'free':
+            asm.free(action.size);
+            break;
+
+          default:
+            console.warn(`Unknown action type:`, action);
+        }
+      }
+
+      const module = asm.module();
+      module.name = module_name;
+      modules.push(module);
+      allMessages.push(...asm.getMessages());
+      continue;
+    }
+
+    // Process source code
+    const asm = new Assembler(Cpu.P02, asmOpts);
     const toks = new TokenStream(
       callbacks?.readText,
       callbacks?.readBinary,
@@ -140,7 +319,7 @@ export async function assemble(
     const tokenizer = new Tokenizer(input.code, input.name, opts, sourceContents, asm.errorCollector);
     toks.enter(tokenizer);
     const pre = new Preprocessor(toks, asm, undefined, asm.errorCollector);
-    await asm.tokens(pre);
+    await asm.tokens(pre, signal);
 
     const module = asm.module();
     module.name = input.name;
@@ -155,10 +334,11 @@ export async function assemble(
 }
 
 /**
- * Result of compilation/linking operation
+ * Result of a link() call - the low-level binary/IPS output for one set of
+ * already-assembled modules.
  */
-export interface CompileResult {
-  /** Whether compilation succeeded (no errors) */
+export interface LinkResult {
+  /** Whether linking succeeded (no errors) */
   success: boolean;
   /** Binary output or IPS patch (empty if errors) */
   data: Uint8Array;
@@ -176,15 +356,16 @@ export interface CompileResult {
  * @param outputFormat - Output format ('binary' or 'ips')
  * @param sourceContents - Optional source contents for debug info generation
  * @param messages - Optional array of messages to include in result
- * @returns Compile result with binary data, debug info, and messages
+ * @returns Link result with binary data, debug info, and messages
  */
 export function link(
   modules: Module[],
   options?: LinkerOptions,
-  outputFormat: OutputFormat = 'binary',
+  outputFormat: 'binary' | 'ips' = 'binary',
   sourceContents?: SourceContents,
-  messages: AssemblerMessage[] = []
-): CompileResult {
+  messages: AssemblerMessage[] = [],
+  signal?: CancelSignal
+): LinkResult {
   // Create a copy of messages so we can add to it
   const allMessages = [...messages];
 
@@ -202,7 +383,7 @@ export function link(
       linker.read(module);
     }
 
-    const out = linker.link();
+    const out = linker.link(signal);
 
     // Generate output based on format
     let binaryData: Uint8Array;
@@ -241,21 +422,27 @@ export function link(
   }
 }
 
-function linkAssembleResult(
-  result: AssembleResult,
-  linkerOpts?: LinkerOptions,
-  outputFormat: OutputFormat = 'binary',
-  sourceContents?: SourceContents
-): CompileResult {
-  if (!result.success) {
-    return {
-      success: false,
-      data: new Uint8Array(0),
-      debugInfo: '',
-      messages: result.messages
-    };
-  }
-  return link(result.modules, linkerOpts, outputFormat, sourceContents, result.messages);
+/**
+ * Result of the canonical compile() entrypoint.
+ */
+export interface CompileResult {
+  /** Whether compilation succeeded (no errors) */
+  success: boolean;
+  /**
+   * Named output files. The linked ROM/IPS is a `type: 'binary'` entry; debug info
+   * (`type: 'debug'`) and serialized .o modules (`type: 'object'`) ride in the same
+   * list rather than as separate fields. Use findOutput()/the type tag to pick one.
+   */
+  outputs: OutputFile[];
+  /** All messages (errors, warnings, info) from compilation */
+  messages: AssemblerMessage[];
+}
+
+/**
+ * Find the first output of a given type (e.g. the linked ROM or the debug sidecar).
+ */
+export function findOutput(result: CompileResult, type: OutputType): OutputFile | undefined {
+  return result.outputs.find(o => o.type === type);
 }
 
 /**
@@ -264,8 +451,7 @@ function linkAssembleResult(
 function failureFromException(err: unknown): CompileResult {
   return {
     success: false,
-    data: new Uint8Array(0),
-    debugInfo: '',
+    outputs: [],
     messages: [{
       level: 'error',
       message: err instanceof Error ? err.message : String(err),
@@ -275,312 +461,167 @@ function failureFromException(err: unknown): CompileResult {
 }
 
 /**
- * Assemble + link
+ * Serialize a module to the .o JSON format, base64-encoding chunk data.
+ */
+function serializeModule(m: Module): string {
+  const base64 = new Base64();
+  return JSON.stringify(m, (k, v) => {
+    if (k === 'data' && v instanceof Uint8Array) {
+      return base64.encode(v);
+    }
+    return v;
+  }, '  ');
+}
+
+/**
+ * Deserialize a Js65Request JSON ({ inputs, options }) into typed inputs.
+ * Parses the JSON (expanding base64 byte/word literals) and validates the structure.
+ */
+export function deserializeRequest(requestJson: string): Js65Request {
+  const base64 = new Base64();
+  // The transport encodes byte/word literals as base64 to keep the JSON compact; expand
+  // them back to number arrays as the request is parsed.
+  const parsed: unknown = JSON.parse(requestJson, (key, value) =>
+    (key === 'bytes' || key === 'words') && typeof value === 'string' ? base64.decode(value) : value);
+  const validated = parseRequest(parsed);
+  if (!validated.ok) throw new Error(`Invalid compile request: ${validated.error}`);
+  return validated.value;
+}
+
+/**
+ * Canonical compile entrypoint: assembles and (unless outputFormat is 'object') links
+ * the given typed inputs, returning the structured result. Never throws: failures come
+ * back as a failure CompileResult. String-transport callers deserialize their JSON with
+ * deserializeRequest() first, then call this with the typed inputs/options.
  *
- * @param inputs - Array of source code or modules
- * @param assemblerOpts - Assembler configuration
- * @param linkerOpts - Linker configuration
- * @param outputFormat - Output format ('binary' or 'ips')
- * @param callbacks - File system callbacks
- * @param sourceContents - Optional source contents for debug info generation
- * @returns Compile result with binary data, debug info, and messages
+ * @param inputs - sources / modules / action lists to assemble and link
+ * @param options - flat options bag (text fields only; baseRom is the separate arg)
+ * @param callbacks - .include / .incbin readers (required only if a directive needs one)
+ * @param baseRom - Optional base ROM the linker patches into (raw bytes, not base64)
  */
 export async function compile(
   inputs: AssemblyInput[],
-  assemblerOpts?: AssemblerOptions,
-  linkerOpts?: LinkerOptions,
-  outputFormat: OutputFormat = 'binary',
+  options: Js65Options = {},
   callbacks?: FileCallbacks,
-  sourceContents?: SourceContents
+  baseRom?: Uint8Array,
+  signal?: CancelSignal,
 ): Promise<CompileResult> {
+  const base64 = new Base64();
   try {
-    const result = await assemble(inputs, assemblerOpts, callbacks, sourceContents);
-    return linkAssembleResult(result, linkerOpts, outputFormat, sourceContents);
-  } catch (err) {
-    return failureFromException(err);
-  }
-}
-
-/**
- * Source location for an action (from the caller's code)
- */
-export interface ActionSource {
-  file: string;
-  line: number;
-}
-
-/**
- * Action types for programmatic assembly
- */
-export type AssemblyAction =
-  | { action: 'code', code: string, name?: string, source?: ActionSource }
-  | { action: 'label', label: string, source?: ActionSource }
-  | { action: 'byte', bytes: Array<number | { op: 'sym', sym: string }>, source?: ActionSource }
-  | { action: 'word', words: Array<number | { op: 'sym', sym: string }>, source?: ActionSource }
-  | { action: 'org', addr: number, name?: string, source?: ActionSource }
-  | { action: 'segment', name: string | string[], source?: ActionSource }
-  | { action: 'reloc', name?: string, source?: ActionSource }
-  | { action: 'export', name: string, source?: ActionSource }
-  | { action: 'assign', name: string, value: number | string, source?: ActionSource }
-  | { action: 'set', name: string, value: number | string, source?: ActionSource }
-  | { action: 'free', size: number, source?: ActionSource };
-
-/**
- * Assembles modules from actions, without converting to source text.
- * AssemblyActions are a way to programatically create a module, which is handy
- * for applications that want to write data to the rom without needing to generate
- * source text and passing it in as code.
- *
- * @param actionModules - Array of action arrays (one per module)
- * @param options - Assembler configuration
- * @param callbacks - File system callbacks for .include/.incbin in code actions
- * @param sourceContents - Optional SourceContents for debug info
- * @returns Modules and any messages from assembly
- */
-export async function assembleActions(
-  actionModules: AssemblyAction[][],
-  options?: AssemblerOptions,
-  callbacks?: FileCallbacks,
-  sourceContents?: SourceContents
-): Promise<AssembleResult> {
-  const modules: Module[] = [];
-  const allMessages: AssemblerMessage[] = [];
-
-  // Helper to convert ActionSource to SourceInfo
-  const toSourceInfo = (source?: ActionSource): SourceInfo | undefined => {
-    if (!source) return undefined;
-    return {
-      file: source.file,
-      line: source.line,
-      column: 0
+    throwIfCancelled(signal);
+    const asmOpts: AssemblerOptions = {
+      includePaths: options.includePaths,
+      lineContinuations: options.lineContinuations,
+      numberSeparators: options.numberSeparators,
+      generateDebugInfo: options.generateDebugInfo,
     };
-  };
-
-  for (let moduleIdx = 0; moduleIdx < actionModules.length; moduleIdx++) {
-    const actions = actionModules[moduleIdx];
-    const asmOpts = {
-      generateDebugInfo: options?.generateDebugInfo
+    const linkerOpts: LinkerOptions = {
+      target: options.target,
+      baseRom,
+      baseRomOffset: options.baseRomOffset,
+      debugLevel: options.debugLevel,
     };
-    const asm = new Assembler(Cpu.P02, asmOpts);
-    let module_name = `module_${moduleIdx}`;
-    const original_module_name = module_name;
+    const outputFormat: OutputFormat = options.outputFormat ?? 'binary';
+    const sourceContents = options.generateDebugInfo ? new SourceContents() : undefined;
 
-    for (const action of actions) {
-      // Set source info for debug purposes before processing each action
-      asm.setSource(toSourceInfo(action.source));
+    // .include / .incbin readers. They are optional (sources may use neither); a missing
+    // one only fails if a directive actually needs it. readBinary may hand back base64
+    // (some hosts can only marshal binary as a string), so decode it to bytes here.
+    const fileCallbacks: FileCallbacks = {
+      readText: async (basePath, relPath) => {
+        if (!callbacks?.readText) throw new Error(`No readText callback provided (reading ${basePath}/${relPath})`);
+        return await callbacks.readText(basePath, relPath);
+      },
+      readBinary: async (basePath, relPath) => {
+        if (!callbacks?.readBinary) throw new Error(`No readBinary callback provided (reading ${basePath}/${relPath})`);
+        const data = await callbacks.readBinary(basePath, relPath);
+        return typeof data === 'string' ? base64.decode(data) : data;
+      },
+    };
 
-      switch (action.action) {
-        case 'code': {
-          // For code actions, we need to tokenize and process through the full pipeline
-          const opts = {
-            includePaths: options?.includePaths || [],
-            lineContinuations: options?.lineContinuations ?? true,
-            numberSeparators: options?.numberSeparators,
-            generateDebugInfo: options?.generateDebugInfo
-          };
-          const toks = new TokenStream(
-            callbacks?.readText,
-            callbacks?.readBinary,
-            opts,
-            sourceContents
-          );
-          // Use the first name provided through a code action as the outer module name
-          if (module_name == original_module_name && action.name) {
-            module_name = action.name;
-          }
-          const tokenizer = new Tokenizer(action.code, module_name, opts, sourceContents, asm.errorCollector);
-          toks.enter(tokenizer);
-          const pre = new Preprocessor(toks, asm, undefined, asm.errorCollector);
-          await asm.tokens(pre);
-          break;
-        }
-
-        case 'label':
-          asm.label(action.label);
-          break;
-
-        case 'byte': {
-          asm.byte(...action.bytes);
-          break;
-        }
-
-        case 'word': {
-          asm.word(...action.words);
-          break;
-        }
-
-        case 'org':
-          asm.org(action.addr, action.name);
-          break;
-
-        case 'segment':
-          asm.segment(...action.name);
-          break;
-
-        case 'reloc':
-          asm.reloc(action.name);
-          break;
-
-        case 'export':
-          asm.export(action.name);
-          break;
-
-        case 'assign': {
-          const value = typeof action.value === 'string'
-            ? parseInt(action.value, 10)
-            : action.value;
-          asm.assign(action.name, value);
-          break;
-        }
-
-        case 'set': {
-          const value = typeof action.value === 'string'
-            ? parseInt(action.value, 10)
-            : action.value;
-          asm.set(action.name, value);
-          break;
-        }
-
-        case 'free':
-          asm.free(action.size);
-          break;
-
-        default:
-          console.warn(`Unknown action type:`, action);
-      }
+    const asm = await assemble(inputs, asmOpts, fileCallbacks, sourceContents, signal);
+    if (!asm.success) {
+      return { success: false, outputs: [], messages: asm.messages };
     }
 
-    const module = asm.module();
-    module.name = module_name;
-    modules.push(module);
+    if (outputFormat === 'object') {
+      const outputs: OutputFile[] = asm.modules.map(m => ({
+        name: `${m.name || 'module'}.o`,
+        data: new TextEncoder().encode(serializeModule(m)),
+        type: 'object',
+      }));
+      return { success: true, outputs, messages: asm.messages };
+    }
 
-    // Collect messages from this assembler
-    allMessages.push(...asm.getMessages());
-  }
-
-  const hasErrors = allMessages.some(m => m.level === 'error');
-  return { success: !hasErrors, modules, messages: allMessages };
-}
-
-/**
- * Convenience function: assemble actions + link in one step
- *
- * @param actionModules - Array of action arrays (one per module)
- * @param assemblerOpts - Assembler configuration
- * @param linkerOpts - Linker configuration
- * @param outputFormat - Output format ('binary' or 'ips')
- * @param callbacks - File system callbacks
- * @param sourceContents - Optional source contents for debug info generation
- * @returns Compile result with binary data, debug info, and messages
- */
-export async function compileActions(
-  actionModules: AssemblyAction[][],
-  assemblerOpts?: AssemblerOptions,
-  linkerOpts?: LinkerOptions,
-  outputFormat: OutputFormat = 'binary',
-  callbacks?: FileCallbacks,
-  sourceContents?: SourceContents
-): Promise<CompileResult> {
-  try {
-    const result = await assembleActions(actionModules, assemblerOpts, callbacks, sourceContents);
-    return linkAssembleResult(result, linkerOpts, outputFormat, sourceContents);
+    const lr = link(asm.modules, linkerOpts, outputFormat, sourceContents, asm.messages, signal);
+    const outputName = outputFormat === 'ips' ? 'out.ips' : 'out.nes';
+    const outputs: OutputFile[] = [{ name: outputName, data: lr.data, type: 'binary' }];
+    // Debug info rides as a sidecar output (type 'debug') rather than a separate field.
+    if (lr.debugInfo) {
+      outputs.push({ name: 'out.mlb', data: new TextEncoder().encode(lr.debugInfo), type: 'debug' });
+    }
+    return {
+      success: lr.success,
+      outputs,
+      messages: lr.messages,
+    };
   } catch (err) {
     return failureFromException(err);
   }
 }
 
 /**
- * Browser-compatible wrapper for compileActions that accepts JSON strings and returns base64-encoded result.
- * This function is designed to be called from C# using JSImport in the browser engine.
- *
- * @param modulesJson - JSON string containing array of action modules
- * @param assemblerOptsJson - JSON string containing assembler options
- * @param linkerOptsJson - JSON string containing linker options (baseRom should be base64-encoded)
- * @param outputFormat - Output format ('binary' or 'ips')
- * @param readTextCallback - Callback function for reading text files (basePath, filePath) => content
- * @param readBinaryCallback - Callback function for reading binary files (basePath, filePath) => base64-encoded content
- * @param useSourceContents - Whether to create SourceContents for debug info
- * @returns Promise<string> - Base64-encoded JSON result with romdata and debugfile
+ * String-transport entry for the frontends so they don't need to validate everything. Deserializes
+ * a Js65RequestData into the components and then compiles it, if the input fails validation, this
+ * catches the error and returns a `CompileResult` with the error message
  */
-export async function compileActionsBrowser(
-  modulesJson: string,
-  assemblerOptsJson: string,
-  linkerOptsJson: string,
-  outputFormat: OutputFormat = 'binary',
-  readTextCallback: (basePath: string, filePath: string) => string,
-  readBinaryCallback: (basePath: string, filePath: string) => string,
-  useSourceContents: boolean = false
+export async function compileRequest(
+  requestJson: string,
+  callbacks?: FileCallbacks,
+  baseRom?: Uint8Array,
+  signal?: CancelSignal,
+): Promise<CompileResult> {
+  try {
+    const { inputs, options } = deserializeRequest(requestJson);
+    return await compile(inputs, options, callbacks, baseRom, signal);
+  } catch (err) {
+    return failureFromException(err);
+  }
+}
+
+/**
+ * Adapter for the .NET WASM browser engine (JSImport). We have to work around limitations
+ * in JS interop and we do that by stringify-ing pretty much all the things.
+ */
+export async function compileBrowser(
+  requestJson: string,
+  readText: (basePath: string, relPath: string) => string | Promise<string>,
+  readBinaryBase64: (basePath: string, relPath: string) => string | Promise<string>,
+  baseRom: ArrayLike<number> | undefined,
+  shouldCancel?: () => boolean,
 ): Promise<string> {
   const base64 = new Base64();
+  const callbacks: FileCallbacks = {
+    readText: async (basePath, relPath) => readText(basePath, relPath),
+    readBinary: async (basePath, relPath) => base64.decode(await readBinaryBase64(basePath, relPath)),
+  };
+  // The marshaller hands the byte[] param across as a JS number array; normalize to a
+  // real Uint8Array for the linker.
+  const rom = baseRom && baseRom.length > 0
+    ? (baseRom instanceof Uint8Array ? baseRom : new Uint8Array(Array.from(baseRom)))
+    : undefined;
 
-  try {
-    // Parse action modules JSON
-    const rawActionModules: unknown = JSON.parse(modulesJson, (key, value) => {
-      // Deserialize base64-encoded byte/word arrays into number arrays
-      if ((key === 'bytes' || key === 'words') && typeof value === 'string') {
-        return base64.decode(value);
-      }
-      return value;
-    });
-    // Validate the untrusted action JSON before assembling it.
-    const validated = parseActionModules(rawActionModules);
-    if (!validated.ok) {
-      throw new Error(`Invalid action module input: ${validated.error}`);
-    }
-    const actionModules: AssemblyAction[][] = validated.value;
+  // JSImport can't marshal an AbortSignal, so the host passes a polling predicate; adapt it to
+  // the CancelSignal shape. 
+  // This doesn't work well in WASM, the .NET token only flips while host code
+  // runs, i.e. cancellation is observed at the file-callback await boundaries, not mid-compute.
+  const signal: CancelSignal | undefined = shouldCancel ? { get aborted() { return shouldCancel(); } } : undefined;
 
-    // Parse assembler options
-    const assemblerOpts: AssemblerOptions = JSON.parse(assemblerOptsJson);
-
-    // Parse linker options and decode base64 ROM
-    const linkerOptsRaw = JSON.parse(linkerOptsJson);
-    const linkerOpts: LinkerOptions = {
-      ...linkerOptsRaw,
-      baseRom: linkerOptsRaw.baseRom ? base64.decode(linkerOptsRaw.baseRom) : undefined
-    };
-
-    // Create callbacks object
-    const callbacks: FileCallbacks = {
-      readText: async (basePath: string, filePath: string) => {
-        return readTextCallback(basePath, filePath);
-      },
-      readBinary: async (basePath: string, filePath: string) => {
-        const base64Content = readBinaryCallback(basePath, filePath);
-        return base64.decode(base64Content);
-      }
-    };
-
-    // Create source contents if needed
-    const sourceContents = useSourceContents ? new SourceContents() : undefined;
-
-    // Call compileActions
-    const result = await compileActions(
-      actionModules,
-      assemblerOpts,
-      linkerOpts,
-      outputFormat,
-      callbacks,
-      sourceContents
-    );
-
-    // Encode result as base64 JSON
-    const resultJson = JSON.stringify({
-      success: result.success,
-      romdata: base64.encode(result.data),
-      debugfile: result.debugInfo || '',
-      messages: result.messages
-    });
-
-    return base64.encode(new TextEncoder().encode(resultJson));
-  } catch (err) {
-    // Return a failure result encoded in the same format
-    const failureResult = failureFromException(err);
-    const resultJson = JSON.stringify({
-      success: failureResult.success,
-      romdata: base64.encode(failureResult.data),
-      debugfile: failureResult.debugInfo,
-      messages: failureResult.messages
-    });
-    return base64.encode(new TextEncoder().encode(resultJson));
-  }
+  const result = await compileRequest(requestJson, callbacks, rom, signal);
+  const resultJson = JSON.stringify({
+    success: result.success,
+    outputs: result.outputs.map(o => ({ name: o.name, data: base64.encode(o.data), type: o.type })),
+    messages: result.messages,
+  });
+  return base64.encode(new TextEncoder().encode(resultJson));
 }

--- a/src/linker.ts
+++ b/src/linker.ts
@@ -78,12 +78,12 @@ export class Linker {
     return this;
   }
 
-  link(): SparseByteArray {
+  link(signal?: { readonly aborted: boolean }): SparseByteArray {
     const target = Targets.get(this.opts.target?.toLowerCase())
     if (target) {
       target.segments.forEach( seg => this._link.addRawSegment(seg) );
     }
-    return this._link.link();
+    return this._link.link(signal);
   }
 
   report(verbose = false) {
@@ -971,7 +971,7 @@ class Link {
     throw new Error(`Unable to fully resolve expr${at}`);
   }
 
-  link(): SparseByteArray {
+  link(signal?: { readonly aborted: boolean }): SparseByteArray {
     // Build up the LinkSegment objects
     for (const [name, segments] of this.rawSegments) {
       let s = segments[0];
@@ -1044,6 +1044,7 @@ class Link {
 
     let count = this.resolvedChunks.length + 2 * this.unresolvedChunks.size;
     while (count) {
+      if (signal?.aborted) throw new Error('Compilation cancelled');
       const c = this.resolvedChunks.pop();
       if (c) {
         this.placeChunk(c);

--- a/src/validate_modules.ts
+++ b/src/validate_modules.ts
@@ -17,7 +17,7 @@ import { Base64 } from './base64.ts';
 import type { Chunk, Module, OverwriteMode, Segment, Substitution, Symbol } from './module.ts';
 import type { Expr, Meta } from './expr.ts';
 import type { SourceInfo } from './token.ts';
-import type { ActionSource, AssemblyAction } from './libassembler.ts';
+import type { ActionSource, AssemblyAction, AssemblyInput, Js65Options, Js65Request, OutputFormat } from './libassembler.ts';
 
 export type Validated<T> =
   | { ok: true; value: T }
@@ -112,8 +112,6 @@ function validateExpr(v: unknown, path: string): Expr {
   }
   return out;
 }
-
-// --- Module pieces ---------------------------------------------------------
 
 function validateSubstitution(v: unknown, path: string): Substitution {
   if (!isObject(v)) fail(path, 'expected object');
@@ -262,9 +260,8 @@ function validateActionSource(v: unknown, path: string): ActionSource {
   };
 }
 
-// `bytes`/`words` arrive either as a Uint8Array (the base64 handler in
-// compileActionsBrowser already decoded a base64 string) or as a literal array
-// of numbers / `{op:'sym', sym}` references.
+// `bytes`/`words` arrive either as a Uint8Array (a JSON reviver already decoded
+// a base64 string) or as a literal array of numbers / `{op:'sym', sym}` references.
 function validateByteList(v: unknown, path: string): Array<number | { op: 'sym'; sym: string }> {
   if (v instanceof Uint8Array) return Array.from(v);
   const arr = reqArray(v, path);
@@ -335,7 +332,7 @@ function validateAction(v: unknown, path: string): AssemblyAction {
 
 /**
  * Validate a parsed-JSON object as `AssemblyAction[][]` (the programmatic
- * action lists fed by the desktop/subprocess and browser paths).
+ * action lists fed by integration libraries).
  */
 export function parseActionModules(obj: unknown): Validated<AssemblyAction[][]> {
   try {
@@ -345,6 +342,82 @@ export function parseActionModules(obj: unknown): Validated<AssemblyAction[][]> 
       return actions.map((a, j) => validateAction(a, `modules[${i}][${j}]`));
     });
     return { ok: true, value };
+  } catch (err) {
+    if (err instanceof ValidationError) return { ok: false, error: err.message };
+    throw err;
+  }
+}
+
+function validateInput(v: unknown, path: string): AssemblyInput {
+  if (!isObject(v)) fail(path, 'expected object');
+  const type = reqString(v.type, `${path}.type`);
+  switch (type) {
+    case 'source':
+      return {
+        type: 'source',
+        code: reqString(v.code, `${path}.code`),
+        name: reqString(v.name, `${path}.name`),
+      };
+    case 'module': {
+      const mod = parseModule(v.module);
+      if (!mod.ok) fail(`${path}.module`, mod.error);
+      return { type: 'module', module: mod.value };
+    }
+    case 'actions': {
+      const actions = reqArray(v.actions, `${path}.actions`)
+        .map((a, i) => validateAction(a, `${path}.actions[${i}]`));
+      const name = optString(v.name, `${path}.name`);
+      return name !== undefined ? { type: 'actions', actions, name } : { type: 'actions', actions };
+    }
+    default:
+      fail(`${path}.type`, `unknown input type "${type}"`);
+  }
+}
+
+/**
+ * Validate a parsed-JSON array as `AssemblyInput[]` to make sure each action is fine
+ */
+export function parseInputs(arr: unknown): AssemblyInput[] {
+  const inputs = reqArray(arr, 'inputs');
+  return inputs.map((v, i) => validateInput(v, `inputs[${i}]`));
+}
+
+const OUTPUT_FORMATS = new Set<string>(['binary', 'ips', 'object']);
+
+function validateOptions(v: unknown, path: string): Js65Options {
+  if (v === undefined) return {};
+  if (!isObject(v)) fail(path, 'expected object');
+  const out: Js65Options = {};
+  if (v.includePaths !== undefined) {
+    out.includePaths = reqArray(v.includePaths, `${path}.includePaths`)
+      .map((s, i) => reqString(s, `${path}.includePaths[${i}]`));
+  }
+  const lineContinuations = optBoolean(v.lineContinuations, `${path}.lineContinuations`);
+  if (lineContinuations !== undefined) out.lineContinuations = lineContinuations;
+  const numberSeparators = optBoolean(v.numberSeparators, `${path}.numberSeparators`);
+  if (numberSeparators !== undefined) out.numberSeparators = numberSeparators;
+  const generateDebugInfo = optBoolean(v.generateDebugInfo, `${path}.generateDebugInfo`);
+  if (generateDebugInfo !== undefined) out.generateDebugInfo = generateDebugInfo;
+  const debugLevel = optNumber(v.debugLevel, `${path}.debugLevel`);
+  if (debugLevel !== undefined) out.debugLevel = debugLevel;
+  const target = optString(v.target, `${path}.target`);
+  if (target !== undefined) out.target = target;
+  const baseRomOffset = optNumber(v.baseRomOffset, `${path}.baseRomOffset`);
+  if (baseRomOffset !== undefined) out.baseRomOffset = baseRomOffset;
+  if (v.outputFormat !== undefined) {
+    const fmt = reqString(v.outputFormat, `${path}.outputFormat`);
+    if (!OUTPUT_FORMATS.has(fmt)) fail(`${path}.outputFormat`, 'expected one of binary|ips|object');
+    out.outputFormat = fmt as OutputFormat;
+  }
+  return out;
+}
+
+export function parseRequest(obj: unknown): Validated<Js65Request> {
+  try {
+    if (!isObject(obj)) fail('request', 'expected object');
+    const inputs = parseInputs(obj.inputs);
+    const options = validateOptions(obj.options, 'request.options');
+    return { ok: true, value: { inputs, options } };
   } catch (err) {
     if (err instanceof ValidationError) return { ok: false, error: err.message };
     throw err;

--- a/test/integration_test.ts
+++ b/test/integration_test.ts
@@ -6,13 +6,12 @@
  */
 
 import {describe, it, expect} from 'bun:test';
-import {compile, type AssemblyInput} from '../src/libassembler.ts';
-import {SourceContents} from '../src/tokenstream.ts';
+import {compile, compileRequest, type AssemblyInput} from '../src/libassembler.ts';
 
 async function compileSource(source: string, filename: string = 'test.s'): Promise<Uint8Array> {
   const input: AssemblyInput = { type: 'source', code: source, name: filename };
-  const result = await compile([input], { lineContinuations: true }, {}, 'binary');
-  return result.data;
+  const result = await compile([input], { lineContinuations: true });
+  return result.outputs[0].data;
 }
 
 async function compileWithBaseRom(source: string, baseRom: Uint8Array, filename: string = 'test.s'): Promise<Uint8Array> {
@@ -24,13 +23,13 @@ async function compileWithBaseRom(source: string, baseRom: Uint8Array, filename:
 FREE "PRG" [$8000, $10000)
 `};
   const input: AssemblyInput = { type: 'source', code: source, name: filename };
-  const result = await compile([initsrc, input], { lineContinuations: true }, { baseRom }, 'binary');
-  return result.data;
+  const result = await compile([initsrc, input], { lineContinuations: true }, undefined, baseRom);
+  return result.outputs[0].data;
 }
 
 async function expectCompileError(source: string, errorMatch?: string | RegExp): Promise<Error> {
   const input: AssemblyInput = { type: 'source', code: source, name: 'test.s' };
-  const result = await compile([input], { lineContinuations: true }, {}, 'binary');
+  const result = await compile([input], { lineContinuations: true });
 
   if (result.success) {
     throw new Error('Expected compilation to fail but it succeeded');
@@ -54,6 +53,62 @@ async function expectCompileError(source: string, errorMatch?: string | RegExp):
 }
 
 describe('End to end test cases', function() {
+  describe('compileRequest data handling', function() {
+    it('returns a failure result (not a throw) for malformed JSON', async function() {
+      const result = await compileRequest('{ not valid json');
+      expect(result.success).toBe(false);
+      expect(result.outputs).toEqual([]);
+      expect(result.messages.some(m => m.level === 'error')).toBe(true);
+    });
+
+    it('returns a failure result (not a throw) for an invalid request shape', async function() {
+      const result = await compileRequest(JSON.stringify({ inputs: 'not-an-array' }));
+      expect(result.success).toBe(false);
+      expect(result.messages.some(m => m.level === 'error' && /Invalid compile request/.test(m.message))).toBe(true);
+    });
+
+    it('compiles well-formed data', async function() {
+      const req = JSON.stringify({
+        inputs: [{ type: 'source', name: 'test.s', code: '.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000\n.org $8000\nlda #$42\n' }],
+        options: { lineContinuations: true },
+      });
+      const result = await compileRequest(req);
+      expect(result.success).toBe(true);
+      expect(result.outputs.find(o => o.type === 'binary')).toBeTruthy();
+    });
+  });
+
+  describe('cancellation', function() {
+    it('returns a cancelled failure result (not a throw) when the signal is already aborted', async function() {
+      const input: AssemblyInput = { type: 'source', name: 'test.s', code: '.org $8000\nlda #$42\n' };
+      const result = await compile([input], { lineContinuations: true }, undefined, undefined, { aborted: true });
+      expect(result.success).toBe(false);
+      expect(result.outputs).toEqual([]);
+      expect(result.messages.some(m => m.level === 'error' && /cancelled/i.test(m.message))).toBe(true);
+    });
+
+    it('cancels mid-assembly at the per-line boundary', async function() {
+      // Stay un-aborted long enough to clear compile()'s top check and assemble()'s per-input
+      // check, then trip inside the per-line tokens() loop.
+      let polls = 0;
+      const signal = { get aborted() { return polls++ > 1; } };
+      const input: AssemblyInput = { type: 'source', name: 'test.s', code: 'lda #$01\nlda #$02\nlda #$03\nlda #$04\n' };
+      const result = await compile([input], { lineContinuations: true }, undefined, undefined, signal);
+      expect(result.success).toBe(false);
+      expect(result.messages.some(m => /cancelled/i.test(m.message))).toBe(true);
+    });
+
+    it('compileRequest forwards the cancel signal', async function() {
+      const req = JSON.stringify({
+        inputs: [{ type: 'source', name: 'test.s', code: '.org $8000\nlda #$42\n' }],
+        options: { lineContinuations: true },
+      });
+      const result = await compileRequest(req, undefined, undefined, { aborted: true });
+      expect(result.success).toBe(false);
+      expect(result.messages.some(m => /cancelled/i.test(m.message))).toBe(true);
+    });
+  });
+
   describe('Real world tests', function() {
     it('should not cause an infinite loop in symbol resolution', async function() {
       const source = `
@@ -238,13 +293,14 @@ HelperRoutine:
 `
       };
 
-      const result = await compile([mainModule, helperModule], { lineContinuations: true }, {}, 'binary');
-      expect(result.data).toBeTruthy();
+      const result = await compile([mainModule, helperModule], { lineContinuations: true });
+      const data = result.outputs[0].data;
+      expect(data).toBeTruthy();
 
       // Main should have JSR to $8100
-      expect(result.data[0]).toBe(0x20); // JSR
-      expect(result.data[1]).toBe(0x00); // low byte of $8100
-      expect(result.data[2]).toBe(0x81); // high byte of $8100
+      expect(data[0]).toBe(0x20); // JSR
+      expect(data[1]).toBe(0x00); // low byte of $8100
+      expect(data[2]).toBe(0x81); // high byte of $8100
     });
 
     it('should handle circular imports between modules', async function() {
@@ -276,8 +332,8 @@ FuncB:
 `
       };
 
-      const result = await compile([moduleA, moduleB], { lineContinuations: true }, {}, 'binary');
-      expect(result.data).toBeTruthy();
+      const result = await compile([moduleA, moduleB], { lineContinuations: true });
+      expect(result.outputs[0].data).toBeTruthy();
     });
   });
 
@@ -289,20 +345,20 @@ FuncB:
   lda #$42
 `;
       const input: AssemblyInput = { type: 'source', code: source, name: 'test.s' };
-      const result = await compile([input], { lineContinuations: true }, {}, 'ips');
+      const result = await compile([input], { lineContinuations: true, outputFormat: 'ips' });
+      const data = result.outputs[0].data;
 
       // IPS header is "PATCH"
-      expect(result.data[0]).toBe(0x50); // 'P'
-      expect(result.data[1]).toBe(0x41); // 'A'
-      expect(result.data[2]).toBe(0x54); // 'T'
-      expect(result.data[3]).toBe(0x43); // 'C'
-      expect(result.data[4]).toBe(0x48); // 'H'
+      expect(data[0]).toBe(0x50); // 'P'
+      expect(data[1]).toBe(0x41); // 'A'
+      expect(data[2]).toBe(0x54); // 'T'
+      expect(data[3]).toBe(0x43); // 'C'
+      expect(data[4]).toBe(0x48); // 'H'
     });
   });
 
   describe('Debug info generation', function() {
     it('should generate debug info when requested', async function() {
-      const sourceContents = new SourceContents();
       const source = `
 .segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000
 .org $8000
@@ -314,15 +370,14 @@ TestLabel:
       const input: AssemblyInput = { type: 'source', code: source, name: 'test.s' };
       const result = await compile(
         [input],
-        { lineContinuations: true, generateDebugInfo: true },
-        { debugLevel: 0 },
-        'binary',
-        undefined,
-        sourceContents
+        { lineContinuations: true, generateDebugInfo: true, debugLevel: 0 }
       );
 
-      expect(result.debugInfo).toBeTruthy();
-      expect(result.debugInfo).toContain('TestLabel');
+      const debug = result.outputs.find(o => o.type === 'debug');
+      expect(debug).toBeTruthy();
+      const debugText = new TextDecoder().decode(debug!.data);
+      expect(debugText).toBeTruthy();
+      expect(debugText).toContain('TestLabel');
     });
   });
 
@@ -336,7 +391,7 @@ TestLabel:
   jsr UndefinedSymbol3
 `;
       const input: AssemblyInput = { type: 'source', code: source, name: 'test.s' };
-      const result = await compile([input], { lineContinuations: true }, {}, 'binary');
+      const result = await compile([input], { lineContinuations: true });
 
       expect(result.success).toBe(false);
       const errors = result.messages.filter(m => m.level === 'error');
@@ -360,7 +415,7 @@ AnotherLabel:
   rts
 `;
       const input: AssemblyInput = { type: 'source', code: source, name: 'test.s' };
-      const result = await compile([input], { lineContinuations: true }, {}, 'binary');
+      const result = await compile([input], { lineContinuations: true });
 
       expect(result.success).toBe(false);
       const errors = result.messages.filter(m => m.level === 'error');
@@ -390,7 +445,7 @@ AnotherLabel:
 `
       };
 
-      const result = await compile([file1, file2], { lineContinuations: true }, {}, 'binary');
+      const result = await compile([file1, file2], { lineContinuations: true });
 
       expect(result.success).toBe(false);
       const errors = result.messages.filter(m => m.level === 'error');
@@ -415,7 +470,7 @@ AnotherLabel:
 `
       };
 
-      const result = await compile([module1], { lineContinuations: true }, {}, 'binary');
+      const result = await compile([module1], { lineContinuations: true });
 
       expect(result.success).toBe(false);
       const errors = result.messages.filter(m => m.level === 'error');
@@ -435,9 +490,7 @@ AnotherLabel:
       const input: AssemblyInput = { type: 'source', code: source, name: 'location_test.s' };
       const result = await compile(
         [input],
-        { lineContinuations: true, generateDebugInfo: true },
-        {},
-        'binary'
+        { lineContinuations: true, generateDebugInfo: true }
       );
 
       expect(result.success).toBe(false);
@@ -464,9 +517,7 @@ AnotherLabel:
       const input: AssemblyInput = { type: 'source', code: source, name: 'test.s' };
       const result = await compile(
         [input],
-        { lineContinuations: true, generateDebugInfo: true },
-        {},
-        'binary'
+        { lineContinuations: true, generateDebugInfo: true }
       );
 
       expect(result.success).toBe(false);
@@ -487,7 +538,7 @@ ValidLabel:
   lda #$43
 `;
       const input: AssemblyInput = { type: 'source', code: source, name: 'test.s' };
-      const result = await compile([input], { lineContinuations: true }, {}, 'binary');
+      const result = await compile([input], { lineContinuations: true });
 
       expect(result.success).toBe(false);
       const errors = result.messages.filter(m => m.level === 'error');
@@ -504,7 +555,7 @@ ValidLabel:
   nop
 `;
       const input: AssemblyInput = { type: 'source', code: source, name: 'test.s' };
-      const result = await compile([input], { lineContinuations: true }, {}, 'binary');
+      const result = await compile([input], { lineContinuations: true });
 
       expect(result.success).toBe(false);
       const errors = result.messages.filter(m => m.level === 'error');

--- a/test/mlb_test.ts
+++ b/test/mlb_test.ts
@@ -8,13 +8,12 @@
 import {describe, it, expect} from 'bun:test';
 import {MesenLabelFormat} from '../src/linker.ts';
 import {compile} from '../src/libassembler.ts';
-import {SourceContents} from '../src/tokenstream.ts';
 
 async function assembleAndGetDebugInfo(source: string, filename: string = 'test.s', debugLevel: number = 0): Promise<MesenLabelFormat[]> {
-  const sourceContents = new SourceContents();
   const opts = {
     lineContinuations: true,
-    generateDebugInfo: true
+    generateDebugInfo: true,
+    debugLevel
   };
 
   const initsrc = { type: 'source' as const, name: 'init.s', code: `
@@ -29,13 +28,11 @@ FREE "FIXED" [$c000, $10000)
 
   const modulesrc = { type: 'source' as const, name: filename, code: source };
 
-  const linkerOpts = {
-    debugLevel: debugLevel
-  };
-  const res = await compile([initsrc, modulesrc], opts, linkerOpts, 'binary', undefined, sourceContents);
-  // console.log("debinfo\n", res.debugInfo);
+  const res = await compile([initsrc, modulesrc], opts);
+  const debug = res.outputs.find(o => o.type === 'debug');
+  const debugInfo = debug ? new TextDecoder().decode(debug.data) : '';
 
-  const mlb = parseMlb(res.debugInfo);
+  const mlb = parseMlb(debugInfo);
   // console.log("mlb ", mlb);
   return mlb;
 }


### PR DESCRIPTION
Lots of changes make to the libassembler make more sense. There used to be a lot of overlapping work across the frontends, and this patch consolidates much of that into less entrypoints.

Also reworks hermes to run as both an exe and dll so it can properly handle callbacks from the C# integration

---

This is the follow up change to the new static hermes based frontend. This change makes it so that it builds as a shared library so that we can properly support integration callbacks (which weren't all that feasible with the CLI. I mean we could've done some sharedpipe stuff, but thats just getting hacky imo)

I got really lazy and didn't bother splitting this up into smaller commits, kinda just kept hacking at it until it all worked (and ended up doing several refactors in the meantime).