### PR TITLE
CA65 compatibility fixes (part 1 of ... ???)

### DIFF
--- a/integrations/bun.ts
+++ b/integrations/bun.ts
@@ -44,6 +44,13 @@ export async function main(args: string[]) {
   await cli.run(args);
 }
 
-(async () => {
-  await main(Bun.argv.slice(2));
-})();
+// Jank workaround for a bun problem. With the original async await, bun will terminate
+// when a missing include happened because that promise failed, and it would exit 0
+// So instead of that, we try to gracefully exit as best we can. But to do that we need
+// to keep it alive by setting some timer so there's "something" running
+const keepAlive = setInterval(() => {}, 1 << 30);
+main(Bun.argv.slice(2))
+  .then(() => process.exit(process.exitCode ?? 0),
+        // run() already printed the diagnostic before rethrowing.
+        () => process.exit(1))
+  .finally(() => clearInterval(keepAlive));

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -218,6 +218,14 @@ export class Assembler {
   // NOTE: we could add 'force-import', 'detect', or others...
   private globals = new Map<string, 'export'|'import'>();
 
+  /** Current state for tracking .struct and .enum members */
+  private structContext: Array<{kind: 'struct'|'enum', offset: number, name?: string}> = [];
+
+  /** Mapping for any string to byte array  */
+  private charMapping = new Map<string, number[]>();
+  /** Saved charmaps for `.pushcharmap`/`.popcharmap`. */
+  private charmapStack: Array<Map<string, number[]>> = [];
+
   /** The current scope. */
   private currentScope = new Scope();
 
@@ -256,6 +264,11 @@ export class Assembler {
 
   /** Origin of the currnet chunk, if fixed. */
   private _org: number|undefined = undefined;
+
+  /** Alignment constraint to stamp on the next chunk, from a pending `.align`. */
+  private _pendingAlign: number|undefined = undefined;
+  /** TODO: use this to actually fill the alignment later. */
+  private _pendingFill: number|undefined = undefined;
 
   /** Prefix to prepend to all segment names. */
   private _segmentPrefix = '';
@@ -311,6 +324,11 @@ export class Assembler {
       this._chunk = {segments: this.segments, data: []};
       if (this._org != null) this._chunk.org = this._org;
       if (this._name) this._chunk.name = this._name;
+      if (this._pendingAlign != null) {
+        this._chunk.align = this._pendingAlign;
+        this._pendingAlign = undefined;
+        this._pendingFill = undefined;
+      }
       this.chunks.push(this._chunk);
       this._chunk.overwrite = this.overwriteMode;
 
@@ -634,7 +652,11 @@ export class Assembler {
     this._source = tokens[0].source;
 
     try {
-      if (tokens.length < 3 && Tokens.eq(tokens[tokens.length - 1], Tokens.COLON)) {
+      // Inside a .struct/.enum, a leading identifier is a member declaration and not
+      // an instruction. We still need to watch for `.endstruct` and similar instructions though.
+      if (this.structContext.length && tokens[0].token === 'ident') {
+        this.structMember(tokens);
+      } else if (tokens.length < 3 && Tokens.eq(tokens[tokens.length - 1], Tokens.COLON)) {
         this.label(tokens[0]);
       } else if (tokens[0].token === 'cs') {
         this.directive(tokens);
@@ -688,6 +710,20 @@ export class Assembler {
         case '.segmentprefix': return this.segmentPrefix(this.parseStr(tokens, 1));
         case '.import': return this.import(...this.parseIdentifierList(tokens));
         case '.export': return this.export(...this.parseIdentifierList(tokens));
+        case '.charmap': return this.charmap(tokens);
+        case '.strmap': return this.strmap(tokens);
+        case '.pushcharmap': return this.parseNoArgs(tokens, 1),
+          void this.charmapStack.push(new Map(this.charMapping));
+        case '.popcharmap': return this.parseNoArgs(tokens, 1),
+          void (this.charMapping = this.charmapStack.pop() ?? this.charMapping);
+        case '.asciiz': return this.asciiz(...this.parseDataList(tokens, true));
+        case '.align': return this.alignDir(tokens);
+        case '.struct': return this.beginStruct(tokens, 'struct');
+        case '.union': return this.beginStruct(tokens, 'struct'); // union sized like struct here
+        case '.enum': return this.beginStruct(tokens, 'enum');
+        case '.endstruct': return this.parseNoArgs(tokens, 1), this.endStruct('struct');
+        case '.endunion': return this.parseNoArgs(tokens, 1), this.endStruct('struct');
+        case '.endenum': return this.parseNoArgs(tokens, 1), this.endStruct('enum');
         case '.scope': return this.scope(this.parseOptionalIdentifier(tokens));
         case '.endscope': return this.parseNoArgs(tokens, 1), this.endScope();
         case '.proc': return this.proc(this.parseRequiredIdentifier(tokens));
@@ -1110,6 +1146,140 @@ export class Assembler {
   byte(...args: Array<Expr|string|number>) {
     this.byteInternal(args);
   }
+
+  // `.asciiz` emits the bytes then a terminating NUL
+  // .charmap/.strmap applies to the string bytes but not the terminator character.
+  asciiz(...args: Array<Expr|string|number>) {
+    this.byteInternal([...args, 0]);
+  }
+
+  beginStruct(tokens: Token[], kind: 'struct'|'enum') {
+    const name = this.parseOptionalIdentifier(tokens);
+    if (name != null) this.enterScope(name, 'scope');
+    this.structContext.push({kind, offset: 0, name: name ?? undefined});
+  }
+
+  endStruct(kind: 'struct'|'enum') {
+    const ctx = this.structContext.pop();
+    if (!ctx || ctx.kind !== kind) this.fail(`.end${kind} without a matching .${kind}`);
+    if (ctx!.name != null) {
+      this.exitScope('scope');
+      // Assign a symbol to hold the size of the struct so `.sizeof(StructName)` works
+      this.assign(ctx!.name, ctx!.offset);
+    }
+  }
+
+  structMember(tokens: Token[]) {
+    const ctx = this.structContext[this.structContext.length - 1];
+    const name = Tokens.str(tokens[0]);
+    this.assign(name, ctx.offset);
+    if (ctx.kind === 'enum') {
+      ctx.offset += 1;
+    } else {
+      ctx.offset += this.structMemberSize(tokens);
+    }
+  }
+
+  // Parses out the rest of a struct member to figure out the size of it
+  private structMemberSize(tokens: Token[]): number {
+    const typeTok = tokens[1];
+    if (!typeTok || typeTok.token !== 'cs') {
+      this.fail(`struct member '${Tokens.str(tokens[0])}' needs a storage type`, tokens[0]);
+    }
+    const t = Tokens.str(typeTok);
+    if (t === '.tag') {
+      const structName = Tokens.expectIdentifier(tokens[2]);
+      const sz = this.evaluate(this.symbol(structName));
+      if (sz == null) this.fail(`.tag references unknown struct: ${structName}`, tokens[2]);
+      return sz;
+    }
+    let unit: number;
+    switch (t) {
+      // NOTE: .addr is tokenized as .word, so it lands in the 2-byte case.
+      case '.byte': case '.res': unit = 1; break;
+      case '.word': case '.dbyt': unit = 2; break;
+      case '.faraddr': unit = 3; break;
+      case '.dword': unit = 4; break;
+      default: this.fail(`Unsupported struct member type: ${t}`, typeTok);
+    }
+    // Optional element count (`field .byte 16`); required for .res.
+    if (tokens.length > 2) return unit * this.parseConst(tokens, 2);
+    if (t === '.res') this.fail(`.res in a struct needs a count`, typeTok);
+    return unit;
+  }
+
+  alignDir(tokens: Token[]) {
+    const args = Tokens.parseArgList(tokens, 1);
+    if (args.length < 1 || args.length > 2) this.fail(`.align expects a boundary and optional fill`, tokens[0]);
+    const boundary = this.parseConst(args[0], 0);
+    const fill = args.length > 1 ? this.parseConst(args[1], 0) : undefined;
+    this.align(boundary, fill);
+  }
+
+  align(boundary: number, fill?: number) {
+    if (boundary < 1) this.fail(`.align boundary must be positive: ${boundary}`);
+    // ca65 requires a power-of-two boundary unless the force option is supplied.
+    // ... which we don't have yet. TODO
+    if ((boundary & (boundary - 1)) !== 0) this.fail(`.align boundary must be a power of two: ${boundary}`);
+    if (boundary === 1) return; // no-op
+    if (this._org != null) {
+      // We have an org address, so we are in absolute mode meaning we can
+      // do the padding now too.
+      const pc = (this._chunk?.org ?? this._org) + (this._chunk?.data.length ?? 0);
+      const pad = (boundary - (pc % boundary)) % boundary;
+      if (pad) this.res(pad, fill);
+      return;
+    }
+    // Relocatable mode means we just delay this until link time instead
+    this._chunk = undefined;
+    this._pendingAlign = boundary;
+    this._pendingFill = fill;
+  }
+
+  // CA65 compatible 1:1 character mapping. Given a single char byte or a byte literal,
+  // converts it to the output value. This applies to any characters in any strings
+  charmap(tokens: Token[]) {
+    const args = Tokens.parseArgList(tokens, 1);
+    if (args.length !== 2) this.fail(`.charmap expects an index and a value`, tokens[0]);
+    const code = this.parseConst(args[0], 0);
+    const target = this.parseConst(args[1], 0);
+    if (code < 0 || code > 255) this.fail(`.charmap index out of range: ${code}`, tokens[0]);
+    this.charMapping.set(String.fromCodePoint(code), [target & 0xff]);
+  }
+
+  // Our own custom string based mapping, which allows any N input bytes to M output bytes
+  // This works by greedily consuming bytes and choosing the largest match first as our output.
+  strmap(tokens: Token[]) {
+    const keyTok = tokens[1];
+    if (!keyTok || keyTok.token !== 'str') this.fail(`.strmap expects a string key`, tokens[0]);
+    const key = keyTok.str;
+    if (!key) this.fail(`.strmap key must not be empty`, keyTok);
+    const commaIdx = Tokens.find(tokens, Tokens.COMMA, 2);
+    if (commaIdx < 0) this.fail(`.strmap expects a value after the key`, tokens[0]);
+    const valueToks = tokens.slice(commaIdx + 1);
+    if (!valueToks.length) this.fail(`.strmap expects a value after the key`, tokens[tokens.length - 1]);
+    let bytes: number[];
+    // The syntax for a multi byte output with hardcoded numbers is `[ $00, $01, ... $mm ]`
+    // so check for the bracket opening.
+    if (Tokens.eq(valueToks[0], Tokens.LB)) {
+      if (!Tokens.eq(valueToks[valueToks.length - 1], Tokens.RB)) {
+        this.fail(`.strmap value list must end with ]`, valueToks[valueToks.length - 1]);
+      }
+      const inner = valueToks.slice(1, -1);
+      bytes = inner.length ? Tokens.parseArgList(inner, 0).map(ts => this.parseConst(ts, 0)) : [];
+      if (!bytes.length) this.fail(`.strmap value list must not be empty`, valueToks[0]);
+    } else if (valueToks.length === 1 && valueToks[0].token === 'str' && !valueToks[0].char) {
+      // If its a string, parse it using the current charmapping values (to match ca65 behavior)
+      bytes = [];
+      writeString(bytes, valueToks[0].str, this.charMapping);
+      if (!bytes.length) this.fail(`.strmap value must not be empty`, valueToks[0]);
+    } else {
+      // Otherwise, its probaly some constant value or something.
+      bytes = [this.parseConst(valueToks, 0)];
+    }
+    this.charMapping.set(key, bytes.map(b => b & 0xff));
+  }
+
   byteInternal(args: Array<Expr|string|number>) {
     const {chunk} = this;
     this.markWritten(args.length);
@@ -1132,7 +1302,7 @@ export class Assembler {
             this._chunk.sourceMap.set(chunk.data.length + i, this._source);
           }
         }
-        writeString(chunk.data, arg);
+        writeString(chunk.data, arg, this.charMapping);
       } else {
         // Record source info before append (which writes 1 byte)
         if (this.opts.generateDebugInfo && this._chunk?.sourceMap && this._source) {
@@ -1294,8 +1464,22 @@ export class Assembler {
     Tokens.expectEol(tokens[1]);
   }
   parseExpr(tokens: Token[], start: number): Expr {
-    return Exprs.parseOnly(tokens, start, this.currentScope.symbols);
+    return Exprs.parseOnly(tokens, start, this.currentScope.symbols, this.encodeChar);
   }
+
+  /**
+   * Converts the character to the numerical value for the output.
+   * This assumes that it is not multimapped to multiple output bytes to keep
+   * ca65 compatibility.
+   */
+  readonly encodeChar = (char: string): number|undefined => {
+    const bytes = this.charMapping.get(char);
+    if (!bytes) return undefined;
+    if (bytes.length !== 1) {
+      this.fail(`Character literal '${char}' maps to ${bytes.length} bytes`);
+    }
+    return bytes[0];
+  };
   // parseStringList(tokens: Token[], start = 1): string[] {
   //   return Tokens.parseArgList(tokens, 1).map(ts => {
   //     const str = Tokens.expectString(ts[0]);
@@ -1521,10 +1705,29 @@ export class Assembler {
   }
 }
 
-function writeString(data: number[], str: string) {
-  // TODO - support character maps (pass as third arg?)
-  for (let i = 0; i < str.length; i++) {
-    data.push(str.charCodeAt(i));
+function writeString(data: number[], str: string, charmap: Map<string, number[]>) {
+  // Split into Unicode code points (not js string UTF-16 code units) so a multi-byte
+  // character is one unit for both matching and the unmapped fallback.
+  const chars = Array.from(str);
+  const maxKeyLen = charmap.size ?
+      Math.max(...[...charmap.keys()].map(k => Array.from(k).length)) : 0;
+  for (let i = 0; i < chars.length; ) {
+    // Greedy longest-match, so a `.strmap` key beats the single-character
+    // `.charmap` entries it overlaps.
+    let bytes: number[]|undefined;
+    let len = Math.min(maxKeyLen, chars.length - i);
+    for (; len >= 1; len--) {
+      bytes = charmap.get(chars.slice(i, i + len).join(''));
+      if (bytes) break;
+    }
+    if (bytes) {
+      data.push(...bytes);
+      i += len;
+    } else {
+      // Unmapped: emit the code point/character itself
+      data.push(chars[i].codePointAt(0)! & 0xff);
+      i++;
+    }
   }
 }
 

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -159,9 +159,9 @@ export interface RefExtractor {
   assign?(name: string, value: number): void;
 }
 
-export class RecoverableError extends Error {
-  constructor(message: string) {
-    super(message);
+export class RecoverableError extends Tokens.SourceError {
+  constructor(message: string, source?: Tokens.SourceInfo) {
+    super(message, source);
     this.name = 'RecoverableError';
   }
 }
@@ -182,7 +182,7 @@ export class ErrorCollector {
     this.messages.push({
       level,
       message: err.message,
-      source,
+      source: (err instanceof Tokens.SourceError ? err.source : undefined) ?? source,
       stack: err.stack,
     });
   }
@@ -646,8 +646,9 @@ export class Assembler {
         // Error already recorded, continue to next line
         return;
       }
-      // Re-throw unrecoverable errors
-      throw err;
+      // Re-throw unrecoverable errors, and use this line for the source if
+      // it didn't have a source attached in the err.
+      throw Tokens.SourceError.locate(err, this._source);
     }
   }
 
@@ -704,7 +705,7 @@ export class Assembler {
           // NOTE: Will need to be actually implemented if 16-bit CPU support is added.
           return;
       }
-      this.fail(`Unknown directive: ${Tokens.nameAt(tokens[0])}`);
+      this.fail(`Unknown directive: ${Tokens.nameOf(tokens[0])}`, tokens[0]);
     } finally {
       this.errorToken = undefined;
     }
@@ -1480,15 +1481,12 @@ export class Assembler {
     // Record the error
     this.errorCollector.add('error', msg, source);
 
-    // Build the full error message for the exception
-    let fullMsg = msg;
-    if (source) {
-      fullMsg += Tokens.at({source});
-    } else if (!this._source && this._chunk?.name) {
-      fullMsg += `\n  in ${this._chunk.name}`;
-    }
+    // If we don't have any source info, then attach the chunk name to the
+    // message to try and provide some context.
+    const fullMsg = !source && !this._source && this._chunk?.name ?
+        `${msg}\n  in ${this._chunk.name}` : msg;
 
-    throw new RecoverableError(fullMsg);
+    throw new RecoverableError(fullMsg, source);
   }
 
   writeNumber(data: number[], size: number, val?: number) {

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -214,9 +214,15 @@ export class Assembler {
   /** All symbols in this object. */
   private symbols: Symbol[] = [];
 
-  /** Global symbols. */
+  /** Global symbols. `.global` resolves to import or export at close time
+   *  depending on whether the symbol ends up defined in this module. */
   // NOTE: we could add 'force-import', 'detect', or others...
-  private globals = new Map<string, 'export'|'import'>();
+  private globals = new Map<string, 'export'|'import'|'global'>();
+  /** Scope each `.export`/`.import`/`.global` was declared in, so the symbol is
+   *  resolved there. */
+  private globalScopes = new Map<string, Scope>();
+  /** Symbols declared zeropage (.importzp/.exportzp/.globalzp) */
+  private zeropageGlobals = new Set<string>();
 
   /** Current state for tracking .struct and .enum members */
   private structContext: Array<{kind: 'struct'|'enum', offset: number, name?: string}> = [];
@@ -526,8 +532,13 @@ export class Assembler {
     close(this.currentScope);
 
     for (const [name, global] of this.globals) {
-      const sym = this.currentScope.symbols.get(name);
-      if (global === 'export') {
+      // Resolve the symbol in the scope the declaration appeared in and
+      // fall back to the global scope if not found.
+      const scope = this.globalScopes.get(name) ?? this.currentScope;
+      const sym = scope.symbols.get(name);
+      // `.global` is import-or-export depending on whether it got defined here.
+      const kind = global === 'global' ? (sym?.expr ? 'export' : 'import') : global;
+      if (kind === 'export') {
         if (!sym?.expr) {
           collector.add('error', `Exported symbol '${name}' undefined`, sym?.ref?.source);
           continue;
@@ -537,16 +548,19 @@ export class Assembler {
           this.symbols.push(sym);
         }
         sym.export = name;
-      } else if (global === 'import') {
+      } else if (kind === 'import') {
         if (!sym) continue; // okay to import but not use.
         // TODO - record both positions?
         if (sym.expr) {
           collector.add('error', `Symbol '${name}' already defined`, sym.ref?.source);
           continue;
         }
-        sym.expr = {op: 'im', sym: name};
+        // Zeropage imports carry a one-byte size so references pick zp modes.
+        const expr: Expr = {op: 'im', sym: name};
+        if (this.zeropageGlobals.has(name)) expr.meta = {size: 1};
+        sym.expr = expr;
       } else {
-        assertNever(global);
+        assertNever(kind);
       }
     }
 
@@ -710,6 +724,10 @@ export class Assembler {
         case '.segmentprefix': return this.segmentPrefix(this.parseStr(tokens, 1));
         case '.import': return this.import(...this.parseIdentifierList(tokens));
         case '.export': return this.export(...this.parseIdentifierList(tokens));
+        case '.importzp': return this.importzp(...this.parseIdentifierList(tokens));
+        case '.exportzp': return this.exportzp(...this.parseIdentifierList(tokens));
+        case '.global': return this.global(...this.parseIdentifierList(tokens));
+        case '.globalzp': return this.globalzp(...this.parseIdentifierList(tokens));
         case '.charmap': return this.charmap(tokens);
         case '.strmap': return this.strmap(tokens);
         case '.pushcharmap': return this.parseNoArgs(tokens, 1),
@@ -735,10 +753,34 @@ export class Assembler {
         case '.warning': return this.log('warn', tokens);
         case '.error': return this.log('error', tokens);
 
-        case '.a8': 
+        case '.a8':
         case '.i8':
         case '.p02':
           // NOTE: Will need to be actually implemented if 16-bit CPU support is added.
+          return;
+
+        // Segment shorthands: ca65 predeclares these named segments.
+        case '.zeropage': return this.parseNoArgs(tokens, 1), this.segment('ZEROPAGE');
+        case '.code': return this.parseNoArgs(tokens, 1), this.segment('CODE');
+        case '.data': return this.parseNoArgs(tokens, 1), this.segment('DATA');
+        case '.rodata': return this.parseNoArgs(tokens, 1), this.segment('RODATA');
+        case '.bss': return this.parseNoArgs(tokens, 1), this.segment('BSS');
+
+        // Unused directives we can figure out what to do with later.
+        case '.setcpu':
+        case '.feature':
+        case '.autoimport':
+        case '.case':
+        case '.listbytes':
+        case '.pagelength':
+        case '.fileopt':
+        case '.localchar':
+        case '.linecont':
+        case '.debuginfo':
+        case '.condes':
+        case '.constructor':
+        case '.destructor':
+        case '.interruptor':
           return;
       }
       this.fail(`Unknown directive: ${Tokens.nameOf(tokens[0])}`, tokens[0]);
@@ -925,7 +967,9 @@ export class Assembler {
       // console.log(`before resolving: ${JSON.stringify(expr)}`);
       // expr = this.resolve(expr);
       
-      const s = expr.meta?.size || 2;
+      // If the size is unknown, but it was declared zp through
+      // importzp/globalzp then we force it to 1 byte.
+      const s = expr.meta?.size ?? (this.isZeropageRef(expr) ? 1 : 2);
       // console.log(`sizing up 'add' expr: ${JSON.stringify(expr)}`);
       if (m === 'add' && s === 1 && 'zpg' in ops) {
         return this.opcode(ops.zpg!, 1, expr);
@@ -1371,15 +1415,48 @@ export class Assembler {
     this._segmentPrefix = prefix;
   }
 
+  /** Whether an operand is a bare reference to a symbol declared zeropage. */
+  private isZeropageRef(expr: Expr): boolean {
+    return expr.op === 'sym' && expr.sym != null && this.zeropageGlobals.has(expr.sym);
+  }
+
+  private declareGlobal(ident: string, kind: 'export'|'import'|'global', weak = false) {
+    if (weak && this.globals.has(ident)) return;
+    this.globals.set(ident, kind);
+    this.globalScopes.set(ident, this.currentScope);
+  }
+
   import(...idents: string[]) {
-    for (const ident of idents) {
-      this.globals.set(ident, 'import');
-    }
+    for (const ident of idents) this.declareGlobal(ident, 'import');
   }
 
   export(...idents: string[]) {
+    for (const ident of idents) this.declareGlobal(ident, 'export');
+  }
+
+  importzp(...idents: string[]) {
     for (const ident of idents) {
-      this.globals.set(ident, 'export');
+      this.declareGlobal(ident, 'import');
+      this.zeropageGlobals.add(ident);
+    }
+  }
+
+  exportzp(...idents: string[]) {
+    for (const ident of idents) {
+      this.declareGlobal(ident, 'export');
+      this.zeropageGlobals.add(ident);
+    }
+  }
+
+  global(...idents: string[]) {
+    // Don't clobber an explicit import/export declaration.
+    for (const ident of idents) this.declareGlobal(ident, 'global', true);
+  }
+
+  globalzp(...idents: string[]) {
+    for (const ident of idents) {
+      this.declareGlobal(ident, 'global', true);
+      this.zeropageGlobals.add(ident);
     }
   }
 
@@ -1527,7 +1604,7 @@ export class Assembler {
           case 'overlay': seg.overlay = this.parseStr(val, 0); break;
           // TODO allow setting free space
           // case 'free': seg.free = this.parseConst(val, 0); break;
-          case 'zp': seg.addressing = 1; break;
+          case 'zp': case 'zeropage': seg.addressing = 1; break;
           default: this.fail(`Unknown segment attr: ${key}`);
         }
       }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,6 +41,7 @@ class Arguments {
   patch : "ips" | "" = "";
   options: Js65Options = {
     includePaths: [],
+    binIncludePaths: [],
     lineContinuations: true,
     debugLevel: 0, // -1 = disabled, 0 = comments/labels only, 1 = full source
     generateDebugInfo: true,
@@ -113,6 +114,10 @@ export class Cli {
         out.rom = args[++i];
       } else if (arg.startsWith('--rom=')) {
         out.rom = arg.substring('--rom='.length);
+      } else if (arg === '--bin-include-dir') {
+        out.options.binIncludePaths!.push(args[++i]);
+      } else if (arg.startsWith('--bin-include-dir=')) {
+        out.options.binIncludePaths!.push(arg.substring('--bin-include-dir='.length));
       } else if (arg === '-I' || arg === '--include-dir') {
         out.options.includePaths!.push(args[++i]);
       } else if (arg === '--ips') {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -59,8 +59,21 @@ export class Cli {
   public static readonly STDIN : string = "//stdin";
   public static readonly STDOUT : string = "//stdout";
 
+  // Keep a local cache of sources opened and compiled for diagnostic printing
+  // later so we don't need to reload the files
+  private readonly sources = new Map<string, string>();
+  private readonly sourceLines = new Map<string, string[]>();
+
   constructor(readonly callbacks: Callbacks) {
     this.callbacks = callbacks;
+  }
+
+  // Load the file and keep the source code in our local cache for later.
+  private async readSource(path: string, filename: string): Promise<string> {
+    const code = await this.callbacks.fsReadString(path, filename);
+    this.sources.set(filename, code);
+    this.sourceLines.delete(filename);
+    return code;
   }
 
   parseArgs(args : string[]) : Arguments {
@@ -158,7 +171,7 @@ export class Cli {
       // Convert CLI arguments to libassembler inputs
       const inputs: AssemblyInput[] = [];
       for (const file of args.files) {
-        const code = await this.callbacks.fsReadString("", file);
+        const code = await this.readSource("", file);
         inputs.push({ type: 'source', code, name: file });
       }
 
@@ -177,7 +190,7 @@ export class Cli {
       }
 
       const callbacks: FileCallbacks = {
-        readText: this.callbacks.fsReadString,
+        readText: (path, filename) => this.readSource(path, filename),
         readBinary: this.callbacks.fsReadBytes
       };
 
@@ -246,29 +259,75 @@ export class Cli {
     // if (err) this.printerrors(err);
   }
 
+  // Builds the `file:line:col: ` when we know where we are, else the program name
+  private locationPrefix(source?: Tokens.SourceInfo): string {
+    if (!source || !source.file || source.line <= 0) return 'js65: ';
+    return `${source.file}:${source.line}:${source.column + 1}: `;
+  }
+
+  // Load the code around the location for creating the inline snippet in the error message
+  private snippet(source?: Tokens.SourceInfo): string[] {
+    if (!source || source.line <= 0) return [];
+    let lines = this.sourceLines.get(source.file);
+    if (!lines) {
+      const text = this.sources.get(source.file);
+      if (text === undefined) return [];
+      lines = text.split(/\r\n|\n|\r/);
+      this.sourceLines.set(source.file, lines);
+    }
+    const line = lines[source.line - 1];
+    if (line === undefined) return [];
+    // We have the target source line that threw the error, so build the
+    // ^ caret pointing at the right location in the source line.
+    const gutter = String(source.line);
+    // Copy tabs into the caret row so the marker lines up under any indentation.
+    const indent = line.substring(0, Math.min(source.column, line.length)).replace(/[^\t]/g, ' ');
+    return [
+      ` ${gutter} | ${line}`,
+      ` ${' '.repeat(gutter.length)} | ${indent}^`,
+    ];
+  }
+
+  /**
+   * Prints one diagnostic in the following format:
+   *
+   *     file.s:12:8: error: Expected identifier
+   *      12 |   lda #$ff,
+   *         |            ^
+   *     file.s:3:1: note: expanded from here
+   */
+  private printDiagnostic(level: Tokens.ErrorLevel, message: string, source?: Tokens.SourceInfo) {
+    const label = level === 'info' ? 'note' : level;
+    console.log(`${this.locationPrefix(source)}${label}: ${message}`);
+    for (const line of this.snippet(source)) console.log(line);
+    // Walk the include / macro-expansion stack outwards.
+    for (let p = source?.parent; p; p = p.parent) {
+      console.log(`${this.locationPrefix(p)}note: expanded from here`);
+      for (const line of this.snippet(p)) console.log(line);
+    }
+  }
+
   printerrors(...err: Error[]) {
-    for (let i = 0; i < err.length; i++) {
-      console.log(`js65 Error: ${err[i].message}`);
+    for (const e of err) {
+      this.printDiagnostic('error', e.message,
+                           e instanceof Tokens.SourceError ? e.source : undefined);
     }
-    if (err.length > 1) {
-      console.log(`js65: Multiple errors`);
-    }
+    this.printSummary(err.length, 0);
   }
 
   printMessages(messages: Tokens.AssemblerMessage[]) {
     for (const msg of messages) {
-      const levelPrefix = msg.level === 'error' ? 'Error' : msg.level === 'warning' ? 'Warning' : 'Info';
-      const location = msg.source ? Tokens.at({ source: msg.source }) : '';
-      console.log(`js65 ${levelPrefix}: ${msg.message}${location}`);
+      this.printDiagnostic(msg.level, msg.message, msg.source);
     }
-    const errorCount = messages.filter(m => m.level === 'error').length;
-    const warningCount = messages.filter(m => m.level === 'warning').length;
-    if (errorCount > 0 || warningCount > 0) {
-      const parts = [];
-      if (errorCount > 0) parts.push(`${errorCount} error${errorCount !== 1 ? 's' : ''}`);
-      if (warningCount > 0) parts.push(`${warningCount} warning${warningCount !== 1 ? 's' : ''}`);
-      console.log(`js65: ${parts.join(', ')}`);
-    }
+    this.printSummary(messages.filter(m => m.level === 'error').length,
+                      messages.filter(m => m.level === 'warning').length);
+  }
+
+  private printSummary(errorCount: number, warningCount: number) {
+    const parts = [];
+    if (errorCount > 0) parts.push(`${errorCount} error${errorCount !== 1 ? 's' : ''}`);
+    if (warningCount > 0) parts.push(`${warningCount} warning${warningCount !== 1 ? 's' : ''}`);
+    if (parts.length) console.log(`${parts.join(', ')} generated.`);
   }
 
   public usage(code = 1, err: Error[]|undefined = undefined) {

--- a/src/define.ts
+++ b/src/define.ts
@@ -27,11 +27,10 @@ export class Define {
   append(define: Define) {
     if (!this.canOverload()) {
       const prevDef = this.overloads[this.overloads.length - 1].definition;
-      const at = prevDef ? Tokens.at(prevDef) : '';
-      const prev = at.replace(/at/, 'previously defined at');
+      // The previous definition is a secondary location, so it stays in the message text.
+      const prev = prevDef ? Tokens.at(prevDef).replace('\n  at', '\n  previously defined at') : '';
       const nextDef = define.overloads[0].definition;
-      const next = nextDef ? Tokens.nameAt(nextDef) : '';
-      throw new Error(`Non-overloadable: ${next}${prev}`);
+      Tokens.fail(`Non-overloadable: ${Tokens.nameOf(nextDef)}${prev}`, nextDef);
     }
     this.overloads.push(...define.overloads);
   }
@@ -68,7 +67,7 @@ export class Define {
       // C-style param list
       const paramEnd = Tokens.findBalanced(macro, 2);
       if (paramEnd < 0) {
-        throw new Error(`Expected close paren ${Tokens.nameAt(macro[2])}`);
+        Tokens.fail(`Expected close paren ${Tokens.nameOf(macro[2])}`, macro[2]);
       }
       overload =
           new CStyleDefine(Tokens.identsFromCList(macro.slice(3, paramEnd)),

--- a/src/expr.ts
+++ b/src/expr.ts
@@ -305,7 +305,7 @@ export function parseOnly(tokens: Token[], index = 0, symbols?: Map<string, Symb
   const [expr, i] = parse(tokens, index, symbols);
   if (i < tokens.length) {
     parse(tokens, index, symbols);
-    throw new Error(`Garbage after expression: ${Tokens.nameAt(tokens[i])}`);
+    Tokens.fail(`Garbage after expression: ${Tokens.nameOf(tokens[i])}`, tokens[i]);
   } else if (!expr) {
     throw new Error(`No expression?`);
   }
@@ -325,7 +325,7 @@ export function parse(tokens: Token[], index = 0, symbols?: Map<string, Symbol>)
     const [op, [,, arity]] = ops.pop()!;
 //console.log('pop', op, arity);
     const args = exprs.splice(exprs.length - arity, arity);
-    if (args.length !== arity) throw new Error(`shunting parse failed? ${Tokens.nameAt(tokens[i])}`);
+    if (args.length !== arity) Tokens.fail(`shunting parse failed? ${Tokens.nameOf(tokens[i])}`, tokens[i]);
     exprs.push(fixSize({op, args}));
   }
 
@@ -344,15 +344,15 @@ export function parse(tokens: Token[], index = 0, symbols?: Map<string, Symbol>)
         } else if (front.token === 'cs') {
           const op = front.str;
           if (!FUNCTIONS.has(op)) {
-            throw new Error(`No such function: ${Tokens.nameAt(front)}`);
+            Tokens.fail(`No such function: ${Tokens.nameOf(front)}`, front);
           }
           const next = tokens[i + 1];
           if (next?.token !== 'lp') {
-            throw new Error(`Bad funcall: ${Tokens.nameAt(next ?? front)}`);
+            Tokens.fail(`Bad funcall: ${Tokens.nameOf(next ?? front)}`, next ?? front);
           }
           const close = Tokens.findBalanced(tokens, i + 1);
           if (close < 0) {
-            throw new Error(`Never closed: ${Tokens.nameAt(next)}`);
+            Tokens.fail(`Never closed: ${Tokens.nameOf(next)}`, next);
           }
           const args: Expr[] = [];
           for (const arg of Tokens.parseArgList(tokens, i + 2, close)) {
@@ -365,13 +365,13 @@ export function parse(tokens: Token[], index = 0, symbols?: Map<string, Symbol>)
           exprs.push({op: 'sym', sym: '*'});
           val = false;
         } else {
-          throw new Error(`Unknown prefix operator: ${Tokens.nameAt(front)}`);
+          Tokens.fail(`Unknown prefix operator: ${Tokens.nameOf(front)}`, front);
         }
       } else if (front.token === 'lp') {
         // find balanced parens
         const close = Tokens.findBalanced(tokens, i);
         if (close < 0) {
-          throw new Error(`No close paren: ${Tokens.nameAt(front)}`);
+          Tokens.fail(`No close paren: ${Tokens.nameOf(front)}`, front);
         } // return [undefined, -1];
         const e = parseOnly(tokens.slice(i + 1, close), 0, symbols);
         exprs.push(e);
@@ -395,7 +395,7 @@ export function parse(tokens: Token[], index = 0, symbols?: Map<string, Symbol>)
         val = false;
       } else {
         // bad token??
-        throw new Error(`Bad expression token: ${Tokens.nameAt(front)}`);
+        Tokens.fail(`Bad expression token: ${Tokens.nameOf(front)}`, front);
         // return [undefined, -1];
       }
     } else {
@@ -415,9 +415,8 @@ export function parse(tokens: Token[], index = 0, symbols?: Map<string, Symbol>)
           const cmp = compareOp(top[1], op);
           if (cmp < 0) break;
           if (cmp === 0) {
-            throw new Error(
-                `Mixing ${top[0]} and ${front.str} needs explicit parens.${
-                  Tokens.at(front)}`);
+            Tokens.fail(
+                `Mixing ${top[0]} and ${front.str} needs explicit parens.`, front);
           }
           popOp();
         }
@@ -435,7 +434,7 @@ export function parse(tokens: Token[], index = 0, symbols?: Map<string, Symbol>)
   while (ops.length) popOp();
 //console.log('post-pop:', exprs);
   if (!tokens[index]) throw new Error(`No token at ${index}:\n${tokens.map(t => '  ' + Tokens.nameAt(t) + '\n')}`);
-  if (exprs.length !== 1) throw new Error(`expression parse failed: nonunique result ${Tokens.nameAt(tokens[index])}`);
+  if (exprs.length !== 1) Tokens.fail(`expression parse failed: nonunique result ${Tokens.nameOf(tokens[index])}`, tokens[index]);
   if (!exprs[0].source && tokens[index].source)
     exprs[0].source = tokens[index].source;
   return [exprs[0], i];

--- a/src/expr.ts
+++ b/src/expr.ts
@@ -141,6 +141,9 @@ export function evaluate(expr: Expr): Expr {
       case '<': return unary(expr, x => x & 0xff);
       case '>': return unary(expr, x => (x >> 8) & 0xff);
       case '^': return num(expr.args![0].meta?.bank) ?? expr;
+      // `.sizeof(X)` is used for structs, and we assign a variable with the name
+      // of the struct, so we can check that here by name.
+      case '.sizeof': return expr.args![0];
       default: throw new Error(`Unknown unary operator: ${mapped}`);
     }
   }
@@ -300,11 +303,19 @@ export function identifier(expr: Expr): string {
 //   }
 // }
 
+/**
+ * Pull in the charEncoder from the current Env context if the user has created
+ * any charmapped values. This way we can do things like `.if 'a'` where `'a'` was
+ * charmapped to some value like `1` or `0` for instance
+ */
+export type CharEncoder = (char: string) => number|undefined;
+
 /** Parse a single expression, must occupy the rest of the line. */
-export function parseOnly(tokens: Token[], index = 0, symbols?: Map<string, Symbol>): Expr {
-  const [expr, i] = parse(tokens, index, symbols);
+export function parseOnly(tokens: Token[], index = 0, symbols?: Map<string, Symbol>,
+                          charEncoder?: CharEncoder): Expr {
+  const [expr, i] = parse(tokens, index, symbols, charEncoder);
   if (i < tokens.length) {
-    parse(tokens, index, symbols);
+    parse(tokens, index, symbols, charEncoder);
     Tokens.fail(`Garbage after expression: ${Tokens.nameOf(tokens[i])}`, tokens[i]);
   } else if (!expr) {
     throw new Error(`No expression?`);
@@ -315,7 +326,8 @@ export function parseOnly(tokens: Token[], index = 0, symbols?: Map<string, Symb
 // Returns [undefined, -1] if a bad parse.
 // Give up on normal parsing, just use a shunting yard again...
 //  - but handle parens recursively.
-export function parse(tokens: Token[], index = 0, symbols?: Map<string, Symbol>): [Expr|undefined, number] {
+export function parse(tokens: Token[], index = 0, symbols?: Map<string, Symbol>,
+                      charEncoder?: CharEncoder): [Expr|undefined, number] {
 //console.log('PARSE: tokens=', tokens, 'index=', index);
 //try { throw new Error(); } catch (e) { console.log(e.stack); }
   const ops: [string, OperatorMeta][] = [];
@@ -356,7 +368,7 @@ export function parse(tokens: Token[], index = 0, symbols?: Map<string, Symbol>)
           }
           const args: Expr[] = [];
           for (const arg of Tokens.parseArgList(tokens, i + 2, close)) {
-            args.push(parseOnly(arg, 0, symbols));
+            args.push(parseOnly(arg, 0, symbols, charEncoder));
           }
           i = close;
           exprs.push(fixSize({op, args}));
@@ -373,7 +385,7 @@ export function parse(tokens: Token[], index = 0, symbols?: Map<string, Symbol>)
         if (close < 0) {
           Tokens.fail(`No close paren: ${Tokens.nameOf(front)}`, front);
         } // return [undefined, -1];
-        const e = parseOnly(tokens.slice(i + 1, close), 0, symbols);
+        const e = parseOnly(tokens.slice(i + 1, close), 0, symbols, charEncoder);
         exprs.push(e);
         i = close;
         val = false;
@@ -388,10 +400,20 @@ export function parse(tokens: Token[], index = 0, symbols?: Map<string, Symbol>)
         const num = front.num;
         exprs.push({op: 'num', num, meta: size(num, front)});
         val = false;
-      } else if (front.token === 'str') { 
-        // TODO: use the charmap to look up literal value
-        const s = front.str
-        exprs.push({op: 'str', str: s, meta: {size: s.length}});
+      } else if (front.token === 'str') {
+        const s = front.str;
+        // A single-quoted literal is a character literal, which is treated like a
+        // number in ca65.
+        const chars = front.char ? Array.from(s) : undefined;
+        if (chars) {
+          if (chars.length !== 1) {
+            Tokens.fail(`Character literal must be one character: '${s}'`, front);
+          }
+          const num = charEncoder?.(chars[0]) ?? chars[0].codePointAt(0)!;
+          exprs.push({op: 'num', num, meta: size(num, front)});
+        } else {
+          exprs.push({op: 'str', str: s, meta: {size: s.length}});
+        }
         val = false;
       } else {
         // bad token??
@@ -605,6 +627,7 @@ const FUNCTIONS = new Set<string>([
   '.wordat',
   '.match', '.xmatch',
   '.max', '.min',
+  '.sizeof',
 ]);
 
 const NAME_MAP = new Map<string, string>([

--- a/src/libassembler.ts
+++ b/src/libassembler.ts
@@ -69,6 +69,7 @@ function throwIfCancelled(signal?: CancelSignal): void {
  */
 export interface AssemblerOptions {
   includePaths?: string[];
+  binIncludePaths?: string[];
   lineContinuations?: boolean;
   numberSeparators?: boolean;
   generateDebugInfo?: boolean;
@@ -101,6 +102,7 @@ export type OutputFormat = 'binary' | 'ips' | 'object';
  */
 export interface Js65Options {
   includePaths?: string[];
+  binIncludePaths?: string[];
   lineContinuations?: boolean;
   numberSeparators?: boolean;
   generateDebugInfo?: boolean;
@@ -186,6 +188,7 @@ export async function assemble(
 
   const opts = {
     includePaths: options?.includePaths || [],
+    binIncludePaths: options?.binIncludePaths,
     lineContinuations: options?.lineContinuations ?? true,
     numberSeparators: options?.numberSeparators,
     generateDebugInfo: options?.generateDebugInfo
@@ -531,6 +534,7 @@ export async function compile(
     throwIfCancelled(signal);
     const asmOpts: AssemblerOptions = {
       includePaths: options.includePaths,
+      binIncludePaths: options.binIncludePaths,
       lineContinuations: options.lineContinuations,
       numberSeparators: options.numberSeparators,
       generateDebugInfo: options.generateDebugInfo,

--- a/src/libassembler.ts
+++ b/src/libassembler.ts
@@ -194,139 +194,156 @@ export async function assemble(
     generateDebugInfo: options?.generateDebugInfo
   };
 
-  for (let i = 0; i < inputs.length; i++) {
-    throwIfCancelled(signal);
-    const input = inputs[i];
+  // Reference to the currently processing assembler. If the current file
+  // errors out so horribly that it hits the outer try block, then we'd
+  // lose any error messages from the current assembler (since we aggregate
+  // errors at the end.) This is just a cheeky way to grab errors from that
+  // assembler if it does explode.
+  let currentAssembler: Assembler | undefined;
 
-    if (input.type === 'module') {
-      // Already compiled module, just add it
-      modules.push(input.module);
-      continue;
-    }
+  try {
+    for (let i = 0; i < inputs.length; i++) {
+      throwIfCancelled(signal);
+      const input = inputs[i];
 
-    if (input.type === 'actions') {
-      const asm = new Assembler(Cpu.P02, asmOpts);
-      let module_name = input.name ?? `module_${i}`;
-      const original_module_name = module_name;
-
-      for (const action of input.actions) {
-        // Set source info for debug purposes before processing each action
-        asm.setSource(toSourceInfo(action.source));
-
-        switch (action.action) {
-          case 'code': {
-            // For code actions, we need to tokenize and process through the full pipeline
-            const toks = new TokenStream(
-              callbacks?.readText,
-              callbacks?.readBinary,
-              opts,
-              sourceContents
-            );
-            // Use the first name provided through a code action as the outer module name
-            if (module_name === original_module_name && action.name) {
-              module_name = action.name;
-            }
-            const tokenizer = new Tokenizer(action.code, module_name, opts, sourceContents, asm.errorCollector);
-            toks.enter(tokenizer);
-            const pre = new Preprocessor(toks, asm, undefined, asm.errorCollector);
-            await asm.tokens(pre, signal);
-            break;
-          }
-
-          case 'label':
-            asm.label(action.label);
-            break;
-
-          case 'byte':
-            asm.byte(...action.bytes);
-            break;
-
-          case 'word':
-            asm.word(...action.words);
-            break;
-
-          case 'org':
-            asm.org(action.addr, action.name);
-            break;
-
-          case 'segment':
-            asm.segment(...action.name);
-            break;
-
-          case 'reloc':
-            asm.reloc(action.name);
-            break;
-
-          case 'export':
-            asm.export(action.name);
-            break;
-
-          case 'assign': {
-            const value = typeof action.value === 'string'
-              ? parseInt(action.value, 10)
-              : action.value;
-            asm.assign(action.name, value);
-            break;
-          }
-
-          case 'set': {
-            const value = typeof action.value === 'string'
-              ? parseInt(action.value, 10)
-              : action.value;
-            asm.set(action.name, value);
-            break;
-          }
-
-          case 'free':
-            asm.free(action.size);
-            break;
-
-          default:
-            console.warn(`Unknown action type:`, action);
-        }
-      }
-
-      const module = asm.module();
-      module.name = module_name;
-      modules.push(module);
-      allMessages.push(...asm.getMessages());
-      continue;
-    }
-
-    // Process source code
-    const asm = new Assembler(Cpu.P02, asmOpts);
-    const toks = new TokenStream(
-      callbacks?.readText,
-      callbacks?.readBinary,
-      opts,
-      sourceContents
-    );
-
-    // Try to parse as JSON Module first (for .o files)
-    try {
-      const obj = JSON.parse(input.code);
-      const parsedModule = parseModule(obj);
-      if (parsedModule.ok) {
-        // Successfully parsed as a module
-        modules.push(parsedModule.value);
+      if (input.type === 'module') {
+        // Already compiled module, just add it
+        modules.push(input.module);
         continue;
       }
-    } catch (_err) {
-      // Not JSON or not a valid module, treat as source code
+
+      if (input.type === 'actions') {
+        const asm = currentAssembler = new Assembler(Cpu.P02, asmOpts);
+        let module_name = input.name ?? `module_${i}`;
+        const original_module_name = module_name;
+
+        for (const action of input.actions) {
+          // Set source info for debug purposes before processing each action
+          asm.setSource(toSourceInfo(action.source));
+
+          switch (action.action) {
+            case 'code': {
+              // For code actions, we need to tokenize and process through the full pipeline
+              const toks = new TokenStream(
+                callbacks?.readText,
+                callbacks?.readBinary,
+                opts,
+                sourceContents
+              );
+              // Use the first name provided through a code action as the outer module name
+              if (module_name === original_module_name && action.name) {
+                module_name = action.name;
+              }
+              const tokenizer = new Tokenizer(action.code, module_name, opts, sourceContents, asm.errorCollector);
+              toks.enter(tokenizer);
+              const pre = new Preprocessor(toks, asm, undefined, asm.errorCollector);
+              await asm.tokens(pre, signal);
+              break;
+            }
+
+            case 'label':
+              asm.label(action.label);
+              break;
+
+            case 'byte':
+              asm.byte(...action.bytes);
+              break;
+
+            case 'word':
+              asm.word(...action.words);
+              break;
+
+            case 'org':
+              asm.org(action.addr, action.name);
+              break;
+
+            case 'segment':
+              asm.segment(...action.name);
+              break;
+
+            case 'reloc':
+              asm.reloc(action.name);
+              break;
+
+            case 'export':
+              asm.export(action.name);
+              break;
+
+            case 'assign': {
+              const value = typeof action.value === 'string'
+                ? parseInt(action.value, 10)
+                : action.value;
+              asm.assign(action.name, value);
+              break;
+            }
+
+            case 'set': {
+              const value = typeof action.value === 'string'
+                ? parseInt(action.value, 10)
+                : action.value;
+              asm.set(action.name, value);
+              break;
+            }
+
+            case 'free':
+              asm.free(action.size);
+              break;
+
+            default:
+              console.warn(`Unknown action type:`, action);
+          }
+        }
+
+        const module = asm.module();
+        module.name = module_name;
+        modules.push(module);
+        allMessages.push(...asm.getMessages());
+        currentAssembler = undefined;
+        continue;
+      }
+
+      // Process source code
+      const asm = currentAssembler = new Assembler(Cpu.P02, asmOpts);
+      const toks = new TokenStream(
+        callbacks?.readText,
+        callbacks?.readBinary,
+        opts,
+        sourceContents
+      );
+
+      // Try to parse as JSON Module first (for .o files)
+      try {
+        const obj = JSON.parse(input.code);
+        const parsedModule = parseModule(obj);
+        if (parsedModule.ok) {
+          // Successfully parsed as a module
+          modules.push(parsedModule.value);
+          continue;
+        }
+      } catch (_err) {
+        // Not JSON or not a valid module, treat as source code
+      }
+
+      // Tokenize and assemble source code
+      const tokenizer = new Tokenizer(input.code, input.name, opts, sourceContents, asm.errorCollector);
+      toks.enter(tokenizer);
+      const pre = new Preprocessor(toks, asm, undefined, asm.errorCollector);
+      await asm.tokens(pre, signal);
+
+      const module = asm.module();
+      module.name = input.name;
+      modules.push(module);
+
+      // Collect messages from this assembler
+      allMessages.push(...asm.getMessages());
+      currentAssembler = undefined;
     }
-
-    // Tokenize and assemble source code
-    const tokenizer = new Tokenizer(input.code, input.name, opts, sourceContents, asm.errorCollector);
-    toks.enter(tokenizer);
-    const pre = new Preprocessor(toks, asm, undefined, asm.errorCollector);
-    await asm.tokens(pre, signal);
-
-    const module = asm.module();
-    module.name = input.name;
-    modules.push(module);
-
-    // Collect messages from this assembler
-    allMessages.push(...asm.getMessages());
+  } catch (err) {
+    // if we have currentAssembler, it means there was some unrecoverable error,
+    // so grab whatever messages we can scavenge
+    if (currentAssembler) allMessages.push(...currentAssembler.getMessages());
+    allMessages.push(messageFromException(err));
+    return { success: false, modules, messages: allMessages };
   }
 
   const hasErrors = allMessages.some(m => m.level === 'error');
@@ -442,13 +459,14 @@ export function findOutput(result: CompileResult, type: OutputType): OutputFile 
 }
 
 /**
- * Create a failure CompileResult from an exception
+ * Create a failure CompileResult from an exception. `collected` carries any diagnostics
+ * produced by the assembler that happened before an unrecoverable exception occured
  */
-function failureFromException(err: unknown): CompileResult {
+function failureFromException(err: unknown, collected: AssemblerMessage[] = []): CompileResult {
   return {
     success: false,
     outputs: [],
-    messages: [messageFromException(err)]
+    messages: [...collected, messageFromException(err)]
   };
 }
 
@@ -491,9 +509,7 @@ export function deserializeRequest(requestJson: string): Js65Request {
 
 /**
  * Canonical compile entrypoint: assembles and (unless outputFormat is 'object') links
- * the given typed inputs, returning the structured result. Never throws: failures come
- * back as a failure CompileResult. String-transport callers deserialize their JSON with
- * deserializeRequest() first, then call this with the typed inputs/options.
+ * the given typed inputs, returning the structured result. 
  *
  * @param inputs - sources / modules / action lists to assemble and link
  * @param options - flat options bag (text fields only; baseRom is the separate arg)
@@ -508,6 +524,9 @@ export async function compile(
   signal?: CancelSignal,
 ): Promise<CompileResult> {
   const base64 = new Base64();
+  // Diagnostics produced so far, so a throw later in the pipeline (serializing, linking)
+  // still reports the warnings/errors assembly already found.
+  let collected: AssemblerMessage[] = [];
   try {
     throwIfCancelled(signal);
     const asmOpts: AssemblerOptions = {
@@ -541,6 +560,7 @@ export async function compile(
     };
 
     const asm = await assemble(inputs, asmOpts, fileCallbacks, sourceContents, signal);
+    collected = [...asm.messages];
     if (!asm.success) {
       return { success: false, outputs: [], messages: asm.messages };
     }
@@ -567,7 +587,7 @@ export async function compile(
       messages: lr.messages,
     };
   } catch (err) {
-    return failureFromException(err);
+    return failureFromException(err, collected);
   }
 }
 

--- a/src/libassembler.ts
+++ b/src/libassembler.ts
@@ -15,7 +15,7 @@ import { TokenStream, SourceContents } from './tokenstream.ts';
 import { type Module, type Segment } from "./module.ts";
 import { parseModule, parseRequest } from "./validate_modules.ts";
 import type { Expr } from './expr.ts';
-import type { SourceInfo, AssemblerMessage } from './token.ts';
+import { SourceError, type SourceInfo, type AssemblerMessage } from './token.ts';
 
 // Re-export Assembler for direct programmatic use
 export { Assembler, Cpu, SourceContents, Base64 };
@@ -407,11 +407,7 @@ export function link(
     };
   } catch (err) {
     // Linker threw an error - add it to messages and return failure
-    allMessages.push({
-      level: 'error',
-      message: err instanceof Error ? err.message : String(err),
-      stack: err instanceof Error ? err.stack : undefined
-    });
+    allMessages.push(messageFromException(err));
 
     return {
       success: false,
@@ -452,11 +448,16 @@ function failureFromException(err: unknown): CompileResult {
   return {
     success: false,
     outputs: [],
-    messages: [{
-      level: 'error',
-      message: err instanceof Error ? err.message : String(err),
-      stack: err instanceof Error ? err.stack : undefined
-    }]
+    messages: [messageFromException(err)]
+  };
+}
+
+function messageFromException(err: unknown): AssemblerMessage {
+  return {
+    level: 'error',
+    message: err instanceof Error ? err.message : String(err),
+    source: err instanceof SourceError ? err.source : undefined,
+    stack: err instanceof Error ? err.stack : undefined
   };
 }
 

--- a/src/macro.ts
+++ b/src/macro.ts
@@ -33,7 +33,7 @@ export class Macro {
       if (Tokens.eq(next[0], Tokens.ENDMACRO)) return new Macro(params, lines);
       lines.push(next);
     }
-    throw new Error(`EOF looking for .endmacro: ${Tokens.nameAt(line[1])}`);
+    Tokens.fail(`EOF looking for .endmacro: ${Tokens.nameOf(line[1])}`, line[1]);
   }
 
   expand(tokens: Token[], idGen: Source<number>): Token[][] {
@@ -56,7 +56,7 @@ export class Macro {
       replacements.set(param, slice);
     }
     if (i < tokens.length) {
-      throw new Error(`Too many macro parameters: ${Tokens.nameAt(tokens[i])}`);
+      Tokens.fail(`Too many macro parameters: ${Tokens.nameOf(tokens[i])}`, tokens[i]);
     }
     // All params filled in, make replacement
     const locals = new Map<string, string>();

--- a/src/module.ts
+++ b/src/module.ts
@@ -35,6 +35,8 @@ interface BaseChunk {
   segments: string[];
   /** Absolute address of the start of the chunk, if not relocatable. */
   org?: number;
+  /** Alignment constraint (a power of two) the linker must place this chunk on */
+  align?: number;
   /** Substitutions to insert into the data. */
   subs?: Substitution[];
   /** Assertions within this chunk. Each expression must be nonzero. */

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -234,6 +234,11 @@ export class Preprocessor implements Tokens.Source {
       case '.skip': return this.skip(line, i);
       case '.noexpand': return this.noexpand(line, i);
       case '.tcount': return this.parseArgs(line, i, 1, this.tcount);
+      case '.match': return this.parseArgs(line, i, 2, this.matchTokens);
+      case '.xmatch': return this.parseArgs(line, i, 2, this.xmatchTokens);
+      case '.left': return this.parseArgs(line, i, 2, this.left);
+      case '.right': return this.parseArgs(line, i, 2, this.right);
+      case '.mid': return this.parseArgs(line, i, 3, this.mid);
       case '.ident': return this.parseArgs(line, i, 1, this.ident);
       case '.string': return this.parseArgs(line, i, 1, this.string);
       case '.concat': return this.parseArgs(line, i, 0, this.concat);
@@ -299,6 +304,64 @@ export class Preprocessor implements Tokens.Source {
 
   private tcount(cs: Token, arg: Token[]) : Token[] {
     return [{token: 'num', num: Tokens.count(arg), source: cs.source}];
+  }
+
+  // `.match`/`.xmatch` compare two token lists as raw tokens and not values, so
+  // they work on things like `#` or register names that aren't expressions.
+  // `.match` compares token type + value but treats all identifiers as equal
+  // `.xmatch` also compares identifier names.
+  // the exact parameter is used to select between the two.
+  private static tokensEqual(a: Token[], b: Token[], exact: boolean): boolean {
+    if (a.length !== b.length) return false;
+    for (let k = 0; k < a.length; k++) {
+      const x = a[k], y = b[k];
+      if (x.token !== y.token) return false;
+      switch (x.token) {
+        case 'ident':
+          if (exact && x.str !== (y as typeof x).str) return false;
+          break;
+        case 'num':
+          if (x.num !== (y as typeof x).num) return false;
+          break;
+        case 'str': case 'op': case 'cs':
+          if (x.str !== (y as typeof x).str) return false;
+          break;
+        default:
+          break; // structural tokens match on type alone
+      }
+    }
+    return true;
+  }
+
+  private matchTokens(cs: Token, a: Token[], b: Token[]) : Token[] {
+    return [{token: 'num', num: Preprocessor.tokensEqual(a, b, false) ? 1 : 0, source: cs.source}];
+  }
+
+  private xmatchTokens(cs: Token, a: Token[], b: Token[]) : Token[] {
+    return [{token: 'num', num: Preprocessor.tokensEqual(a, b, true) ? 1 : 0, source: cs.source}];
+  }
+
+  /** Evaluate an already-expanded token list to a constant token count. */
+  private constCount(toks: Token[], cs: Token): number {
+    const e = Exprs.evaluate(Exprs.parseOnly(toks, 0));
+    if (e.num == null) Tokens.fail(`Expected a constant token count`, cs);
+    return e.num;
+  }
+
+  private left(cs: Token, count: Token[], list: Token[]) : Token[] {
+    const n = Math.max(0, this.constCount(count, cs));
+    return list.slice(0, n);
+  }
+
+  private right(cs: Token, count: Token[], list: Token[]) : Token[] {
+    const n = Math.max(0, this.constCount(count, cs));
+    return n >= list.length ? list.slice() : list.slice(list.length - n);
+  }
+
+  private mid(cs: Token, start: Token[], count: Token[], list: Token[]) : Token[] {
+    const s = Math.max(0, this.constCount(start, cs));
+    const n = Math.max(0, this.constCount(count, cs));
+    return list.slice(s, s + n);
   }
 
   private ident(cs: Token, arg: Token[]) : Token[] {
@@ -423,7 +486,7 @@ export class Preprocessor implements Tokens.Source {
     return true;
   }
 
-  evaluateConst(expr: Expr): number {
+  evaluateConst(expr: Expr, source?: Token): number {
     // Attempt to look up a symbol and see if its a constant value
     const evalWrapper = (ex: Expr) => {
       if (ex.op === 'sym' && this.env.definedSymbol(ex.sym!)) {
@@ -433,10 +496,28 @@ export class Preprocessor implements Tokens.Source {
         return Exprs.evaluate({op: 'num', num, meta: Exprs.size(num, undefined)});
       }
       return Exprs.evaluate(ex);
-    }
-    expr = Exprs.traversePost(expr, evalWrapper);
-    if (expr.op === 'num' && !expr.meta?.rel) return expr.num!;
-    Tokens.fail(`Expected a constant: ${expr}`, expr);
+    };
+    // Check for short circuiting to see if we should skip the rest of the check
+    const truthy = (n: number | undefined) => n === undefined ? undefined : n !== 0;
+    const evalNode = (ex: Expr): number | undefined => {
+      const isAnd = ex.op === '&&' || ex.op === '.and';
+      const isOr = ex.op === '||' || ex.op === '.or';
+      if ((isAnd || isOr) && ex.args?.length === 2) {
+        const l = truthy(evalNode(ex.args[0]));
+        if (isAnd && l === false) return 0;
+        if (isOr && l === true) return 1;
+        const r = truthy(evalNode(ex.args[1]));
+        if (l === undefined || r === undefined) return undefined;
+        return (isAnd ? (l && r) : (l || r)) ? 1 : 0;
+      }
+      const reduced = Exprs.traversePost(ex, evalWrapper);
+      return reduced.op === 'num' && !reduced.meta?.rel ? reduced.num : undefined;
+    };
+    const v = evalNode(expr);
+    if (v !== undefined) return v;
+    const reduced = Exprs.traversePost(expr, evalWrapper);
+    const desc = reduced.op === 'sym' ? `symbol ${reduced.sym}` : `${reduced.op} expression`;
+    Tokens.fail(`Expected a constant: ${desc}`, reduced.source ?? source);
   }
 
   private readonly runDirectives: Record<string, (ts: Token[]) => Promise<void>> = {
@@ -450,7 +531,7 @@ export class Preprocessor implements Tokens.Source {
     '.exitmacro': async ([, a]) => { noGarbage(a); this.stream.exit(); 
       return await Promise.resolve(); },
     '.if': ([cs, ...args]) =>
-        this.parseIf(!!this.evaluateConst(parseOneExpr(args, cs))),
+        this.parseIf(!!this.evaluateConst(parseOneExpr(args, cs), cs)),
     '.ifdef': ([cs, ...args]) =>
         this.parseIf(this.parseIfDef(args, cs)),
     '.ifndef': ([cs, ...args]) =>
@@ -576,7 +657,7 @@ export class Preprocessor implements Tokens.Source {
           continue;
         } else if (Tokens.eq(front, Tokens.ELSEIF)) {
           // if false ... else if .....
-          cond = !!this.evaluateConst(parseOneExpr(this.expandLine(line.slice(1)), front));
+          cond = !!this.evaluateConst(parseOneExpr(this.expandLine(line.slice(1)), front), front);
           continue;
         } else if (Tokens.eq(front, Tokens.ELSE)) {
           // if false ... else .....

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -160,7 +160,7 @@ export class Preprocessor implements Tokens.Source {
           }
           /* fallthrough */
         default:
-          throw new Error(`Unexpected: ${Tokens.nameAt(line[0])}`);
+          Tokens.fail(`Unexpected: ${Tokens.nameOf(line[0])}`, line[0]);
       }
     }
     return true;
@@ -186,8 +186,8 @@ export class Preprocessor implements Tokens.Source {
         maxPos = pos;
         depth = 0;
       } else if (depth++ > MAX_STACK_DEPTH) {
-        throw new Error(`Maximum expansion depth reached: ${
-                         line.map(Tokens.name).join(' ')}${Tokens.at(front)}`);
+        Tokens.fail(`Maximum expansion depth reached: ${
+                      line.map(Tokens.name).join(' ')}`, front);
       }
       pos = this.expandToken(line, pos);
     }
@@ -290,7 +290,7 @@ export class Preprocessor implements Tokens.Source {
           return this.expandLine(ts);
         });
     if (argCount && args.length !== argCount) {
-      throw new Error(`Expected ${argCount} parameters: ${Tokens.nameAt(cs)}`);
+      Tokens.fail(`Expected ${argCount} parameters: ${Tokens.nameOf(cs)}`, cs);
     }
     const expansion = fn.call(this, cs, ...args);
     line.splice(i, end + 1 - i, ...expansion);
@@ -436,8 +436,7 @@ export class Preprocessor implements Tokens.Source {
     }
     expr = Exprs.traversePost(expr, evalWrapper);
     if (expr.op === 'num' && !expr.meta?.rel) return expr.num!;
-    const at = Tokens.at(expr);
-    throw new Error(`Expected a constant: ${at} : ${expr}`);
+    Tokens.fail(`Expected a constant: ${expr}`, expr);
   }
 
   private readonly runDirectives: Record<string, (ts: Token[]) => Promise<void>> = {
@@ -500,7 +499,7 @@ export class Preprocessor implements Tokens.Source {
     const name = Tokens.expectIdentifier(ident, cs);
     Tokens.expectEol(eol);
     if (!this.macros.has(name)) {
-      throw new Error(`Not defined: ${Tokens.nameAt(ident)}`);
+      Tokens.fail(`Not defined: ${Tokens.nameOf(ident)}`, ident);
     }
     this.macros.delete(name);
     return await Promise.resolve();
@@ -517,13 +516,13 @@ export class Preprocessor implements Tokens.Source {
   private async parseRepeat(line: Token[]) {
     const [expr, end] = Exprs.parse(line, 1);
     const at = line[1] || line[0];
-    if (!expr) throw new Error(`Expected expression: ${Tokens.nameAt(at)}`);
+    if (!expr) Tokens.fail(`Expected expression: ${Tokens.nameOf(at)}`, at);
     const times = this.evaluateConst(expr);
-    if (times == null) throw new Error(`Expected a constant${Tokens.at(expr)}`);
+    if (times == null) Tokens.fail(`Expected a constant`, expr);
     let ident: string|undefined;
     if (end < line.length) {
       if (!Tokens.eq(line[end], Tokens.COMMA)) {
-        throw new Error(`Expected comma: ${Tokens.nameAt(line[end])}`);
+        Tokens.fail(`Expected comma: ${Tokens.nameOf(line[end])}`, line[end]);
       }
       ident = Tokens.expectIdentifier(line[end + 1]);
       Tokens.expectEol(line[end + 2]);
@@ -543,7 +542,7 @@ export class Preprocessor implements Tokens.Source {
   private async parseEndRepeat(line: Token[]) {
     Tokens.expectEol(line[1]);
     const top = this.repeats.pop();
-    if (!top) throw new Error(`.endrep with no .repeat${Tokens.at(line[0])}`);
+    if (!top) Tokens.fail(`.endrep with no .repeat`, line[0]);
     if (++top[2] >= top[1]) return await Promise.resolve();
     this.repeats.push(top);
     this.stream.unshift(...top[0].map(line => line.map(token => {
@@ -735,13 +734,13 @@ function parseOneIdent(ts: Token[], prev?: Token): string {
 function parseOneExpr(ts: Token[], prev?: Token): Expr {
   if (!ts.length) {
     if (!prev) throw new Error(`Expected expression`);
-    throw new Error(`Expected expression: ${Tokens.nameAt(prev)}`);
+    Tokens.fail(`Expected expression: ${Tokens.nameOf(prev)}`, prev);
   }
   return Exprs.parseOnly(ts);
 }
 
 function noGarbage(token: Token|undefined): void {
-  if (token) throw new Error(`garbage at end of line: ${Tokens.nameAt(token)}`);
+  if (token) Tokens.fail(`garbage at end of line: ${Tokens.nameOf(token)}`, token);
 }
 
 // function fail(t: Token, msg: string): never {
@@ -754,7 +753,7 @@ function noGarbage(token: Token|undefined): void {
 // }
 
 function badClose(open: string, tok: Token): never {
-  throw new Error(`${Tokens.name(tok)} with no ${open}${Tokens.at(tok)}`);
+  Tokens.fail(`${Tokens.name(tok)} with no ${open}`, tok);
 }
 
 function fail(msg: string): never {

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -47,6 +47,8 @@ interface Env {
   evaluate(expr: Expr): number|undefined;
   assignSym(line: Token[]): void;
   setSym(line: Token[]): void;
+  /** Applies the current charmap to a character literal (`'a'`). */
+  encodeChar(char: string): number|undefined;
   // also want methods to apply shunting yard to token list?
   //  - turn it into a json tree...?
 }
@@ -419,7 +421,7 @@ export class Preprocessor implements Tokens.Source {
           if (specType == 's')
             arg = Tokens.expectString(argToks[0], prevTok);
           else
-            arg = this.evaluateConst(parseOneExpr(argToks, prevTok));
+            arg = this.evaluateConst(parseOneExpr(argToks, prevTok, this.env.encodeChar));
 
           sprintfArgs.push(arg);
           argIdx++;
@@ -531,7 +533,7 @@ export class Preprocessor implements Tokens.Source {
     '.exitmacro': async ([, a]) => { noGarbage(a); this.stream.exit(); 
       return await Promise.resolve(); },
     '.if': ([cs, ...args]) =>
-        this.parseIf(!!this.evaluateConst(parseOneExpr(args, cs), cs)),
+        this.parseIf(!!this.evaluateConst(parseOneExpr(args, cs, this.env.encodeChar), cs)),
     '.ifdef': ([cs, ...args]) =>
         this.parseIf(this.parseIfDef(args, cs)),
     '.ifndef': ([cs, ...args]) =>
@@ -595,7 +597,7 @@ export class Preprocessor implements Tokens.Source {
   }
 
   private async parseRepeat(line: Token[]) {
-    const [expr, end] = Exprs.parse(line, 1);
+    const [expr, end] = Exprs.parse(line, 1, undefined, this.env.encodeChar);
     const at = line[1] || line[0];
     if (!expr) Tokens.fail(`Expected expression: ${Tokens.nameOf(at)}`, at);
     const times = this.evaluateConst(expr);
@@ -657,7 +659,8 @@ export class Preprocessor implements Tokens.Source {
           continue;
         } else if (Tokens.eq(front, Tokens.ELSEIF)) {
           // if false ... else if .....
-          cond = !!this.evaluateConst(parseOneExpr(this.expandLine(line.slice(1)), front), front);
+          cond = !!this.evaluateConst(
+              parseOneExpr(this.expandLine(line.slice(1)), front, this.env.encodeChar), front);
           continue;
         } else if (Tokens.eq(front, Tokens.ELSE)) {
           // if false ... else .....
@@ -812,12 +815,12 @@ function parseOneIdent(ts: Token[], prev?: Token): string {
   return Exprs.identifier(e);
 }
 
-function parseOneExpr(ts: Token[], prev?: Token): Expr {
+function parseOneExpr(ts: Token[], prev?: Token, charEncoder?: Exprs.CharEncoder): Expr {
   if (!ts.length) {
     if (!prev) throw new Error(`Expected expression`);
     Tokens.fail(`Expected expression: ${Tokens.nameOf(prev)}`, prev);
   }
-  return Exprs.parseOnly(ts);
+  return Exprs.parseOnly(ts, 0, undefined, charEncoder);
 }
 
 function noGarbage(token: Token|undefined): void {

--- a/src/token.ts
+++ b/src/token.ts
@@ -65,6 +65,7 @@ export interface StringToken {
   token: StringTok;
   str: string; // Canonical form for CS tokens
   rawStr?: string; // Original possibly aliased form for CS tokens
+  char?: boolean; // marks a difference between char single quotes and string double quotes.
   source?: SourceInfo;
 }
 export interface NumberToken {

--- a/src/token.ts
+++ b/src/token.ts
@@ -181,23 +181,63 @@ export function at(arg: {source?: SourceInfo}): string {
   // TODO - definition vs usage?
 }
 
+/**
+ * Renders a token together with its location. Only for *secondary* locations inside a
+ * message ("previously defined at ...")
+ * Most every kind of error should use `nameOf` instead since the source location should
+ * be a part of the SourceError instead of the message text where this puts it.
+ * 
+ * TODO: we should expand the errors section to add a list of `notes` for handling these
+ * cases better.
+ */
 export function nameAt(arg: {source?: SourceInfo}|undefined): string {
   if (!arg) return 'at unknown';
   const token = arg as Token;
   return (token.token ? name(token) : '') + at(arg);
 }
 
+export function nameOf(arg: {source?: SourceInfo}|undefined): string {
+  if (!arg) return 'unknown';
+  const token = arg as Token;
+  return token.token ? name(token) : 'unknown';
+}
+
+export class SourceError extends Error {
+  readonly source?: SourceInfo;
+  constructor(message: string, at?: {source?: SourceInfo}|SourceInfo) {
+    super(message);
+    this.name = 'SourceError';
+    const source = at && ('source' in at ? at.source : at as SourceInfo);
+    if (source) this.source = source;
+  }
+
+  /**
+   * Add a stack to the eror if we haven't gotten that resolved yet.
+   */
+  static locate(err: unknown, source?: SourceInfo): unknown {
+    if (!source || !(err instanceof Error) || err instanceof SourceError) return err;
+    const located = new SourceError(err.message, source);
+    located.stack = err.stack;
+    return located;
+  }
+}
+
+// Helper function to create a source error from the message + sourceinfo
+export function fail(message: string, at?: {source?: SourceInfo}|SourceInfo): never {
+  throw new SourceError(message, at);
+}
+
 export function expectEol(token: Token|undefined, name = 'end of line') {
-  if (token) throw new Error(`Expected ${name}: ${nameAt(token)}`);
+  if (token) fail(`Expected ${name}: ${nameOf(token)}`, token);
 }
 
 export function expect(want: Token, token: Token, prev?: Token) {
   if (!token) {
     if (!prev) throw new Error(`Expected ${name(want)}`);
-    throw new Error(`Expected ${name(want)} after ${nameAt(token)}`);
+    fail(`Expected ${name(want)} after ${nameOf(prev)}`, prev);
   }
   if (!eq(want, token)) {
-    throw new Error(`Expected ${name(want)}: ${nameAt(token)}`);
+    fail(`Expected ${name(want)}: ${nameOf(token)}`, token);
   }
 }
 
@@ -224,10 +264,10 @@ function expectStringToken(want: StringTok,
                             prev?: Token): string {
   if (!token) {
     if (!prev) throw new Error(`Expected ${name}`);
-    throw new Error(`Expected ${name} after ${nameAt(prev)}`);
+    fail(`Expected ${name} after ${nameOf(prev)}`, prev);
   }
   if (token.token !== want) {
-    throw new Error(`Expected ${name}: ${nameAt(token)}`);
+    fail(`Expected ${name}: ${nameOf(token)}`, token);
   }
   return token.str;
 }
@@ -239,16 +279,10 @@ function optionalStringToken(want: StringTok,
     return undefined;
   }
   if (token.token !== want) {
-    throw new Error(`Expected ${name}: ${nameAt(token)}`);
+    fail(`Expected ${name}: ${nameOf(token)}`, token);
   }
   return token.str;
 }
-  
-// export function fail(token: Token, msg: string): never {
-//   if 
-//   throw new Error(msg + 
-
-// }
 
 /**
  * Given a comma-separated list of identifiers, return the
@@ -261,12 +295,12 @@ export function identsFromCList(list: Token[]): string[] {
   for (let i = 0; i <= list.length; i += 2) {
     const ident = list[i];
     if (ident?.token !== 'ident') {
-      if (ident) throw new Error(`Expected identifier: ${nameAt(ident)}`);
+      if (ident) fail(`Expected identifier: ${nameOf(ident)}`, ident);
       const last = list[list.length - 1];
-      throw new Error(`Expected identifier after ${nameAt(last)}`);
+      fail(`Expected identifier after ${nameOf(last)}`, last);
     } else if (i + 1 < list.length && !eq(list[i + 1], COMMA)) {
       const sep = list[i + 1];
-      throw new Error(`Expected comma: ${nameAt(sep)}`);
+      fail(`Expected comma: ${nameOf(sep)}`, sep);
     }
     out.push(ident.str);
   }
@@ -304,7 +338,7 @@ export function parseArgList(tokens: Token[],
       arg.push(token);
       if (eq(token, LP)) parens++;
       if (eq(token, RP)) {
-        if (--parens < 0) throw new Error(`Unbalanced paren${at(token)}`);
+        if (--parens < 0) fail(`Unbalanced paren`, token);
       }
     }
   }
@@ -321,12 +355,12 @@ export function parseAttrList(tokens: Token[],
   let val: Token[] = [];
   if (start >= tokens.length) return out;
   if (!eq(tokens[start], COLON)) {
-    throw new Error(`Unexpected: ${nameAt(tokens[start])}`);
+    fail(`Unexpected: ${nameOf(tokens[start])}`, tokens[start]);
   }
   for (let i = start + 1; i < tokens.length; i++) {
     const tok = tokens[i];
     if (eq(tok, COLON)) {
-      if (key == null) throw new Error(`Missing key${at(tok)}`);
+      if (key == null) fail(`Missing key`, tok);
       out.set(key, val);
       key = undefined;
       val = [];
@@ -382,7 +416,7 @@ export function str(t: Token) {
     case 'op':
       return t.str;
   }
-  throw new Error(`Non-string token: ${nameAt(t)}`);
+  fail(`Non-string token: ${nameOf(t)}`, t);
 }
 
 export function strip(t: Token): Token {

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -106,8 +106,12 @@ export class Tokenizer implements Tokens.Source {
     }
     if (this.buffer.token(/^\.[a-z][a-z0-9]*/i)) return this.csTok();
     if (this.buffer.token(/^:([+-]\d+|[-+]+|<+rts|>*rts)/)) return this.strTok('ident');
-    if (this.buffer.token(/^(:|\++|-+|&&?|\|\|?|[#*/,=~!^]|<[<>=]?|>[>=]?)/)) {
-      return this.strTok('op');
+    if (this.buffer.token(/^(:=|:|\++|-+|&&?|\|\|?|[#*/,=~!^]|<[<>=]?|>[>=]?)/)) {
+      const op = this.strTok('op');
+      // the := is just like = but it marks it as a label in the dbg file.
+      // which we don't support so just treat it as = for now.
+      if ((op as Tokens.StringToken).str === ':=') return {token: 'op', str: '='};
+      return op;
     }
     if (this.buffer.token('[')) return {token: 'lb'};
     if (this.buffer.token('{')) return {token: 'lc'};

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -139,7 +139,8 @@ export class Tokenizer implements Tokens.Source {
       }
     }
     b.token(end);
-    return {token: 'str', str};
+    // mark single quoted strings as 'char' so they can be used as numeric literals later
+    return end === `'` ? {token: 'str', str, char: true} : {token: 'str', str};
   }
 
   private strTok(token: Tokens.StringToken['token']): Token {

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -88,7 +88,7 @@ export class Tokenizer implements Tokens.Source {
         tok.source = source;
       }
       return tok;
-    } catch (err) {
+    } catch (err:any) {
       // Add a `near` part to the message if we know what the last token was
       const last = this.buffer.group();
       const located = new Tokens.SourceError(

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -201,6 +201,8 @@ function parseBin(str: string): Token {
  */
 export interface Options {
   includePaths?: string[];
+  /** Search path for `.incbin`.*/
+  binIncludePaths?: string[];
   // caseInsensitive?: boolean; // handle elsewhere?
   lineContinuations?: boolean;
   numberSeparators?: boolean;

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -89,11 +89,12 @@ export class Tokenizer implements Tokens.Source {
       }
       return tok;
     } catch (err) {
-      const {file, line, column} = source;
-      let last = this.buffer.group();
-      last = last ? ` near '${last}'` : '';
-      err.message += `\n  at ${file}:${line}:${column}${last}`;
-      throw err;
+      // Add a `near` part to the message if we know what the last token was
+      const last = this.buffer.group();
+      const located = new Tokens.SourceError(
+          `${err.message}${last ? ` near '${last}'` : ''}`, source);
+      located.stack = err.stack;
+      throw located;
     }
   }
 

--- a/src/tokenstream.ts
+++ b/src/tokenstream.ts
@@ -16,9 +16,36 @@ import * as Generic from './macpack/generic.ts'
 import * as Longbranch from './macpack/longbranch.ts'
 import * as Nes2header from './macpack/nes2header.ts'
 
-type Frame = [Tokens.Source|undefined, Token[][]];
+// A frame is a token source, a pushback queue, and the directory that
+// `.include`/`.incbin` inside this file should resolve relative to.
+type Frame = {
+  source?: Tokens.Source,
+  queue: Token[][],
+  dir?: string
+};
 
-const MAX_DEPTH = 100;
+// Arbitrarily chosen max stack depth for frames. Could bump it if people actually
+// ran into this in practice. Just want it high enough to not cause real problems
+// but low enough to catch issues quickly.
+const MAX_DEPTH = 256;
+
+/** Directory portion of a POSIX-style path ('a/b/c.s' -> 'a/b', 'x.s' -> ''). */
+function dirOf(p: string): string {
+  const i = p.lastIndexOf('/');
+  return i < 0 ? '' : p.substring(0, i);
+}
+
+/** Combine two paths together and handle `.` and `..` when joining */
+function joinDir(base: string, rel: string): string {
+  const combined = !base ? rel : !rel ? base : `${base}/${rel}`;
+  const out: string[] = [];
+  for (const part of combined.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..' && out.length && out[out.length - 1] !== '..') out.pop();
+    else out.push(part);
+  }
+  return out.join('/');
+}
 
 const MACPACK: Map<string, string> = new Map(
   [
@@ -45,24 +72,48 @@ export class TokenStream implements Tokens.Source {
     readonly opts?: Options,
     readonly sourceContents?: SourceContents) {}
 
-  // Try each include directory in turn, returning the first that loads.
-  async loadFile<T>(path: string, action: (path: string, filename: string) => Promise<T>,
-                    at?: Token): Promise<T> {
-    const paths = this.opts?.includePaths ?? ['./'];
-    for (const base of paths) {
+  /** Directory the frame currently on top should resolve includes against. */
+  private currentDir(): string | undefined {
+    return this.stack.length ? this.stack[this.stack.length - 1].dir : undefined;
+  }
+
+  // Try each search directory in turn, returning the first that loads along with
+  // the base it loaded from.
+  async loadFile<T>(path: string, bases: string[],
+                    action: (path: string, filename: string) => Promise<T>,
+                    at?: Token): Promise<{value: T, base: string}> {
+    for (const base of bases) {
       try {
-        return await action(base, path);
+        return {value: await action(base, path), base};
       } catch (_e) {
         // unable to load the file at that path, try the next include directory.
       }
     }
     // Report against the .include/.incbin line so the diagnostic carries a source location.
-    Tokens.fail(`Could not find file ${path} in include directories: ${paths.join(",")}`, at);
+    Tokens.fail(`Could not find file ${path} in include directories: ${bases.join(",")}`, at);
+  }
+
+  /** Search list for a `.include`. Including file's dir first, then -I dirs. 
+   * TODO: Support the other include path things like the CA65_INC env var
+  */
+  private includeSearch(): string[] {
+    const dir = this.currentDir();
+    const paths = this.opts?.includePaths ?? ['./'];
+    return dir != null ? [dir, ...paths] : [...paths];
+  }
+
+  /** Search list for a `.incbin`. Including file's dir first, then --bin-include-dir. */
+  private binIncludeSearch(): string[] {
+    const dir = this.currentDir();
+    const paths = this.opts?.binIncludePaths ?? this.opts?.includePaths ?? ['./'];
+    return dir != null ? [dir, ...paths] : [...paths];
   }
 
   async next(): Promise<Token[]|undefined> {
     while (this.stack.length) {
-      const [tok, front] = this.stack[this.stack.length - 1];
+      const frame = this.stack[this.stack.length - 1];
+      const tok = frame.source;
+      const front = frame.queue;
       if (front.length) return front.pop()!;
       const line = await tok?.next();
       if (line) {
@@ -72,8 +123,11 @@ export class TokenStream implements Tokens.Source {
             const path = this.str(line);
             if (!this.readFile) this.err(line);
             // TODO - options?
-            const code = await this.loadFile<string>(path, this.readFile, line[0]);
-            this.enter(new Tokenizer(code, path, this.opts, this.sourceContents));
+            const {value: code, base} = await this.loadFile<string>(
+                path, this.includeSearch(), this.readFile, line[0]);
+            // Nested includes resolve relative to this file's own directory.
+            this.enter(new Tokenizer(code, path, this.opts, this.sourceContents),
+                       joinDir(base, dirOf(path)));
             continue;
           }
           case '.macpack': {
@@ -108,8 +162,9 @@ export class TokenStream implements Tokens.Source {
             // The data passed in from the call back can either be base64 encoded or a u8 array
             // but because the user can slice the input, its easier to decode to bytes, then slice
             // then reencode for now.
-            let inbytes = await this.loadFile<Uint8Array|string>(path, this.readFileBinary, line[0]);
-            inbytes = (typeof inbytes === 'string') ? new Base64().decode(inbytes) : inbytes;
+            const loaded = await this.loadFile<Uint8Array|string>(
+                path, this.binIncludeSearch(), this.readFileBinary, line[0]);
+            let inbytes = (typeof loaded.value === 'string') ? new Base64().decode(loaded.value) : loaded.value;
   
             const end = length !== undefined ? offset + length : undefined;
             const bin = new Base64().encode(inbytes.slice(offset, end));
@@ -130,7 +185,7 @@ export class TokenStream implements Tokens.Source {
 
   unshift(...lines: Token[][]) {
     if (!this.stack.length) throw new Error(`Cannot unshift after EOF`);
-    const front = this.stack[this.stack.length - 1][1];
+    const front = this.stack[this.stack.length - 1].queue;
     for (let i = lines.length - 1; i >= 0; i--) {
       front.push(lines[i]);
     }
@@ -140,10 +195,21 @@ export class TokenStream implements Tokens.Source {
   //   const code = await this.task.parent.readFile(file);
   //   this.stack.push([new Tokenizer(code, file, this.task.opts),  []]);
   // }
-  // Enter a macro scope.
-  enter(tokens?: Tokens.Source) {
-    const frame: Frame = [undefined, []];
-    if (tokens) frame[0] = tokens;
+  // Enter a macro scope, an included file, or the top-level source.
+  // dir parameter is the base level include directory for the file,
+  // used when dealing with expanding included macros in files (it should inherit
+  // the relative include for the file the macro is running in.)
+  enter(tokens?: Tokens.Source, dir?: string) {
+    let frameDir = dir;
+    if (frameDir == null) {
+      if (this.stack.length) {
+        frameDir = this.stack[this.stack.length - 1].dir;
+      } else {
+        const file = (tokens as {file?: string} | undefined)?.file;
+        frameDir = file && file.includes('/') ? dirOf(file) : '';
+      }
+    }
+    const frame: Frame = {source:tokens, queue:[], dir:frameDir};
     this.stack.push(frame);
     if (this.stack.length > MAX_DEPTH) throw new Error(`Stack overflow`);
   }

--- a/src/tokenstream.ts
+++ b/src/tokenstream.ts
@@ -45,17 +45,19 @@ export class TokenStream implements Tokens.Source {
     readonly opts?: Options,
     readonly sourceContents?: SourceContents) {}
 
-  loadFile<T>(path: string, action: (path: string, filename: string) => Promise<T>) {
+  // Try each include directory in turn, returning the first that loads.
+  async loadFile<T>(path: string, action: (path: string, filename: string) => Promise<T>,
+                    at?: Token): Promise<T> {
     const paths = this.opts?.includePaths ?? ['./'];
     for (const base of paths) {
       try {
-        // console.log(`gonna try including base: ${base} path: ${path}`);
-        return action(base, path);
+        return await action(base, path);
       } catch (_e) {
-        // unable to load the files at that path.
+        // unable to load the file at that path, try the next include directory.
       }
     }
-    throw new Error(`Could not find file ${path} in include directories: ${paths.join(",")}`);
+    // Report against the .include/.incbin line so the diagnostic carries a source location.
+    Tokens.fail(`Could not find file ${path} in include directories: ${paths.join(",")}`, at);
   }
 
   async next(): Promise<Token[]|undefined> {
@@ -70,7 +72,7 @@ export class TokenStream implements Tokens.Source {
             const path = this.str(line);
             if (!this.readFile) this.err(line);
             // TODO - options?
-            const code = await this.loadFile<string>(path, this.readFile);
+            const code = await this.loadFile<string>(path, this.readFile, line[0]);
             this.enter(new Tokenizer(code, path, this.opts, this.sourceContents));
             continue;
           }
@@ -106,7 +108,7 @@ export class TokenStream implements Tokens.Source {
             // The data passed in from the call back can either be base64 encoded or a u8 array
             // but because the user can slice the input, its easier to decode to bytes, then slice
             // then reencode for now.
-            let inbytes = await this.loadFile<Uint8Array|string>(path, this.readFileBinary);
+            let inbytes = await this.loadFile<Uint8Array|string>(path, this.readFileBinary, line[0]);
             inbytes = (typeof inbytes === 'string') ? new Base64().decode(inbytes) : inbytes;
   
             const end = length !== undefined ? offset + length : undefined;

--- a/src/tokenstream.ts
+++ b/src/tokenstream.ts
@@ -155,8 +155,7 @@ export class TokenStream implements Tokens.Source {
   // }
   
   err(line: Token[]): never {
-    const msg = this.str(line);
-    throw new Error(msg + Tokens.at(line[0]));
+    Tokens.fail(this.str(line), line[0]);
   }
 
   str(line: Token[]): string {

--- a/test/assembler_test.ts
+++ b/test/assembler_test.ts
@@ -7,10 +7,10 @@
 
 import {describe, it, expect} from 'bun:test';
 import {Cpu} from '../src/cpu.ts';
-import {Expr} from '../src/expr.ts';
-import {Module} from '../src/module.ts';
+import {type Expr} from '../src/expr.ts';
+import {type Module} from '../src/module.ts';
 import {Assembler} from '../src/assembler.ts';
-import {Token} from '../src/token.ts';
+import {type Token} from '../src/token.ts';
 import * as Tokens from '../src/token.ts';
 import * as util from '../src/util.ts';
 

--- a/test/cli_test.ts
+++ b/test/cli_test.ts
@@ -7,24 +7,24 @@
 
 import {describe, it, expect} from 'bun:test';
 import {Cli} from '../src/cli.ts'
-import { toHexViewString, toHexString, fromHexString, fromByteString } from "../src/util.ts";
+import { fromHexString, fromByteString } from "../src/util.ts";
 
 describe('CLI', function() {
   describe('STDIN', function() {
     it('should handle `lda #$03`', async function() {
-      const [out, data] = await make(["--target", "sim", "--stdin"], `lda #3`);
+      const [_out, data] = await make(["--target", "sim", "--stdin"], `lda #3`);
       expect(data.length, "output should not be empty").toBeGreaterThan(0);
     });
 
     const bgHexStr = '00 01 02 03';
     const bg = fromHexString(bgHexStr);
     it('should handle `lda #$03` on top of binary `${bgHexStr}`', async function() {
-      const [out, data] = await make(["--target", "sim", "--stdin", "--rom", "dummy"], `lda #3`, bg);
+      const [_out, data] = await make(["--target", "sim", "--stdin", "--rom", "dummy"], `lda #3`, bg);
       expect(data).toEqual(fromHexString('A9 03 02 03'));
     });
 
     it('test IPS patch generation', async function() {
-      const [out, data] = await make(["--target", "sim", "--stdin", "--rom", "dummy", "--ips"], `lda #3`, bg);
+      const [_out, data] = await make(["--target", "sim", "--stdin", "--rom", "dummy", "--ips"], `lda #3`, bg);
       expect(data).toEqual(fromByteString('PATCH\0\0\0\0\x02\xa9\x03EOF'));
     });
   });

--- a/test/define_test.ts
+++ b/test/define_test.ts
@@ -7,7 +7,7 @@
 
 import {describe, it, expect} from 'bun:test';
 import {Define} from '../src/define.ts';
-import {Token} from '../src/token.ts';
+import {type Token} from '../src/token.ts';
 import * as Tokens from '../src/token.ts';
 import {Tokenizer} from '../src/tokenizer.ts';
 import * as util from '../src/util.ts';

--- a/test/expr_test.ts
+++ b/test/expr_test.ts
@@ -6,9 +6,9 @@
  */
 
 import {describe, it, expect} from 'bun:test';
-import {Expr} from '../src/expr.ts';
+import {type Expr} from '../src/expr.ts';
 import * as Exprs from '../src/expr.ts';
-import {Token} from '../src/token.ts';
+import {type Token} from '../src/token.ts';
 import * as Tokens from '../src/token.ts';
 import * as util from '../src/util.ts';
 

--- a/test/integration_test.ts
+++ b/test/integration_test.ts
@@ -11,6 +11,9 @@ import {compile, compileRequest, type AssemblyInput, type FileCallbacks} from '.
 async function compileSource(source: string, filename: string = 'test.s'): Promise<Uint8Array> {
   const input: AssemblyInput = { type: 'source', code: source, name: filename };
   const result = await compile([input], { lineContinuations: true });
+  if (!result.success) {
+    throw new Error(`Expected compile result but got ${JSON.stringify(result)}`);
+  }
   return result.outputs[0].data;
 }
 
@@ -684,6 +687,261 @@ ValidLabel:
       expect(result.success).toBe(false);
       const errors = result.messages.filter(m => m.level === 'error');
       expect(errors.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe('Data & storage directives', function() {
+    it('.charmap remaps .byte-emitted string characters', async function() {
+      const source = `
+.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000
+.org $8000
+.charmap $41, $01
+  .byte "A"
+`;
+      const result = await compileSource(source);
+      expect(Array.from(result)).toEqual([0x01]);
+    });
+
+    it('.asciiz emits the bytes then a terminating NUL', async function() {
+      const source = `
+.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000
+.org $8000
+  .asciiz "hi"
+`;
+      const result = await compileSource(source);
+      expect(Array.from(result)).toEqual([0x68, 0x69, 0x00]);
+    });
+
+    it('.align pads an absolute chunk up to the boundary', async function() {
+      const source = `
+.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000
+.org $8000
+  .byte $01, $02, $03
+  .align $10
+  .byte $ff
+`;
+      const result = await compileSource(source);
+      expect(Array.from(result.slice(0, 3))).toEqual([0x01, 0x02, 0x03]);
+      expect(Array.from(result.slice(3, 16))).toEqual(new Array(13).fill(0));
+      expect(result[16]).toBe(0xff);
+    });
+
+    it('.struct members yield byte offsets and .sizeof reports the total', async function() {
+      const source = `
+.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000
+.org $8000
+.struct Player
+  xpos .byte
+  ypos .byte
+  hp   .word
+.endstruct
+  .byte Player::xpos, Player::ypos, Player::hp, .sizeof(Player)
+`;
+      const result = await compileSource(source);
+      expect(Array.from(result)).toEqual([0, 1, 2, 4]);
+    });
+
+    it('.enum members auto-increment from zero', async function() {
+      const source = `
+.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000
+.org $8000
+.enum
+  CMD_NOP
+  CMD_MOVE
+  CMD_JUMP
+.endenum
+  .byte CMD_NOP, CMD_MOVE, CMD_JUMP
+`;
+      const result = await compileSource(source);
+      expect(Array.from(result)).toEqual([0, 1, 2]);
+    });
+  });
+
+  describe('.strmap encoding', function() {
+    it('maps a single-character key to a single byte', async function() {
+      const source = `
+.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000
+.org $8000
+.strmap "A", $42
+  .byte "A"
+`;
+      const result = await compileSource(source);
+      expect(Array.from(result)).toEqual([0x42]);
+    });
+
+    it('maps a multi-character key to a bracketed multi-byte sequence', async function() {
+      const source = `
+.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000
+.org $8000
+.strmap "the", [1, 2, 3]
+  .byte "the"
+`;
+      const result = await compileSource(source);
+      expect(Array.from(result)).toEqual([1, 2, 3]);
+    });
+
+    it('maps a single character key to a single character output', async function() {
+      const source = `
+.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000
+.org $8000
+.strmap "t", "w"
+  .byte "the"
+`;
+      const result = await compileSource(source);
+      expect(Array.from(result)).toEqual([...'whe'].map(c => c.charCodeAt(0)));
+    });
+
+    it('maps a multi-character key to a multi character output', async function() {
+      const source = `
+.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000
+.org $8000
+.strmap "the", "what"
+  .byte "the"
+`;
+      const result = await compileSource(source);
+      expect(Array.from(result)).toEqual([...'what'].map(c => c.charCodeAt(0)));
+    });
+
+    it('matches the longest registered key, falling back to .charmap/identity for the rest', async function() {
+      const source = `
+.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000
+.org $8000
+.strmap "the", [1, 2, 3]
+.strmap "cat", $09
+  .byte "the cat"
+`;
+      const result = await compileSource(source);
+      expect(Array.from(result)).toEqual([1, 2, 3, 0x20, 9]);
+    });
+
+    it('accepts a non-ASCII Unicode code point as a key', async function() {
+      const source = `
+.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000
+.org $8000
+.strmap "é", $ff
+  .byte "café"
+`;
+      const result = await compileSource(source);
+      expect(Array.from(result)).toEqual([0x63, 0x61, 0x66, 0xff]);
+    });
+
+    it('accepts any constant expression as a byte value, not just a literal', async function() {
+      const source = `
+.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000
+CONST_A = $10
+CONST_B = CONST_A + 1
+.org $8000
+.strmap "x", [CONST_A, CONST_B]
+  .byte "x"
+`;
+      const result = await compileSource(source);
+      expect(Array.from(result)).toEqual([0x10, 0x11]);
+    });
+
+    it('.pushcharmap/.popcharmap save and restore .strmap together with .charmap', async function() {
+      const source = `
+.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000
+.org $8000
+.strmap "AB", $01
+.pushcharmap
+.strmap "AB", $02
+.popcharmap
+  .byte "AB"
+`;
+      const result = await compileSource(source);
+      expect(Array.from(result)).toEqual([0x01]);
+    });
+
+    it('rejects an empty key', async function() {
+      await expectCompileError(`
+.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000
+.org $8000
+.strmap "", $01
+`, '.strmap key must not be empty');
+    });
+
+    it('rejects an unterminated bracketed value list', async function() {
+      await expectCompileError(`
+.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000
+.org $8000
+.strmap "x", [1, 2
+`, '.strmap value list must end with ]');
+    });
+  });
+
+  // Test for ca65 compatible character literal shenanigans
+  describe('character literals', function() {
+    it('encodes a character literal through the charmap in a later .charmap', async function() {
+      const source = `
+.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000
+.org $8000
+.charmap 'a', $20
+.charmap 'b', 'a'
+  .byte "aabbcc"
+`;
+      // 'a' is already $20 when .charmap 'b', 'a' runs, so b maps to $20 too.
+      const result = await compileSource(source);
+      expect(Array.from(result)).toEqual([0x20, 0x20, 0x20, 0x20, 0x63, 0x63]);
+    });
+
+    it('is a number usable in arithmetic and in .word', async function() {
+      const source = `
+.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000
+.org $8000
+.charmap 'a', $20
+  .byte 'a'
+  .byte 'a'+1
+  .word 'a'
+`;
+      const result = await compileSource(source);
+      expect(Array.from(result)).toEqual([0x20, 0x21, 0x20, 0x00]);
+    });
+
+    it('is encoded when assigned to a symbol and when tested in .if', async function() {
+      const source = `
+.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000
+.org $8000
+.charmap 'a', $20
+FOO = 'a'
+  .byte FOO
+.if 'a' = $20
+  .byte $ee
+.else
+  .byte $dd
+.endif
+`;
+      const result = await compileSource(source);
+      expect(Array.from(result)).toEqual([0x20, 0xee]);
+    });
+
+    it('falls back to the raw code point when unmapped', async function() {
+      const source = `
+.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000
+.org $8000
+  .byte 'a'
+`;
+      const result = await compileSource(source);
+      expect(Array.from(result)).toEqual([0x61]);
+    });
+
+    it('keeps double-quoted strings distinct from character literals', async function() {
+      const source = `
+.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000
+.org $8000
+.charmap 'a', $20
+  .byte "a"
+  .byte 'a'
+`;
+      const result = await compileSource(source);
+      expect(Array.from(result)).toEqual([0x20, 0x20]);
+    });
+
+    it('rejects a multi-character single-quoted literal in an expression', async function() {
+      await expectCompileError(`
+.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000
+.org $8000
+  .word 'ab'+1
+`, 'Character literal must be one character');
     });
   });
 });

--- a/test/integration_test.ts
+++ b/test/integration_test.ts
@@ -381,6 +381,52 @@ TestLabel:
     });
   });
 
+  describe('.include resolution', function() {
+    // Only 'inc/' has the file; 'missing/' is searched first so the loop has to fall through.
+    const callbacks = {
+      readText: async (base: string, file: string) => {
+        if (base !== 'inc') throw new Error(`ENOENT ${base}/${file}`);
+        return '.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000\n.org $8000\n';
+      },
+      readBinary: async () => { throw new Error('no binaries in this test'); },
+    };
+
+    it('reports a missing include as an error rather than succeeding silently', async function() {
+      const input: AssemblyInput = { type: 'source', code: '.include "nope.s"\n  nop\n', name: 'test.s' };
+      // generateDebugInfo is what makes the tokenizer stamp source info onto tokens, so it
+      // has to be on for the diagnostic to carry a location (the CLI turns it on by default).
+      const result = await compile([input],
+                                   { includePaths: ['missing'], generateDebugInfo: true },
+                                   callbacks);
+
+      expect(result.success).toBe(false);
+      const errors = result.messages.filter(m => m.level === 'error');
+      expect(errors.length).toBe(1);
+      expect(errors[0].message).toContain('Could not find file nope.s');
+      // The diagnostic points at the .include line, not at the assembler as a whole.
+      expect(errors[0].source?.file).toBe('test.s');
+      expect(errors[0].source?.line).toBe(1);
+    });
+
+    it('falls through to later include directories', async function() {
+      const input: AssemblyInput = { type: 'source', code: '.include "found.s"\n  nop\n', name: 'test.s' };
+      const result = await compile([input], { includePaths: ['missing', 'inc'] }, callbacks);
+
+      expect(result.messages.filter(m => m.level === 'error')).toEqual([]);
+      expect(result.success).toBe(true);
+    });
+
+    it('keeps diagnostics collected before the failure', async function() {
+      const source = '.warning "earlier warning"\n.include "nope.s"\n';
+      const input: AssemblyInput = { type: 'source', code: source, name: 'test.s' };
+      const result = await compile([input], { includePaths: ['missing'] }, callbacks);
+
+      expect(result.success).toBe(false);
+      expect(result.messages.filter(m => m.level === 'warning').map(m => m.message))
+          .toEqual(['earlier warning']);
+    });
+  });
+
   describe('Multi-error collection', function() {
     it('should collect multiple assembly errors from different lines', async function() {
       const source = `

--- a/test/integration_test.ts
+++ b/test/integration_test.ts
@@ -6,7 +6,7 @@
  */
 
 import {describe, it, expect} from 'bun:test';
-import {compile, compileRequest, type AssemblyInput} from '../src/libassembler.ts';
+import {compile, compileRequest, type AssemblyInput, type FileCallbacks} from '../src/libassembler.ts';
 
 async function compileSource(source: string, filename: string = 'test.s'): Promise<Uint8Array> {
   const input: AssemblyInput = { type: 'source', code: source, name: filename };
@@ -50,6 +50,39 @@ async function expectCompileError(source: string, errorMatch?: string | RegExp):
   }
 
   return new Error(errorMessages);
+}
+
+// Simple mock filesystem for testing path resolution
+function normalize(p: string): string {
+  const out: string[] = [];
+  for (const part of p.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..' && out.length && out[out.length - 1] !== '..') out.pop();
+    else out.push(part);
+  }
+  return out.join('/');
+}
+function resolve(base: string, rel: string): string {
+  return normalize(base ? `${base}/${rel}` : rel);
+}
+
+function makeFs(text: Record<string, string>, bin: Record<string, number[]> = {}): FileCallbacks {
+  return {
+    readText: async (base, rel) => {
+      const key = resolve(base, rel);
+      if (!(key in text)) throw new Error(`ENOENT ${key}`);
+      return text[key];
+    },
+    readBinary: async (base, rel) => {
+      const key = resolve(base, rel);
+      if (!(key in bin)) throw new Error(`ENOENT ${key}`);
+      return new Uint8Array(bin[key]);
+    },
+  };
+}
+
+async function asmObject(input: AssemblyInput, opts: Parameters<typeof compile>[1], fs: FileCallbacks) {
+  return compile([input], {...opts, outputFormat: 'object'}, fs);
 }
 
 describe('End to end test cases', function() {
@@ -424,6 +457,51 @@ TestLabel:
       expect(result.success).toBe(false);
       expect(result.messages.filter(m => m.level === 'warning').map(m => m.message))
           .toEqual(['earlier warning']);
+    });
+    it('resolves nested .include relative to the including file', async () => {
+      const fs = makeFs({
+        'prg/sub/inner.inc': '.include "leaf.inc"\n',
+        'prg/sub/leaf.inc': 'lda #1\n',
+      });
+      const result = await asmObject(
+        {type: 'source', code: '.include "sub/inner.inc"\n', name: 'prg/stub.s'},
+        {}, fs);
+      expect(result.messages.filter(m => m.level === 'error')).toEqual([]);
+      expect(result.success).toBe(true);
+    });
+
+    it('falls through every -I directory, not just the first', async () => {
+      const fs = makeFs({ 'inc2/common.inc': 'lda #2\n' });
+      const result = await asmObject(
+        {type: 'source', code: '.include "common.inc"\n', name: 'main.s'},
+        {includePaths: ['inc1', 'inc2']}, fs);
+      expect(result.messages.filter(m => m.level === 'error')).toEqual([]);
+      expect(result.success).toBe(true);
+    });
+
+    it('uses --bin-include-dir (binIncludePaths) for .incbin', async () => {
+      const fs = makeFs(
+        {},
+        { 'art/data.bin': [0xAA, 0xBB, 0xCC] });
+      const result = await asmObject(
+        {type: 'source', code: '.incbin "data.bin"\n', name: 'main.s'},
+        {binIncludePaths: ['art']}, fs);
+      expect(result.messages.filter(m => m.level === 'error')).toEqual([]);
+      expect(result.success).toBe(true);
+      const mod = JSON.parse(new TextDecoder().decode(result.outputs[0].data));
+      // The three bytes should land in the module's data as base64 of AA BB CC.
+      const b64 = Buffer.from([0xAA, 0xBB, 0xCC]).toString('base64');
+      const found = (mod.chunks ?? []).some((c: {data?: string}) => c.data === b64);
+      expect(found).toBe(true);
+    });
+
+    it('reports the search list when a file is genuinely missing', async () => {
+      const fs = makeFs({});
+      const result = await asmObject(
+        {type: 'source', code: '.include "nope.inc"\n', name: 'main.s'},
+        {includePaths: ['a', 'b']}, fs);
+      expect(result.success).toBe(false);
+      expect(result.messages.some(m => /Could not find file nope\.inc/.test(m.message))).toBe(true);
     });
   });
 

--- a/test/integration_test.ts
+++ b/test/integration_test.ts
@@ -757,6 +757,138 @@ ValidLabel:
     });
   });
 
+  describe('ca65 syntax compatibility', function() {
+    it(':= assigns a constant like =', async function() {
+      const source = `
+.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000
+.org $8000
+FOO := 5
+  .byte FOO
+`;
+      const result = await compileSource(source);
+      expect(Array.from(result)).toEqual([5]);
+    });
+
+    it('accepts zeropage as an alias for the zp segment attribute', async function() {
+      const source = `
+.segment "ZP" :bank $00 :size $0100 :mem $0000 :off $0000 : zeropage
+.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0100
+.org $8000
+  .byte $42
+`;
+      const result = await compileSource(source);
+      expect(result[0x100]).toBe(0x42);
+    });
+
+    it('rejects an unknown segment attribute', async function() {
+      await expectCompileError(`
+.segment "ZP" :bank $00 :size $0100 :mem $0000 :off $0000 : nonsense
+`, 'Unknown segment attr');
+    });
+  });
+
+  describe('Directive recognition', function() {
+    it('.code / .rodata / .bss switch to the named segment', async function() {
+      const source = `
+.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000
+.segment "RODATA" :bank $00 :size $0100 :mem $9000 :off $1000
+.code
+.org $8000
+  .byte $11
+.rodata
+.org $9000
+  .byte $22
+`;
+      const result = await compileSource(source);
+      expect(result[0]).toBe(0x11);
+      expect(result[0x1000]).toBe(0x22);
+    });
+
+    it('.export inside a .scope binds to that scope', async function() {
+      const lib: AssemblyInput = {
+        type: 'source',
+        name: 'lib.s',
+        code: `
+.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000
+.org $8100
+.scope BHOP
+.export play
+.proc play
+  rts
+.endproc
+.endscope
+`
+      };
+      const main: AssemblyInput = {
+        type: 'source',
+        name: 'main.s',
+        code: `
+.segment "CODE"
+.import play
+.org $8000
+  jsr play
+`
+      };
+      const result = await compile([main, lib], { lineContinuations: true });
+      expect(result.success).toBe(true);
+      const data = result.outputs[0].data;
+      expect(data[0]).toBe(0x20); // JSR resolved, no "undefined symbol"
+    });
+
+    it('.importzp sizes references to one byte', async function() {
+      const zp: AssemblyInput = {
+        type: 'source',
+        name: 'zp.s',
+        code: `
+.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000
+.exportzp Var
+Var = $10
+`
+      };
+      const main: AssemblyInput = {
+        type: 'source',
+        name: 'main.s',
+        code: `
+.segment "CODE"
+.importzp Var
+.org $8000
+  lda Var
+`
+      };
+      const result = await compile([main, zp], { lineContinuations: true });
+      expect(result.success).toBe(true);
+      expect(Array.from(result.outputs[0].data.slice(0, 2))).toEqual([0xa5, 0x10]);
+    });
+
+    it('.global becomes an export when defined and an import when not', async function() {
+      const lib: AssemblyInput = {
+        type: 'source',
+        name: 'lib.s',
+        code: `
+.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000
+.global Helper
+.org $8100
+Helper:
+  rts
+`
+      };
+      const main: AssemblyInput = {
+        type: 'source',
+        name: 'main.s',
+        code: `
+.segment "CODE"
+.global Helper
+.org $8000
+  jsr Helper
+`
+      };
+      const result = await compile([main, lib], { lineContinuations: true });
+      expect(result.success).toBe(true);
+      const data = result.outputs[0].data;
+      expect(Array.from(data.slice(0, 3))).toEqual([0x20, 0x00, 0x81]);
+    });
+  });
+
   describe('.strmap encoding', function() {
     it('maps a single-character key to a single byte', async function() {
       const source = `

--- a/test/linker_test.ts
+++ b/test/linker_test.ts
@@ -6,7 +6,7 @@
  */
 
 import {describe, it, expect} from 'bun:test';
-import {Expr} from '../src/expr.ts';
+import {type Expr} from '../src/expr.ts';
 import {Linker} from '../src/linker.ts';
 import * as util from '../src/util.ts';
 

--- a/test/macro_test.ts
+++ b/test/macro_test.ts
@@ -7,7 +7,7 @@
 
 import {describe, it, expect} from 'bun:test';
 import {Macro} from '../src/macro.ts';
-import {Token} from '../src/token.ts';
+import {type Token} from '../src/token.ts';
 import {Tokenizer} from '../src/tokenizer.ts';
 import * as util from '../src/util.ts';
 

--- a/test/mlb_test.ts
+++ b/test/mlb_test.ts
@@ -6,7 +6,7 @@
  */
 
 import {describe, it, expect} from 'bun:test';
-import {MesenLabelFormat} from '../src/linker.ts';
+import {type MesenLabelFormat} from '../src/linker.ts';
 import {compile} from '../src/libassembler.ts';
 
 async function assembleAndGetDebugInfo(source: string, filename: string = 'test.s', debugLevel: number = 0): Promise<MesenLabelFormat[]> {

--- a/test/preprocessor_test.ts
+++ b/test/preprocessor_test.ts
@@ -490,6 +490,66 @@ describe('Preprocessor', function() {
     // });
   });
 
+  describe('.left/.right/.mid', function() {
+    it('should take the leftmost tokens', async function() {
+      await test(['a .left(1, {a b c})'], await instruction('a a'));
+    });
+
+    it('should take the rightmost tokens', async function() {
+      await test(['a .right(2, {a b c})'], await instruction('a b c'));
+    });
+
+    it('should take a slice from the middle', async function() {
+      await test(['a .mid(1, 1, {a b c})'], await instruction('a b'));
+    });
+  });
+
+  describe('.match/.xmatch', function() {
+    it('should match identical raw tokens', async function() {
+      await test(['a .match(#, #)'], await instruction('a 1'));
+    });
+
+    it('should not match different tokens', async function() {
+      await test(['a .match(x, 0)'], await instruction('a 0'));
+    });
+
+    it('.match should treat all identifiers as equal', async function() {
+      await test(['a .match(x, y)'], await instruction('a 1'));
+    });
+
+    it('.xmatch should require identical identifier names', async function() {
+      await test(['a .xmatch(a, b)'], await instruction('a 0'));
+    });
+  });
+
+  describe('.if short-circuit', function() {
+    it('should not evaluate the right side of .and when the left side is false', async function() {
+      await test(['.if .defined(fwd) .and (fwd)',
+            'nope',
+            '.else',
+            'yep',
+            '.endif'],
+           await instruction('yep'));
+    });
+
+    it('should not evaluate the right side of .or when the left side is true', async function() {
+      await test(['.if 1 .or (fwd)',
+            'yep',
+            '.else',
+            'nope',
+            '.endif'],
+           await instruction('yep'));
+    });
+    it('should not evaluate the right side of .or when the middle arg is true, checking left to right', async function() {
+      await test(['.if 0 .or 1 .or (fwd)',
+            'yep',
+            '.else',
+            'nope',
+            '.endif'],
+           await instruction('yep'));
+    });
+  });
+
   // TODO - test .local, both for symbols AND for defines.
 
   // TODO - tests for .if, make sure it evaluates numbers, etc...

--- a/test/token_test.ts
+++ b/test/token_test.ts
@@ -6,7 +6,7 @@
  */
 
 import {describe, it, expect} from 'bun:test';
-import { Token } from '../src/token.ts';
+import { type Token } from '../src/token.ts';
 import * as Tokens from '../src/token.ts';
 
 const {LP, LB, RP, RB} = Tokens;

--- a/test/tokenizer_test.ts
+++ b/test/tokenizer_test.ts
@@ -16,6 +16,21 @@ import { TokenStream } from '../src/tokenstream.ts';
 
 const [_] = [util];
 
+// Validate that the error has the proper source info on it
+async function expectSourceError(promise: Promise<unknown>, message: RegExp,
+                                 line: number, column: number) {
+  let err: unknown;
+  try {
+    await promise;
+  } catch (e) {
+    err = e;
+  }
+  expect(err).toBeInstanceOf(Tokens.SourceError);
+  expect((err as Error).message).toMatch(message);
+  expect((err as Tokens.SourceError).source)
+      .toMatchObject({file: 'input.s', line, column});
+}
+
 //const MATCH = Symbol();
 
 async function tokenize(str: string, opts: Options = {}): Promise<Token[][]> {
@@ -240,31 +255,31 @@ describe('Tokenizer.line', function() {
     ]);
   });
 
-  it('should fail to parse a bad hex number', function() {
-    expect(tokenize('  adc $1g')).rejects.toThrow(/Bad hex number.*at input.s:1:6 near '\$1g'/s);
+  it('should fail to parse a bad hex number', async function() {
+    await expectSourceError(tokenize('  adc $1g'), /Bad hex number.*near '\$1g'/s, 1, 6);
   });
 
-  it('should fail to parse a bad decimal number', function() {
-    expect(tokenize('  12a')).rejects.toThrow(/Bad decimal.*at input.s:1:2 near '12a'/s);
+  it('should fail to parse a bad decimal number', async function() {
+    await expectSourceError(tokenize('  12a'), /Bad decimal.*near '12a'/s, 1, 2);
   });
 
-  it('should fail to parse a bad octal number', function() {
-    expect(tokenize('  018')).rejects.toThrow(/Bad octal.*at input.s:1:2 near '018'/s);
+  it('should fail to parse a bad octal number', async function() {
+    await expectSourceError(tokenize('  018'), /Bad octal.*near '018'/s, 1, 2);
   });
 
-  it('should fail to parse a bad binary number', function() {
-    expect(tokenize('  %012')).rejects.toThrow(/Bad binary.*at input.s:1:2 near '%012'/s);
+  it('should fail to parse a bad binary number', async function() {
+    await expectSourceError(tokenize('  %012'), /Bad binary.*near '%012'/s, 1, 2);
   });
 
-  it('should fail to parse a bad character', function() {
-    expect(tokenize('  `abc')).rejects.toThrow(/Syntax error.*at input.s:1:2/s);
+  it('should fail to parse a bad character', async function() {
+    await expectSourceError(tokenize('  `abc'), /Syntax error/s, 1, 2);
   });
 
   it('should fail to parse a bad string', function() {
     expect(tokenize('  "abc')).rejects.toThrow(/EOF while looking for "/);
   });
 
-  it('should not parse .2 as a directive', function() {
-    expect(tokenize(' .2')).rejects.toThrow(/Syntax error.*at input.s:1:1/s);
+  it('should not parse .2 as a directive', async function() {
+    await expectSourceError(tokenize(' .2'), /Syntax error/s, 1, 1);
   });
 });

--- a/test/tokenizer_test.ts
+++ b/test/tokenizer_test.ts
@@ -8,9 +8,9 @@
 import {describe, it, expect} from 'bun:test';
 
 import { Base64 } from '../src/base64.ts';
-import { Token } from '../src/token.ts';
+import { type Token } from '../src/token.ts';
 import * as Tokens from '../src/token.ts';
-import {Tokenizer, Options} from '../src/tokenizer.ts';
+import {Tokenizer, type Options} from '../src/tokenizer.ts';
 import * as util from '../src/util.ts';
 import { TokenStream } from '../src/tokenstream.ts';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "extends": "./tsconfig.base.json",
     "compilerOptions": {
         "module": "es2022",
-        "target": "es2020",
+        "target": "es2022",
         "types": ["bun", "node"],
     },
     "include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,12 @@
 {
     "extends": "./tsconfig.base.json",
     "compilerOptions": {
-        "rootDir": "src/",
         "module": "es2022",
         "target": "es2020",
         "types": ["bun", "node"],
     },
     "include": [
-        "src/**/*.ts"
+        "src/**/*.ts",
+        "test/**/*.ts"
     ],
 }


### PR DESCRIPTION
Each commit is self contained (except charmapping and structs :p) and adds several CA65 compatibility fixes.

* Error tracking makes the error output look better for CLI. Updates all the places in the assembler that throws errors so they report error messages better and then the CLI makes it look pretty.
```
file.s:1:6: error: Unknown prefix operator: #
 1 | lda ##1
   |      ^
1 error generated.
```

* Fixed up include path and add `--bin-include-dir` like ca65
* Added `.if` constant shortcircuiting and added `.left/right/mid/match/xmatch` for token matching.
* struct/enum/union "start/end" blocks
* Char/str mapping. Charmapping works like ca65 and maps 1 byte to 1 byte, but strmapping allows for N bytes to M bytes (which effectively superscedes charmapping, but charmap is kept for ca65 compat) This change involves a somewhat invasive change since the ca65 charmapping applies to any characters in any location like in math equations or in directives.
* Add a buncha import/export fixes.
* Filled in a buncha meta directives to do nothing for now. (like .autoimport and .fileopt or such)