### PR TITLE
Ca65 compat reloaded redux recharged (part 3 of ??? hopefully 4?)

### DIFF
--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -946,6 +946,7 @@ export class Assembler {
         case '.out': return this.log('info', tokens);
         case '.warning': return this.log('warn', tokens);
         case '.error': return this.log('error', tokens);
+        case '.fatal': return this.log('error', tokens, true);
 
         case '.a8':
         case '.i8':
@@ -1785,10 +1786,14 @@ export class Assembler {
     this.append({op: '.move', args: [source], meta: {size}}, size);
   }
 
-  log(level: 'info'|'warn'|'error', line: Token[]) {
+  log(level: 'info'|'warn'|'error', line: Token[], fatal = false) {
     const str = Tokens.expectString(line[1], line[0]);
     Tokens.expectEol(line[2], 'a single string');
     const source = line[0].source;
+
+    // Don't add the error to the error collector if its from `.fatal`
+    // since its unrecoverable.
+    if (fatal) throw new Tokens.SourceError(str, source);
 
     // Map 'warn' to 'warning' for ErrorLevel
     const errorLevel: ErrorLevel = level === 'warn' ? 'warning' : level;

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -906,6 +906,7 @@ export class Assembler {
         case '.bytestr': return this.byteInternal(this.parseByteStr(tokens));
         case '.res': return this.res(...this.parseResArgs(tokens));
         case '.word': return this.word(...this.parseDataList(tokens));
+        case '.dbyt': return this.dbyte(...this.parseDataList(tokens));
         case '.dword': return this.dword(...this.parseDataList(tokens));
         case '.free': return this.free(this.parseConst(tokens, 1));
         case '.segmentprefix': return this.segmentPrefix(this.parseStr(tokens, 1));
@@ -1586,6 +1587,29 @@ export class Assembler {
         this.writeNumber(chunk.data, 2, arg);
       } else {
         this.append(arg, 2);
+      }
+    }
+  }
+
+  // `.dbyt` is a big-endian word, but substitutions only work in little endian.
+  // So we need to split this into a `.hiByte` and `.loByte` pair if this is
+  // a forward reference that will be substituted in later.
+  dbyte(...args: Array<Expr|number>) {
+    const {chunk} = this;
+    this.markWritten(2 * args.length);
+
+    for (const arg of args) {
+      // Record source info for each byte of the word (2 bytes)
+      if (this.opts.generateDebugInfo && this._chunk?.sourceMap && this._source) {
+        this._chunk.sourceMap.set(chunk.data.length, this._source);
+        this._chunk.sourceMap.set(chunk.data.length + 1, this._source);
+      }
+      if (typeof arg === 'number') {
+        this.writeNumber(chunk.data, 1, arg >> 8);
+        this.writeNumber(chunk.data, 1, arg);
+      } else {
+        this.append(Exprs.hiByte(arg), 1);
+        this.append(Exprs.loByte(arg), 1);
       }
     }
   }

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -906,6 +906,7 @@ export class Assembler {
         case '.bytestr': return this.byteInternal(this.parseByteStr(tokens));
         case '.res': return this.res(...this.parseResArgs(tokens));
         case '.word': return this.word(...this.parseDataList(tokens));
+        case '.dword': return this.dword(...this.parseDataList(tokens));
         case '.free': return this.free(this.parseConst(tokens, 1));
         case '.segmentprefix': return this.segmentPrefix(this.parseStr(tokens, 1));
         case '.import': return this.import(...this.parseIdentifierList(tokens));
@@ -1585,6 +1586,25 @@ export class Assembler {
         this.writeNumber(chunk.data, 2, arg);
       } else {
         this.append(arg, 2);
+      }
+    }
+  }
+
+  dword(...args: Array<Expr|number>) {
+    const {chunk} = this;
+    this.markWritten(4 * args.length);
+
+    for (const arg of args) {
+      // Record source info for each byte of the dword (4 bytes)
+      if (this.opts.generateDebugInfo && this._chunk?.sourceMap && this._source) {
+        for (let i = 0; i < 4; i++) {
+          this._chunk.sourceMap.set(chunk.data.length + i, this._source);
+        }
+      }
+      if (typeof arg === 'number') {
+        this.writeNumber(chunk.data, 4, arg);
+      } else {
+        this.append(arg, 4);
       }
     }
   }

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -904,6 +904,7 @@ export class Assembler {
         case '.hibytes': return this.byte(...this.parseDataList(tokens).map(e => Exprs.hiByte(e)));
         case '.lobytes': return this.byte(...this.parseDataList(tokens).map(e => Exprs.loByte(e)));
         case '.bytestr': return this.byteInternal(this.parseByteStr(tokens));
+        case '.literal': return this.byteInternal(this.parseDataList(tokens, true), new Map());
         case '.res': return this.res(...this.parseResArgs(tokens));
         case '.word': return this.word(...this.parseDataList(tokens));
         case '.dbyt': return this.dbyte(...this.parseDataList(tokens));
@@ -1535,7 +1536,10 @@ export class Assembler {
     this.charMapping.set(key, bytes.map(b => b & 0xff));
   }
 
-  byteInternal(args: Array<Expr|string|number>) {
+  // the `charMap` parameter defaults to the current charMap, but for `.literal`
+  // we pass in an empty map to disable the charMapping for this string.
+  byteInternal(args: Array<Expr|string|number>,
+               charmap: Map<string, number[]> = this.charMapping) {
     const {chunk} = this;
     this.markWritten(args.length);
 
@@ -1557,7 +1561,7 @@ export class Assembler {
             this._chunk.sourceMap.set(chunk.data.length + i, this._source);
           }
         }
-        writeString(chunk.data, arg, this.charMapping);
+        writeString(chunk.data, arg, charmap);
       } else {
         // Record source info before append (which writes 1 byte)
         if (this.opts.generateDebugInfo && this._chunk?.sourceMap && this._source) {

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -27,6 +27,14 @@ function isSizeOfSymbol(name: string): boolean {
   return name === SIZE_NAME || name.endsWith(SIZE_SUFFIX);
 }
 
+/**
+ * List of CPUs that we support. 
+ * We aren't very strict about the difference between 6502 and 6502x.
+ */
+const SUPPORTED_CPUS = new Set(['6502', '6502x']);
+
+const DEFAULT_CPU_NAME = '6502';
+
 export class Symbol {
   /**
    * Index into the global symbol array.  Only applies to immutable
@@ -277,6 +285,12 @@ export class Assembler {
   private charMapping = new Map<string, number[]>();
   /** Saved charmaps for `.pushcharmap`/`.popcharmap`. */
   private charmapStack: Array<Map<string, number[]>> = [];
+
+  /**
+   * We don't have any CPUs to switch to, so this is just there to make sure the
+   * .push/.popcpus match.
+   */
+  private cpuStack: string[] = [];
 
   /** The current scope. */
   private currentScope = new Scope();
@@ -927,6 +941,9 @@ export class Assembler {
           void this.charmapStack.push(new Map(this.charMapping));
         case '.popcharmap': return this.parseNoArgs(tokens, 1),
           void (this.charMapping = this.charmapStack.pop() ?? this.charMapping);
+        case '.setcpu': return this.setCpu(this.parseStr(tokens, 1));
+        case '.pushcpu': return this.parseNoArgs(tokens, 1), this.pushCpu();
+        case '.popcpu': return this.parseNoArgs(tokens, 1), this.popCpu();
         case '.asciiz': return this.asciiz(...this.parseDataList(tokens, true));
         case '.align': return this.alignDir(tokens);
         case '.struct': return this.beginStruct(tokens, 'struct');
@@ -963,17 +980,20 @@ export class Assembler {
         case '.rodata': return this.parseNoArgs(tokens, 1), this.segment('RODATA');
         case '.bss': return this.parseNoArgs(tokens, 1), this.segment('BSS');
 
-        // Unused directives we can figure out what to do with later.
-        case '.setcpu':
-        case '.feature':
-        case '.autoimport':
-        case '.case':
+        // Directives js65 accepts and deliberately ignores, because the thing
+        // they configure either doesn't exist yet or isn't configurable yet.
+        // These should probably be fixed at some point.
+        case '.list':
         case '.listbytes':
         case '.pagelength':
         case '.fileopt':
-        case '.localchar':
-        case '.linecont':
         case '.debuginfo':
+        case '.linecont':
+        case '.localchar':
+        case '.case':
+        case '.feature':
+        case '.autoimport':
+        // Probably not going to add these.
         case '.condes':
         case '.constructor':
         case '.destructor':
@@ -1780,6 +1800,21 @@ export class Assembler {
     if (!this.segmentStack.length) this.fail(`.popseg without .pushseg`);
     [this.segments, this._chunk] = this.segmentStack.pop()!;
     this._org = this._chunk?.org;
+  }
+
+  setCpu(name: string) {
+    if (!SUPPORTED_CPUS.has(name.toLowerCase())) {
+      this.fail(`Unsupported CPU: ${name}`);
+    }
+  }
+
+  pushCpu() {
+    this.cpuStack.push(DEFAULT_CPU_NAME);
+  }
+
+  popCpu() {
+    if (!this.cpuStack.length) this.fail(`.popcpu without .pushcpu`);
+    this.cpuStack.pop();
   }
 
   move(size: number, source: Expr) {

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -425,6 +425,10 @@ export class Assembler {
     return s != null; // NOTE: this counts definitions.
   }
 
+  isMnemonic(name: string): boolean {
+    return name.toLowerCase() in this.cpu.table;
+  }
+
   evaluate(expr: Expr): number|undefined {
     expr = this.resolve(expr);
     if (expr.op === 'num' && !expr.meta?.rel) return expr.num;

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -334,6 +334,9 @@ export class Assembler {
   /** Token for reporting errors. */
   private errorToken?: Token;
 
+  /** Flag set by `.end` directive to kill the rest of the file processing. */
+  private ended = false;
+
   /** Collector for errors and messages */
   readonly errorCollector = new ErrorCollector();
 
@@ -877,7 +880,8 @@ export class Assembler {
   // (compile) turns into an ordinary failure result.
   async tokens(source: Tokens.Source, signal?: { readonly aborted: boolean }) {
     let line;
-    while ((line = await source.next())) {
+    // The `ended` check comes before `next()` so that nothing past `.end` is even tokenized.
+    while (!this.ended && (line = await source.next())) {
       if (signal?.aborted) throw new Error('Compilation cancelled');
       await this.line(line);
     }
@@ -938,6 +942,7 @@ export class Assembler {
         case '.pushseg': return this.pushSeg(...this.parseSegmentList(tokens, 1, true));
         case '.popseg': return this.parseNoArgs(tokens, 1), this.popSeg();
         case '.move': return this.move(...this.parseMoveArgs(tokens));
+        case '.end': return this.parseNoArgs(tokens, 1), void (this.ended = true);
         case '.out': return this.log('info', tokens);
         case '.warning': return this.log('warn', tokens);
         case '.error': return this.log('error', tokens);

--- a/src/expr.ts
+++ b/src/expr.ts
@@ -124,8 +124,8 @@ export function evaluate(expr: Expr): Expr {
         return {op: 'num', num: expr.num! + meta.org!, meta};
       }
       return expr;
-    case '.max': return sameChunk(expr, Math.max);
-    case '.min': return sameChunk(expr, Math.min);
+    case '.max': return varArg(expr, Math.max);
+    case '.min': return varArg(expr, Math.min);
     default: // fall through to later checks
   }
 
@@ -138,7 +138,13 @@ export function evaluate(expr: Expr): Expr {
       case '!': return unary(expr, x => +!x);
       case '<': return unary(expr, x => x & 0xff);
       case '>': return unary(expr, x => (x >> 8) & 0xff);
-      case '^': return num(expr.args![0].meta?.bank) ?? expr;
+      case '^': {
+        // Minor diff between js65, but if you use `^` on an addr instead of
+        // a number, then we load the `.bank` value instead of the upper bits
+        // 16-23 of the number like ca65 .bankbyte
+        const bank = num(expr.args![0].meta?.bank);
+        return bank ?? unary(expr, x => (x >>> 16) & 0xff);
+      }
       case '.sizeof': {
         const arg = expr.args![0];
         return arg.op === 'sym' ? expr : arg;
@@ -177,22 +183,29 @@ export function evaluate(expr: Expr): Expr {
     case '+': return plus(expr);
     case '-': return minus(expr);
     case '*': return binary(expr, (a, b) => a * b);
-    case '/': return binary(expr, (a, b) => Math.floor(a / b));
-    case '.mod': return binary(expr, (a, b) => a % b);
+    case '/': return binary(expr, (a, b) => {
+      if (b === 0) throw new Error('Division by zero');
+      return Math.trunc(a / b); // ca65 truncates toward zero
+    });
+    case '.mod': return binary(expr, (a, b) => {
+      if (b === 0) throw new Error('Modulo operation with zero');
+      return a % b;
+    });
     case '&': return binary(expr, (a, b) => a & b);
     case '|': return binary(expr, (a, b) => a | b);
     case '^': return binary(expr, (a, b) => a ^ b);
-    case '<<': return binary(expr, (a, b) => a << b);
-    case '>>': return binary(expr, (a, b) => a >>> b);
+    case '<<': return binary(expr, shift((a, b) => a << b));
+    case '>>': return binary(expr, shift((a, b) => a >>> b));
     case '<': return binary(expr, (a, b) => +(a < b));
     case '<=': return binary(expr, (a, b) => +(a <= b));
     case '>': return binary(expr, (a, b) => +(a > b));
     case '>=': return binary(expr, (a, b) => +(a >= b));
     case '=': return binary(expr, (a, b) => +(a == b));
     case '<>': return binary(expr, (a, b) => +(a != b));
-    case '&&': return binary(expr, (a, b) => a && b);
-    case '||': return binary(expr, (a, b) => a || b);
-    case '.xor': return binary(expr, (a, b) => !a && b || !b && a || 0);
+    // The boolean operators always reduce to 0 or 1, never to an operand.
+    case '&&': return binary(expr, (a, b) => +(!!a && !!b));
+    case '||': return binary(expr, (a, b) => +(!!a || !!b));
+    case '.xor': return binary(expr, (a, b) => +(!!a !== !!b));
     case '.strat': {
       const [s, idx] = expr.args!;
       if (s.op !== 'str') throw new Error('.strat requires a string literal');
@@ -491,10 +504,14 @@ export function parse(tokens: Token[], index = 0, symbols?: Map<string, Symbol>,
 }
 
 
-// works on absolute numbers, or relative numbers if all in same chunk.
-// may not mix relative + absolute.
-function sameChunk(_expr: Expr, _f: (...nums: number[]) => number): Expr {
-  throw new Error();
+/** ca65 evaluates expressions as signed 32-bit integers, so we do too. */
+function i32(x: number): number {
+  return x | 0;
+}
+
+/** Wrap the shift so that counts outside 0..31 produce 0. */
+function shift(f: (x: number, n: number) => number): (x: number, n: number) => number {
+  return (x, n) => (n >>> 0) >= 32 ? 0 : f(x, n);
 }
 
 function num(num: number|undefined): Expr|undefined {
@@ -506,7 +523,7 @@ function unary(expr: Expr, f: (x: number) => number): Expr {
   // require absolute
   const arg = expr.args![0];
   if (!isAbs(arg)) return expr;
-  const num = f(arg.num!);
+  const num = i32(f(i32(arg.num!)));
   return {op: 'num', num, meta: size(num)};
 }
 
@@ -514,7 +531,15 @@ function binary(expr: Expr, f: (x: number, y: number) => number): Expr {
   // require both to be absolute
   const [a, b] = expr.args!;
   if (!isAbs(a) || !isAbs(b)) return expr;
-  const num = f(a.num!, b.num!);
+  const num = i32(f(i32(a.num!), i32(b.num!)));
+  return {op: 'num', num, meta: size(num)};
+}
+
+/** `.max`/`.min`: works on absolute numbers only. */
+function varArg(expr: Expr, f: (...nums: number[]) => number): Expr {
+  const args = expr.args!;
+  if (!args.length || !args.every(isAbs)) return expr;
+  const num = i32(f(...args.map(a => i32(a.num!))));
   return {op: 'num', num, meta: size(num)};
 }
 
@@ -590,51 +615,58 @@ function compareOp(top: OperatorMeta, next: OperatorMeta): number {
 type OperatorMeta = readonly [number, number, number];
 const BINARY = 2;
 const UNARY = 1;
+
+// Precedence follows ca65's table in section 5.5 of its manual.
+// The numbers here are opposite of what ca65 uses, but that is fine as long
+// as they are the same relative to each other.
+const LEFT = 1;
+const RIGHT = -1;
 export const BINOPS = new Map<string, OperatorMeta>([
   // Scoping operator
-  // ['::', [8, 1, BINARY]],
+  // ['::', [8, LEFT, BINARY]],
   // Memory hints
   //[':', [6, 0]],
-  // Multiplicative operators: note that bitwise and arithmetic cannot associate
-  ['*', [5, 4, BINARY]],
-  ['/', [5, 4, BINARY]],
-  ['.mod', [5, 3, BINARY]],
-  ['&', [5, 2, BINARY]],
-  ['^', [5, 1, BINARY]],
-  ['<<', [5, 0, BINARY]],
-  ['>>', [5, 0, BINARY]],
-  // Arithmetic operators: note that bitwise and arithmetic cannot associate
-  ['+', [4, 2, BINARY]],
-  ['-', [4, 2, BINARY]],
-  ['|', [4, 1, BINARY]],
+  // Multiplicative and bitwise operators
+  ['*', [6, LEFT, BINARY]],
+  ['/', [6, LEFT, BINARY]],
+  ['.mod', [6, LEFT, BINARY]],
+  ['&', [6, LEFT, BINARY]],
+  ['^', [6, LEFT, BINARY]],
+  ['<<', [6, LEFT, BINARY]],
+  ['>>', [6, LEFT, BINARY]],
+  // Arithmetic operators
+  ['+', [5, LEFT, BINARY]],
+  ['-', [5, LEFT, BINARY]],
+  ['|', [5, LEFT, BINARY]],
   // Comparison operators
-  ['<', [3, 0, BINARY]],
-  ['<=', [3, 0, BINARY]],
-  ['>', [3, 0, BINARY]],
-  ['>=', [3, 0, BINARY]],
-  ['=', [3, 0, BINARY]],
-  ['<>', [3, 0, BINARY]],
-  // Logical operators: different kinds cannot associate
-  ['&&', [2, 3, BINARY]],
-  ['.xor', [2, 2, BINARY]],
-  ['||', [2, 1, BINARY]],
+  ['<', [4, LEFT, BINARY]],
+  ['<=', [4, LEFT, BINARY]],
+  ['>', [4, LEFT, BINARY]],
+  ['>=', [4, LEFT, BINARY]],
+  ['=', [4, LEFT, BINARY]],
+  ['<>', [4, LEFT, BINARY]],
+  // Boolean and/xor have more precedence than boolean or
+  ['&&', [3, LEFT, BINARY]],
+  ['.xor', [3, LEFT, BINARY]],
+  ['||', [2, LEFT, BINARY]],
   // Comma
   //[',', [1, 1]],
 ]);
 
 const PREFIXOPS = new Map<string, OperatorMeta>([
-  // ['::', [9, -1, UNARY]], // global scope
-  ['+', [9, -1, UNARY]],
-  ['-', [9, -1, UNARY]],
-  ['~', [9, -1, UNARY]],
-  ['<', [9, -1, UNARY]],
-  ['>', [9, -1, UNARY]],
-  ['^', [9, -1, UNARY]],
-  ['!', [2, -1, UNARY]],
+  // ['::', [7, RIGHT, UNARY]], // global scope
+  ['+', [7, RIGHT, UNARY]],
+  ['-', [7, RIGHT, UNARY]],
+  ['~', [7, RIGHT, UNARY]],
+  ['<', [7, RIGHT, UNARY]],
+  ['>', [7, RIGHT, UNARY]],
+  ['^', [7, RIGHT, UNARY]],
+  // Boolean not has less precedence than everything else, so `!a && b` is `!(a && b)`.
+  ['!', [1, RIGHT, UNARY]],
   // The following operations force the value to use a certain addresing mode
-  // ['z:', [2, -1, UNARY]], // direct/zeropage
-  // ['a:', [2, -1, UNARY]], // absolute
-  // ['f:', [2, -1, UNARY]], // far
+  // ['z:', [2, RIGHT, UNARY]], // direct/zeropage
+  // ['a:', [2, RIGHT, UNARY]], // absolute
+  // ['f:', [2, RIGHT, UNARY]], // far
 ]);
 
 // TODO - skip1 and skip2 macros

--- a/src/libassembler.ts
+++ b/src/libassembler.ts
@@ -234,7 +234,8 @@ export async function assemble(
                 callbacks?.readText,
                 callbacks?.readBinary,
                 opts,
-                sourceContents
+                sourceContents,
+                asm.errorCollector
               );
               // Use the first name provided through a code action as the outer module name
               if (module_name === original_module_name && action.name) {
@@ -314,7 +315,8 @@ export async function assemble(
         callbacks?.readText,
         callbacks?.readBinary,
         opts,
-        sourceContents
+        sourceContents,
+        asm.errorCollector
       );
 
       // Tokenize and assemble source code

--- a/src/linker.ts
+++ b/src/linker.ts
@@ -823,8 +823,11 @@ class LinkChunk {
       }
     } else {
       // Regular values use unsigned range check
+      // NOTE: 2**bits rather than 1<<bits, since a 4-byte value shifts by 32,
+      // which wraps around to 1 and rejects everything.
       const bits = (size) << 3;
-      if (val != null && (val < (-1 << bits) || val >= (1 << bits))) {
+      const limit = 2 ** bits;
+      if (val != null && (val < -limit || val >= limit)) {
         const name = ['byte', 'word', 'farword', 'dword'][size - 1];
         throw new Error(`Not a ${name}: $${val.toString(16)} at $${
             (this.org! + offset).toString(16)}`);

--- a/src/macro.ts
+++ b/src/macro.ts
@@ -39,7 +39,10 @@ export class Macro {
     let i = 1; // start looking _after_ macro ident
     const replacements = new Map<string, Token[]>();
     const lines: Token[][] = [];
-    
+    // `.paramCount` needs to know how many commas were used in the invocation
+    // in case they use it later, so store it here.
+    const paramCount = Macro.countArgs(tokens, 1);
+
     // Find a comma, skipping balanced curlies.  Parens are not special.
     for (const param of this.params) {
       const comma = Tokens.findComma(tokens, i);
@@ -84,6 +87,11 @@ export class Macro {
               mapped.push({token: 'ident', str: local});
               continue;
             }
+          } else if (tok.token === 'cs' && tok.str === '.paramcount') {
+            // .paramcount can only be used in macros, so we don't need to put
+            // it in the main directive switch statement.
+            mapped.push({token: 'num', num: paramCount, source: tok.source});
+            continue;
           } else if (tok.token === 'grp') {
             mapped.push({token: 'grp', inner: map(tok.inner)});
             continue;
@@ -99,5 +107,19 @@ export class Macro {
       lines.push(map(line));
     }
     return lines.filter(m => m.length != 0);
+  }
+
+  /**
+   * Counts the number of commas used in a macro invocation.
+   * If a param is blank like foo ,, 3 it still counts as a param
+   * If there's no params, then this should return 0
+   */
+  private static countArgs(tokens: Token[], start: number): number {
+    if (start >= tokens.length) return 0;
+    let count = 1;
+    for (let i = start; i < tokens.length; i++) {
+      if (Tokens.eq(tokens[i], Tokens.COMMA)) count++;
+    }
+    return count;
   }
 }

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -16,6 +16,12 @@ import { ErrorCollector, RecoverableError } from './assembler.ts';
 //    to know when to release the frame?
 const MAX_STACK_DEPTH = 100;
 
+/**
+ * Value reported by `.version`, encoded the way ca65 does it:
+ * `(major << 8) | minor`.
+ */
+const JS65_VERSION = 0x0213; // matches ca65 version 2.19
+
 // interface TokenSource {
 //   next(): Token[];
 //   include(file: string): Promise<void>;
@@ -264,7 +270,21 @@ export class Preprocessor implements Tokens.Source {
         return this.parseArgs(line, i, 1, this.constantSymbol);
       case '.referencedsymbol':
         return this.parseArgs(line, i, 1, this.referencedSymbol);
+      case '.time':
+        // Seconds since the epoch, so that source can stamp a build time.
+        return this.pseudoVariable(line, i, Math.floor(Date.now() / 1000));
+      case '.version':
+        return this.pseudoVariable(line, i, JS65_VERSION);
     }
+    return i + 1;
+  }
+
+  /**
+   * Substitutes a bare pseudo-variable with its value. Unlike
+   * the pseudo-functions these take no parentheses at all.
+   */
+  private pseudoVariable(line: Token[], i: number, num: number): number {
+    line.splice(i, 1, {token: 'num', num, source: line[i].source});
     return i + 1;
   }
 

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -40,6 +40,8 @@ interface Env {
   definedSymbol(sym: string): boolean;
   constantSymbol(sym: string): boolean;
   referencedSymbol(sym: string): boolean;
+  /** Whether the name is an opcode mnemonic of the CPU being assembled for. */
+  isMnemonic(name: string): boolean;
   evaluate(expr: Expr): number|undefined;
   assignSym(line: Token[]): void;
   setSym(line: Token[]): void;
@@ -256,6 +258,8 @@ export class Preprocessor implements Tokens.Source {
         return this.parseArgs(line, i, 1, this.definedMacro);
       case '.definedsymbol':
         return this.parseArgs(line, i, 1, this.definedSymbol);
+      case '.ismnemonic':
+        return this.parseArgs(line, i, 1, this.isMnemonic);
       case '.constantsymbol':
         return this.parseArgs(line, i, 1, this.constantSymbol);
       case '.referencedsymbol':
@@ -471,6 +475,14 @@ export class Preprocessor implements Tokens.Source {
     const ident = Tokens.expectIdentifier(arg[0], cs);
     Tokens.expectEol(arg[1], 'a single identifier');
     return [{token: 'num', num: this.macros.get(ident) instanceof Macro ? 1 : 0,
+             source: cs.source}];
+  }
+
+  /** Checks if the current CPU setting supports this mnemonic */
+  private isMnemonic(cs: Token, arg: Token[]) : Token[] {
+    const ident = Tokens.expectIdentifier(arg[0], cs);
+    Tokens.expectEol(arg[1], 'a single identifier');
+    return [{token: 'num', num: this.env.isMnemonic(ident) ? 1 : 0,
              source: cs.source}];
   }
 

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -248,6 +248,8 @@ export class Preprocessor implements Tokens.Source {
       case '.cond': return this.parseArgs(line, i, 3, this.cond);
       case '.blank':
         return this.parseArgs(line, i, 1, this.blank);
+      case '.const':
+        return this.parseArgs(line, i, 1, this.constExpr);
       case '.defined':
         return this.parseArgs(line, i, 1, this.definedSymbol);
       case '.definedsymbol':
@@ -310,8 +312,9 @@ export class Preprocessor implements Tokens.Source {
 
   // `.match`/`.xmatch` compare two token lists as raw tokens and not values, so
   // they work on things like `#` or register names that aren't expressions.
-  // `.match` compares token type + value but treats all identifiers as equal
-  // `.xmatch` also compares identifier names.
+  // `.match` compares token types only, so any number matches any other number
+  // and any identifier matches any other identifier; `.xmatch` also compares
+  // the attribute (the number's value, the identifier's or string's text).
   // the exact parameter is used to select between the two.
   private static tokensEqual(a: Token[], b: Token[], exact: boolean): boolean {
     if (a.length !== b.length) return false;
@@ -319,13 +322,15 @@ export class Preprocessor implements Tokens.Source {
       const x = a[k], y = b[k];
       if (x.token !== y.token) return false;
       switch (x.token) {
-        case 'ident':
+        case 'ident': case 'str':
           if (exact && x.str !== (y as typeof x).str) return false;
           break;
         case 'num':
-          if (x.num !== (y as typeof x).num) return false;
+          if (exact && x.num !== (y as typeof x).num) return false;
           break;
-        case 'str': case 'op': case 'cs':
+        case 'op': case 'cs':
+          // Operators and control commands *are* their text, so the text is
+          // part of the token type rather than an attribute.
           if (x.str !== (y as typeof x).str) return false;
           break;
         default:
@@ -443,6 +448,18 @@ export class Preprocessor implements Tokens.Source {
 
   private blank(cs: Token, arg: Token[]) : Token[] {
     return [{token: 'num', num: arg.length === 0 ? 1 : 0}];
+  }
+
+  /** `.const(expr)` is 1 when the expression is already known, 0 otherwise. */
+  private constExpr(cs: Token, arg: Token[]) : Token[] {
+    const expr = parseOneExpr(arg, cs, this.env.encodeChar);
+    let known = true;
+    try {
+      this.evaluateConst(expr, cs);
+    } catch {
+      known = false; // `*`, forward references and imports are not constant
+    }
+    return [{token: 'num', num: known ? 1 : 0, source: cs.source}];
   }
 
   private definedSymbol(cs: Token, arg: Token[]) : Token[] {

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -236,9 +236,10 @@ export class Preprocessor implements Tokens.Source {
 
   private expandDirective(directive: string, line: Token[], i: number): number {
     switch (directive) {
-      case '.define': 
-      case '.ifdef':  
-      case '.ifndef': 
+      case '.define':
+      case '.delmacro':
+      case '.ifdef':
+      case '.ifndef':
       case '.undefine':
         return this.skipIdentifier(line, i);
       case '.skip': return this.skip(line, i);
@@ -531,7 +532,7 @@ export class Preprocessor implements Tokens.Source {
 
   /**
    * If the following is an identifier, skip it.  This is used when
-   * expanding .define, .undefine, .defined, .ifdef, and .ifndef.
+   * expanding .define, .undefine, .delmacro, .defined, .ifdef, and .ifndef.
    * Does not skip scoped identifiers, since macros can't be scoped.
    */
   private skipIdentifier(line: Token[], i: number): number {
@@ -586,6 +587,7 @@ export class Preprocessor implements Tokens.Source {
 
   private readonly runDirectives: Record<string, (ts: Token[]) => Promise<void>> = {
     '.define': (line) => this.parseDefine(line),
+    '.delmacro': (line) => this.parseDelMacro(line),
     '.undefine': (line) => this.parseUndefine(line),
     '.else': ([cs]) => badClose('.if', cs),
     '.elseif': ([cs]) => badClose('.if', cs),
@@ -643,8 +645,30 @@ export class Preprocessor implements Tokens.Source {
     const [cs, ident, eol] = line;
     const name = Tokens.expectIdentifier(ident, cs);
     Tokens.expectEol(eol);
-    if (!this.macros.has(name)) {
+    const prev = this.macros.get(name);
+    if (!prev) {
       Tokens.fail(`Not defined: ${Tokens.nameOf(ident)}`, ident);
+    }
+    // ca65 only deletes .define-style macros here
+    // they should use .delmacro for the classic .macro-style ones.
+    if (prev instanceof Macro) {
+      Tokens.fail(`Not a .define macro: ${Tokens.nameOf(ident)}`, ident);
+    }
+    this.macros.delete(name);
+    return await Promise.resolve();
+  }
+
+  /** `.delmacro` deletes a classic `.macro` the counterpart of `.undefine`. */
+  private async parseDelMacro(line: Token[]) {
+    const [cs, ident, eol] = line;
+    const name = Tokens.expectIdentifier(ident, cs);
+    Tokens.expectEol(eol);
+    const prev = this.macros.get(name);
+    if (!prev) {
+      Tokens.fail(`Not defined: ${Tokens.nameOf(ident)}`, ident);
+    }
+    if (!(prev instanceof Macro)) {
+      Tokens.fail(`Not a .macro: ${Tokens.nameOf(ident)}`, ident);
     }
     this.macros.delete(name);
     return await Promise.resolve();

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -252,6 +252,8 @@ export class Preprocessor implements Tokens.Source {
         return this.parseArgs(line, i, 1, this.constExpr);
       case '.defined':
         return this.parseArgs(line, i, 1, this.definedSymbol);
+      case '.definedmacro':
+        return this.parseArgs(line, i, 1, this.definedMacro);
       case '.definedsymbol':
         return this.parseArgs(line, i, 1, this.definedSymbol);
       case '.constantsymbol':
@@ -460,6 +462,16 @@ export class Preprocessor implements Tokens.Source {
       known = false; // `*`, forward references and imports are not constant
     }
     return [{token: 'num', num: known ? 1 : 0, source: cs.source}];
+  }
+
+  /**
+   * `.definedmacro` checks only for `.macro` and not the c-style `.define` macros
+   */
+  private definedMacro(cs: Token, arg: Token[]) : Token[] {
+    const ident = Tokens.expectIdentifier(arg[0], cs);
+    Tokens.expectEol(arg[1], 'a single identifier');
+    return [{token: 'num', num: this.macros.get(ident) instanceof Macro ? 1 : 0,
+             source: cs.source}];
   }
 
   private definedSymbol(cs: Token, arg: Token[]) : Token[] {

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -22,6 +22,20 @@ const MAX_STACK_DEPTH = 100;
  */
 const JS65_VERSION = 0x0213; // matches ca65 version 2.19
 
+/**
+ * Value reported by `.cpu`.
+ * The set of instruction sets the current CPU supports, using ca65's bit numbering
+ * where bit 0 is the base 6502 set and bit 1 the undocumented "6502X" opcodes
+ * We always compile with 6502x as the default.
+ */
+const JS65_CPU_ISET = 0x03;
+
+/**
+ * Value reported by `.asize` and `.isize`.  js65 assembles for the 6502, whose
+ * accumulator and index registers are always 8 bits wide.
+ */
+const REGISTER_SIZE = 8;
+
 // interface TokenSource {
 //   next(): Token[];
 //   include(file: string): Promise<void>;
@@ -276,6 +290,11 @@ export class Preprocessor implements Tokens.Source {
         return this.pseudoVariable(line, i, Math.floor(Date.now() / 1000));
       case '.version':
         return this.pseudoVariable(line, i, JS65_VERSION);
+      case '.asize':
+      case '.isize':
+        return this.pseudoVariable(line, i, REGISTER_SIZE);
+      case '.cpu':
+        return this.pseudoVariable(line, i, JS65_CPU_ISET);
     }
     return i + 1;
   }

--- a/src/token.ts
+++ b/src/token.ts
@@ -131,6 +131,10 @@ export const CS_TOKEN_ALIAS_MAP = new Map([
   ['.endmac', '.endmacro'],
   ['.endrep', '.endrepeat'],
   ['.exitmac', '.exitmacro'],
+  ['.fopt', '.fileopt'],
+  // NOTE: js65's linker always links every module fully, so forceimport
+  // does nothing. Just alias it to .import for compatibility.
+  ['.forceimport', '.import'],
   ['.ismnem', '.ismnemonic'],
   ['.mac', '.macro'],
   ['.ref', '.referencedsymbol'],

--- a/src/token.ts
+++ b/src/token.ts
@@ -128,6 +128,7 @@ export const CS_TOKEN_ALIAS_MAP = new Map([
   ['.bank', '.bankbyte'],
   ['.byt', '.byte'],
   ['.def', '.defined'],
+  ['.delmac', '.delmacro'],
   ['.endmac', '.endmacro'],
   ['.endrep', '.endrepeat'],
   ['.exitmac', '.exitmacro'],

--- a/src/token.ts
+++ b/src/token.ts
@@ -131,7 +131,10 @@ export const CS_TOKEN_ALIAS_MAP = new Map([
   ['.endmac', '.endmacro'],
   ['.endrep', '.endrepeat'],
   ['.exitmac', '.exitmacro'],
+  ['.ismnem', '.ismnemonic'],
   ['.mac', '.macro'],
+  ['.ref', '.referencedsymbol'],
+  ['.referenced', '.referencedsymbol'],
   ['.undef', '.undefine'],
 ]);
 

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -7,6 +7,8 @@ import * as Tokens from './token.ts';
 import { SourceContents } from './tokenstream.ts';
 import { ErrorCollector } from './assembler.ts';
 
+const NEWLINE = /^(\r\n|\n|\r)/;
+
 export class Tokenizer implements Tokens.Source {
   readonly buffer: Buffer;
 
@@ -126,7 +128,15 @@ export class Tokenizer implements Tokens.Source {
     const end = m[0];
     let str = '';
     while (!b.lookingAt(end)) {
-      if (b.eof()) throw new Error(`EOF while looking for ${end}`);
+      // Strings don't span lines, so running into a newline (or the end of the
+      // file) means the terminator is missing. Report it and pretend the string
+      // ended here, leaving the newline in the buffer so the rest of the file
+      // still tokenizes normally.
+      if (b.eof() || b.lookingAt(NEWLINE)) {
+        this.unterminated(`Unterminated string, expected ${end}`,
+                          {file: this.file, line: m.line, column: m.column});
+        return this.makeStrToken(end, str);
+      }
       if (b.token(/^\\u([0-9a-f]{4})/i)) {
         str += String.fromCodePoint(parseInt(b.group(1)!, 16));
       } else if (b.token(/^\\x([0-9a-f]{2})/i)) {
@@ -139,8 +149,22 @@ export class Tokenizer implements Tokens.Source {
       }
     }
     b.token(end);
-    // mark single quoted strings as 'char' so they can be used as numeric literals later
-    return end === `'` ? {token: 'str', str, char: true} : {token: 'str', str};
+    return this.makeStrToken(end, str);
+  }
+
+  /** mark single quoted strings as 'char' so they can be used as numeric literals later */
+  private makeStrToken(quote: string, str: string): Token {
+    return quote === `'` ? {token: 'str', str, char: true} : {token: 'str', str};
+  }
+
+  /**
+   * Records a missing string terminator. If we have an error collector, then treat
+   * it as a recoverable error by marking the end of line as the end of the string,
+   * and continue processing.
+   */
+  private unterminated(message: string, source: Tokens.SourceInfo): void {
+    if (!this.errorCollector) throw new Tokens.SourceError(message, source);
+    this.errorCollector.add('error', message, source);
   }
 
   private strTok(token: Tokens.StringToken['token']): Token {

--- a/src/tokenstream.ts
+++ b/src/tokenstream.ts
@@ -5,6 +5,7 @@ import * as Exprs from './expr.ts';
 import { Base64 } from './base64.ts'
 import {type Token} from './token.ts'
 import {Tokenizer, type Options} from './tokenizer.ts'
+import {type ErrorCollector} from './assembler.ts';
 import * as Tokens from './token.ts';
 // TODO: import raw text files seems painful right now.
 import * as Common from './macpack/common.ts'
@@ -66,7 +67,8 @@ export class TokenStream implements Tokens.Source {
     readonly readFile?: ReadFileCallback,
     readonly readFileBinary?: ReadFileBinaryCallback,
     readonly opts?: Options,
-    readonly sourceContents?: SourceContents) {}
+    readonly sourceContents?: SourceContents,
+    readonly errorCollector?: ErrorCollector) {}
 
   /** Directory the frame currently on top should resolve includes against. */
   private currentDir(): string | undefined {
@@ -122,14 +124,16 @@ export class TokenStream implements Tokens.Source {
             const {value: code, base} = await this.loadFile<string>(
                 path, this.includeSearch(), this.readFile, line[0]);
             // Nested includes resolve relative to this file's own directory.
-            this.enter(new Tokenizer(code, path, this.opts, this.sourceContents),
+            this.enter(new Tokenizer(code, path, this.opts, this.sourceContents,
+                                     this.errorCollector),
                        joinDir(base, dirOf(path)));
             continue;
           }
           case '.macpack': {
             const pack = Tokens.expectIdentifier(line[1])?.toLowerCase();
             const code = MACPACK.get(pack) ?? this.err(line);
-            this.enter(new Tokenizer(code, `${pack}.macpack`, this.opts, this.sourceContents));
+            this.enter(new Tokenizer(code, `${pack}.macpack`, this.opts, this.sourceContents,
+                                     this.errorCollector));
             continue;
           }
           case '.incbin': {

--- a/test/assembler_test.ts
+++ b/test/assembler_test.ts
@@ -964,6 +964,51 @@ describe('Assembler', function() {
     });
   });
 
+  describe('.dword', function() {
+    it('should support numbers', function() {
+      const a = new Assembler(Cpu.P02);
+      a.directive([cs('.dword'), num(1), COMMA, num(0x12345678)]);
+      expect(strip(a.module())).toEqual({
+        chunks: [{
+          overwrite: 'allow',
+          segments: [],
+          data: Uint8Array.of(1, 0, 0, 0, 0x78, 0x56, 0x34, 0x12),
+        }],
+        symbols: [], segments: []});
+    });
+
+    it('should support expressions with backward refs', function() {
+      const a = new Assembler(Cpu.P02);
+      a.assign('q', 0x305);
+      a.directive([cs('.dword'), ident('q')]);
+      expect(strip(a.module())).toEqual({
+        chunks: [{
+          overwrite: 'allow',
+          segments: [],
+          data: Uint8Array.of(5, 3, 0, 0),
+        }],
+        symbols: [], segments: []});
+    });
+
+    it('should support expressions with forward refs', function() {
+      const a = new Assembler(Cpu.P02);
+      a.directive([cs('.dword'), ident('q'), op('+'), num(1)]);
+      a.label('q');
+      expect(strip(a.module())).toEqual({
+        chunks: [{
+          overwrite: 'allow',
+          segments: [],
+          data: Uint8Array.of(0xff, 0xff, 0xff, 0xff),
+          subs: [{offset: 0, size: 4,
+                  expr: {op: '+', args: [{op: 'sym', num: 0},
+                                         {op: 'num', num: 1,
+                                          meta: {size: 1}}]}}],
+        }],
+        symbols: [{expr: off(4)}],
+        segments: []});
+    });
+  });
+
   describe('.loword/.hiword', function() {
     it('should split a 32-bit value into words', function() {
       const a = new Assembler(Cpu.P02);

--- a/test/assembler_test.ts
+++ b/test/assembler_test.ts
@@ -20,6 +20,15 @@ async function assemble(body: string): Promise<number[]> {
   return Array.from(result.outputs[0].data);
 }
 
+// Same as `assemble`, but for sources that are expected to fail.
+// Returns the recorded error messages rather than the output bytes.
+async function assembleErrors(body: string): Promise<string[]> {
+  const code = `.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000\n.org $8000\n${body}`;
+  const result = await compile([{type: 'source', code, name: 'test.s'} as AssemblyInput], {});
+  if (result.success) throw new Error('Expected the assembly to fail');
+  return result.messages.filter(m => m.level === 'error').map(m => m.message);
+}
+
 const [_a] = [util];
 
 function ident(str: string): Token { return {token: 'ident', str}; }
@@ -1739,6 +1748,30 @@ describe('Assembler', function() {
   .endif
   .byte 2
 `)).toEqual([1, 2]);
+    });
+  });
+
+  describe('.fatal', function() {
+    it('aborts the assembly instead of continuing like .error', async function() {
+      // `.error` is recoverable, so everything after it is still assembled...
+      expect(await assembleErrors(`
+  .error "first"
+  .error "second"
+`)).toEqual(['first', 'second']);
+      // ...while `.fatal` stops immediately, so the second one never runs.
+      expect(await assembleErrors(`
+  .fatal "first"
+  .error "second"
+`)).toEqual(['first']);
+    });
+
+    it('reports its message exactly once', async function() {
+      expect(await assembleErrors(`  .fatal "boom"\n`)).toEqual(['boom']);
+    });
+
+    it('requires a single string argument', async function() {
+      expect(await assembleErrors(`  .fatal\n`))
+          .toEqual(['Expected constant string after .FATAL']);
     });
   });
 

--- a/test/assembler_test.ts
+++ b/test/assembler_test.ts
@@ -1346,6 +1346,36 @@ describe('Assembler', function() {
     });
   });
 
+  describe('.setcpu/.pushcpu/.popcpu', function() {
+    it('should accept a supported cpu', function() {
+      const a = new Assembler(Cpu.P02);
+      a.directive([cs('.setcpu'), str('6502')]);
+      a.directive([cs('.setcpu'), str('6502X')]);
+    });
+
+    it('should reject an unsupported cpu', function() {
+      const a = new Assembler(Cpu.P02);
+      expect(() => a.directive([cs('.setcpu'), str('65816')]))
+          .toThrow(/Unsupported CPU: 65816/);
+    });
+
+    it('should allow balanced pushes and pops', function() {
+      const a = new Assembler(Cpu.P02);
+      a.directive([cs('.pushcpu')]);
+      a.directive([cs('.pushcpu')]);
+      a.directive([cs('.popcpu')]);
+      a.directive([cs('.popcpu')]);
+    });
+
+    it('should reject a .popcpu with no matching .pushcpu', function() {
+      const a = new Assembler(Cpu.P02);
+      a.directive([cs('.pushcpu')]);
+      a.directive([cs('.popcpu')]);
+      expect(() => a.directive([cs('.popcpu')]))
+          .toThrow(/\.popcpu without \.pushcpu/);
+    });
+  });
+
   describe('.assert', function() {
     it('should pass immediately when true', function() {
       const a = new Assembler(Cpu.P02);

--- a/test/assembler_test.ts
+++ b/test/assembler_test.ts
@@ -1711,6 +1711,37 @@ describe('Assembler', function() {
     });
   });
 
+  describe('.end', function() {
+    it('stops assembling the rest of the file', async function() {
+      expect(await assemble(`
+  .byte 1
+  .end
+  .byte 2
+`)).toEqual([1]);
+    });
+
+    // `###` fails in the preprocessor rather than the assembler, checking that
+    // the file is really stopped processing completely
+    it('does not require the rest of the file to be valid', async function() {
+      expect(await assemble(`
+  .byte 1
+  .end
+  .notadirective bogus
+  ###
+`)).toEqual([1]);
+    });
+
+    it('is skipped inside a false conditional', async function() {
+      expect(await assemble(`
+  .byte 1
+  .if 0
+  .end
+  .endif
+  .byte 2
+`)).toEqual([1, 2]);
+    });
+  });
+
   describe('.sizeof', function() {
     it('reports the total size of a struct', async function() {
       expect(await assemble(`

--- a/test/assembler_test.ts
+++ b/test/assembler_test.ts
@@ -27,7 +27,7 @@ function num(num: number): Token { return {token: 'num', num}; }
 function str(str: string): Token { return {token: 'str', str}; }
 function cs(str: string): Token { return {token: 'cs', str}; }
 function op(str: string): Token { return {token: 'op', str}; }
-const {COLON, COMMA, IMMEDIATE, LP, RP} = Tokens;
+const {COLON, COMMA, IMMEDIATE, LB, LP, RB, RP} = Tokens;
 const ORG = cs('.org');
 const RELOC = cs('.reloc');
 const ASSERT = cs('.assert');
@@ -754,6 +754,69 @@ describe('Assembler', function() {
     it('should support expressions with forward refs', function() {
       const a = new Assembler(Cpu.P02);
       a.directive([cs('.byte'), ident('q'), op('+'), num(1)]);
+      a.label('q');
+      expect(strip(a.module())).toEqual({
+        chunks: [{
+          overwrite: 'allow',
+          segments: [],
+          data: Uint8Array.of(0xff),
+          subs: [{offset: 0, size: 1,
+                  expr: {op: '+', args: [{op: 'sym', num: 0},
+                                         {op: 'num', num: 1,
+                                          meta: {size: 1}}]}}],
+        }],
+        symbols: [{expr: off(1)}],
+        segments: []});
+    });
+  });
+
+  describe('.literal', function() {
+    it('should emit strings without applying the charmap', function() {
+      const a = new Assembler(Cpu.P02);
+      a.directive([cs('.charmap'), num(0x61), COMMA, num(0x80)]);
+      a.directive([cs('.byte'), str('ab')]);
+      a.directive([cs('.literal'), str('ab')]);
+      expect(strip(a.module())).toEqual({
+        chunks: [{
+          overwrite: 'allow',
+          segments: [],
+          data: Uint8Array.of(0x80, 0x62, 0x61, 0x62),
+        }],
+        symbols: [], segments: []});
+    });
+
+    it('should emit strings without applying a multi-byte strmap', function() {
+      const a = new Assembler(Cpu.P02);
+      a.directive([cs('.strmap'), str('ab'), COMMA,
+                   LB, num(1), COMMA, num(2), COMMA, num(3), RB]);
+      a.directive([cs('.byte'), str('ab')]);
+      a.directive([cs('.literal'), str('ab')]);
+      expect(strip(a.module())).toEqual({
+        chunks: [{
+          overwrite: 'allow',
+          segments: [],
+          data: Uint8Array.of(1, 2, 3, 0x61, 0x62),
+        }],
+        symbols: [], segments: []});
+    });
+
+    it('should support numbers and expressions like .byte', function() {
+      const a = new Assembler(Cpu.P02);
+      a.assign('q', 5);
+      a.directive([cs('.literal'), num(1), COMMA, num(2), op('+'), num(3),
+                   COMMA, ident('q')]);
+      expect(strip(a.module())).toEqual({
+        chunks: [{
+          overwrite: 'allow',
+          segments: [],
+          data: Uint8Array.of(1, 5, 5),
+        }],
+        symbols: [], segments: []});
+    });
+
+    it('should support expressions with forward refs', function() {
+      const a = new Assembler(Cpu.P02);
+      a.directive([cs('.literal'), ident('q'), op('+'), num(1)]);
       a.label('q');
       expect(strip(a.module())).toEqual({
         chunks: [{

--- a/test/assembler_test.ts
+++ b/test/assembler_test.ts
@@ -964,6 +964,51 @@ describe('Assembler', function() {
     });
   });
 
+  describe('.dbyt', function() {
+    it('should write words big-endian', function() {
+      const a = new Assembler(Cpu.P02);
+      a.directive([cs('.dbyt'), num(1), COMMA, num(0x403)]);
+      expect(strip(a.module())).toEqual({
+        chunks: [{
+          overwrite: 'allow',
+          segments: [],
+          data: Uint8Array.of(0, 1, 4, 3),
+        }],
+        symbols: [], segments: []});
+    });
+
+    it('should support expressions with backward refs', function() {
+      const a = new Assembler(Cpu.P02);
+      a.assign('q', 0x305);
+      a.directive([cs('.dbyt'), ident('q')]);
+      expect(strip(a.module())).toEqual({
+        chunks: [{
+          overwrite: 'allow',
+          segments: [],
+          data: Uint8Array.of(3, 5),
+        }],
+        symbols: [], segments: []});
+    });
+
+    it('should support expressions with forward refs', function() {
+      const a = new Assembler(Cpu.P02);
+      a.directive([cs('.dbyt'), ident('q')]);
+      a.label('q');
+      expect(strip(a.module())).toEqual({
+        chunks: [{
+          overwrite: 'allow',
+          segments: [],
+          data: Uint8Array.of(0xff, 0xff),
+          subs: [{offset: 0, size: 1,
+                  expr: {op: '>', args: [{op: 'sym', num: 0}]}},
+                 {offset: 1, size: 1,
+                  expr: {op: '<', args: [{op: 'sym', num: 0}]}}],
+        }],
+        symbols: [{expr: off(2)}],
+        segments: []});
+    });
+  });
+
   describe('.dword', function() {
     it('should support numbers', function() {
       const a = new Assembler(Cpu.P02);

--- a/test/assembler_test.ts
+++ b/test/assembler_test.ts
@@ -6,7 +6,7 @@ import {Cpu} from '../src/cpu.ts';
 import {type Expr} from '../src/expr.ts';
 import {type Module} from '../src/module.ts';
 import {Assembler} from '../src/assembler.ts';
-import {compile, type AssemblyInput} from '../src/libassembler.ts';
+import {assemble as libAssemble, compile, type AssemblyInput} from '../src/libassembler.ts';
 import {type Token} from '../src/token.ts';
 import * as Tokens from '../src/token.ts';
 import * as util from '../src/util.ts';
@@ -27,6 +27,16 @@ async function assembleErrors(body: string): Promise<string[]> {
   const result = await compile([{type: 'source', code, name: 'test.s'} as AssemblyInput], {});
   if (result.success) throw new Error('Expected the assembly to fail');
   return result.messages.filter(m => m.level === 'error').map(m => m.message);
+}
+
+// Assembles a snippet through the full tokenizer/preprocessor pipeline and returns
+// the module without linking it. Allows us to test for aliases as those are handled
+// at the tokenizer level.
+async function assembleModule(body: string): Promise<Module> {
+  const result = await libAssemble([{type: 'source', code: body, name: 'test.s'} as AssemblyInput],
+                                   {generateDebugInfo: false});
+  if (!result.success) throw new Error(JSON.stringify(result.messages));
+  return result.modules[0];
 }
 
 const [_a] = [util];
@@ -1748,6 +1758,20 @@ describe('Assembler', function() {
   .endif
   .byte 2
 `)).toEqual([1, 2]);
+    });
+  });
+
+  describe('.forceimport', function() {
+    it('imports the symbol like .import', async function() {
+      const m = await assembleModule(`.forceimport foo\n.byte foo\n`);
+      expect(strip(m).symbols).toEqual([{expr: {op: 'im', sym: 'foo'}}]);
+    });
+  });
+
+  describe('.fopt', function() {
+    it('is accepted and ignored as its unimplemented still', async function() {
+      const m = await assembleModule(`.fopt comment, "hello"\n.byte 1\n`);
+      expect(m.chunks![0].data).toEqual(Uint8Array.of(1));
     });
   });
 

--- a/test/expr_test.ts
+++ b/test/expr_test.ts
@@ -4,6 +4,7 @@
 import {describe, it, expect} from 'bun:test';
 import {type Expr} from '../src/expr.ts';
 import * as Exprs from '../src/expr.ts';
+import {compile, type AssemblyInput} from '../src/libassembler.ts';
 import {type Token} from '../src/token.ts';
 import * as Tokens from '../src/token.ts';
 import * as util from '../src/util.ts';
@@ -294,4 +295,160 @@ describe('Expr', function() {
   //        .toEqual({op: 'num', num: 0x37, meta: {chunk: 1, size: 1}});
   //   });
   // });
+
+  // Test cases and output for each test case came from running each in ca65
+  describe('ca65 operator compatibility', function() {
+
+    async function assemble(body: string): Promise<number[]> {
+      const code = `.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000
+.org $8000
+${body}`;
+      const result =
+          await compile([{type: 'source', code, name: 'test.s'} as AssemblyInput], {});
+      if (!result.success) {
+        throw new Error(result.messages.filter(m => m.level === 'error')
+            .map(m => m.message).join('; '));
+      }
+      return Array.from(result.outputs[0].data);
+    }
+
+    // Really should add the .dword soon, but till then, we can check the 4 bytes of the
+    // output by splitting it into a loword and hiword.
+    async function value(expr: string): Promise<number> {
+      const [lo, hi, hi2, hi3] =
+          await assemble(`.word ((${expr}) & $ffff)\n.word (.hiword(${expr}))\n`);
+      return lo | hi << 8 | hi2 << 16 | hi3 << 24;
+    }
+
+    function check(cases: Array<[string, number]>) {
+      for (const [expr, want] of cases) {
+        it(`should evaluate \`${expr}\` to ${want}`, async function() {
+          expect(await value(expr)).toBe(want);
+        });
+      }
+    }
+
+    describe('precedence', function() {
+      // ca65 gives boolean not the loosest precedence of all its operators.
+      check([
+        ['!1 && 1', 0],
+        ['!0 && 0', 1],
+        ['!1 || 0', 0],
+        ['!0 || 0', 1],
+        ['!1 .xor 1', 1],
+        ['!1 = 0', 1],
+        ['!0 = 0', 0],
+        ['!(1 = 1)', 0],
+        // boolean or is looser than boolean and/xor
+        ['1 && 0 || 1', 1],
+        ['0 || 1 && 1', 1],
+        ['1 && 0 .xor 1', 1],
+        ['0 || 1 .xor 1', 0],
+        // unary operators are the highest priority
+        ['-1 + 2', 1],
+        ['<$1234 + 1', 0x35],
+        ['2 * -3', -6],
+      ]);
+    });
+
+    describe('associativity', function() {
+      // Operators sharing a precedence level evaluate left to right.
+      check([
+        ['1 << 2 << 3', 32],
+        ['1 - 2 - 3', -4],
+        ['16 / 4 / 2', 2],
+        ['1 = 1 = 1', 1],
+        ['1 < 2 < 3', 1],
+        ['1 .xor 0 .xor 1', 0],
+        // ...including operators ca65 groups together but spells differently
+        ['2 * 3 & 7', 6],
+        ['1 << 2 * 3', 12],
+        ['2 ^ 3 & 1', 1],
+        ['1 + 2 | 4', 7],
+        ['7 - 2 | 8', 13],
+      ]);
+    });
+
+    describe('boolean operators', function() {
+      // These always reduce to 0 or 1 rather than to one of their operands.
+      check([
+        ['2 && 3', 1],
+        ['2 && 0', 0],
+        ['2 || 0', 1],
+        ['0 || 5', 1],
+        ['0 .xor 5', 1],
+        ['5 .xor 3', 0],
+        ['2 .and 3', 1],
+        ['2 .or 0', 1],
+        ['!2', 0],
+        ['.not 2', 0],
+      ]);
+    });
+
+    describe('arithmetic', function() {
+      check([
+        // Division truncates toward zero and operates on signed 32-bit values.
+        ['-7 / 2', -3],
+        ['-3 / 2', -1],
+        ['7 / -2', -3],
+        ['$80000000 / 2', -0x40000000],
+        ['-1 = $ffffffff', 1],
+        // A shift count outside 0..31 clears the value.
+        ['1 << 32', 0],
+        ['1 << 64', 0],
+        ['1 << -1', 0],
+        ['$ffffffff >> 32', 0],
+        // The bank byte of a plain number is bits 16-23.
+        ['^$123456', 0x12],
+        ['.bankbyte($123456)', 0x12],
+      ]);
+
+      it('should reject division by zero', async function() {
+        await expect(value('1 / 0')).rejects.toThrow(/division by zero/i);
+      });
+
+      it('should reject modulo by zero', async function() {
+        await expect(value('1 .mod 0')).rejects.toThrow(/modulo operation with zero/i);
+      });
+    });
+
+    describe('functions', function() {
+      check([
+        ['.max(3, 7)', 7],
+        ['.min(3, 7)', 3],
+        ['.max(-3, 7)', 7],
+        ['.min(-3, 7)', -3],
+        ['.match(1, 2)', 1],
+        ['.xmatch(1, 2)', 0],
+        ['.xmatch(1, 1)', 1],
+        ['.match("a", "b")', 1],
+        ['.xmatch("a", "b")', 0],
+        ['.match(abc, def)', 1],
+        ['.xmatch(abc, def)', 0],
+        ['.match(+, -)', 0],
+        ['.const(5)', 1],
+        ['.const(1+2)', 1],
+        ['.const(*)', 0],
+      ]);
+    });
+
+    describe('constant expressions in .if', function() {
+      it('should apply the same precedence as the assembler', async function() {
+        expect(await assemble(`
+.if !0 && 0
+.byte $11
+.endif
+.if !1 || 0
+.byte $22
+.endif
+.if 1 && 0 || 1
+.byte $33
+.endif
+.if 0 || 1 && 1
+.byte $44
+.endif
+`)).toEqual([0x11, 0x33, 0x44]);
+      });
+    });
+  });
 });

--- a/test/linker_test.ts
+++ b/test/linker_test.ts
@@ -83,6 +83,19 @@ describe('Linker', function() {
     expect([...link(m).chunks()]).toEqual([[50, [2, 4, 103, 8]]]);
   });
 
+  it('should fill in a 4-byte substitution', function() {
+    const m = {
+      chunks: [{
+        segments: ['code'],
+        org: 100,
+        data: Uint8Array.of(0xff, 0xff, 0xff, 0xff),
+        subs: [{offset: 0, size: 4, expr: num(0x12345678)}],
+      }],
+      segments: [{name: 'code', size: 400, offset: 30, memory: 80}],
+    };
+    expect([...link(m).chunks()]).toEqual([[50, [0x78, 0x56, 0x34, 0x12]]]);
+  });
+
   it('should fill in an offset from a symbol', function() {
     const m = {
       chunks: [{

--- a/test/macro_test.ts
+++ b/test/macro_test.ts
@@ -50,6 +50,27 @@ describe('Macro', function() {
           .rejects.toThrowError(/Too many macro parameters: baz/);
     });
   });
+
+  describe('.paramcount', function() {
+    // Expected values cross-checked against a real ca65 invocation.
+    const macro = '.macro foo a, b, c\n  .byte .paramcount\n.endmacro';
+
+    it('should be 0 for a bare invocation', async function() {
+      await testExpand(macro, 'foo', '  .byte 0');
+    });
+    it('should count a single supplied argument', async function() {
+      await testExpand(macro, 'foo 1', '  .byte 1');
+    });
+    it('should count commas, not declared parameters', async function() {
+      await testExpand(macro, 'foo 1, 2', '  .byte 2');
+    });
+    it('should count blank slots between commas', async function() {
+      await testExpand(macro, 'foo ,, 3', '  .byte 3');
+    });
+    it('should count a trailing blank slot', async function() {
+      await testExpand(macro, 'foo 1,', '  .byte 2');
+    });
+  });
 });
 
 function strip(t: Token): Token {

--- a/test/preprocessor_test.ts
+++ b/test/preprocessor_test.ts
@@ -26,13 +26,13 @@ describe('Preprocessor', function() {
     expect(out).toEqual(want);
   }
 
-  function testError(lines: string[], msg: RegExp) {
+  async function testError(lines: string[], msg: RegExp) {
     const code = lines.join('\n');
     const toks = new TokenStream();
     toks.enter(new Tokenizer(code, 'input.s'));
     // deno-lint-ignore no-explicit-any
     const preprocessor = new Preprocessor(toks, {} as any);
-    expect((async () => { while (await preprocessor.next()); })())
+    await expect((async () => { while (await preprocessor.next()); })())
         .rejects.toThrow(msg);
   }
 
@@ -523,6 +523,42 @@ describe('Preprocessor', function() {
     it('should not find a plain symbol', async function() {
       await test(['foo = 1', 'a .definedmacro(foo)'],
            await assign('foo = 1'), await instruction('a 0'));
+    });
+  });
+
+  describe('.delmacro', function() {
+    it('should delete a .macro definition', async function() {
+      await test(['.macro foo', '  nop', '.endmacro', '.delmacro foo', 'foo'],
+           await instruction('foo'));
+    });
+
+    it('should accept the .delmac spelling', async function() {
+      await test(['.macro foo', '  nop', '.endmacro', '.delmac foo', 'foo'],
+           await instruction('foo'));
+    });
+
+    it('should allow redefining the macro afterwards', async function() {
+      await test(['.macro foo', '  nop', '.endmacro',
+            '.delmacro foo',
+            '.macro foo', '  rts', '.endmacro',
+            'foo'],
+           await instruction('rts'));
+    });
+
+    it('should reject a .define style macro', async function() {
+      await testError(['.define foo bar', '.delmacro foo'],
+                      /Not a \.macro: foo/);
+    });
+
+    it('should reject an unknown name', async function() {
+      await testError(['.delmacro foo'], /Not defined: foo/);
+    });
+  });
+
+  describe('.undefine', function() {
+    it('should reject a .macro style macro', async function() {
+      await testError(['.macro foo', '  nop', '.endmacro', '.undefine foo'],
+                      /Not a \.define macro: foo/);
     });
   });
 

--- a/test/preprocessor_test.ts
+++ b/test/preprocessor_test.ts
@@ -526,6 +526,43 @@ describe('Preprocessor', function() {
     });
   });
 
+  describe('.ref/.referenced', function() {
+    it('should report an unreferenced symbol as 0', async function() {
+      await test(['a .referencedsymbol(foo)'], await instruction('a 0'));
+    });
+
+    it('should accept the .referenced', async function() {
+      await test(['a .referenced(foo)'], await instruction('a 0'));
+    });
+
+    it('should accept the .ref', async function() {
+      await test(['a .ref(foo)'], await instruction('a 0'));
+    });
+
+    it('should report a defined symbol as referenced', async function() {
+      await test(['foo = 1', 'a .ref(foo)'],
+           await assign('foo = 1'), await instruction('a 1'));
+    });
+  });
+
+  describe('.ismnemonic', function() {
+    it('should recognize an opcode', async function() {
+      await test(['a .ismnemonic(lda)'], await instruction('a 1'));
+    });
+
+    it('should recognize an opcode in upper case', async function() {
+      await test(['a .ismnemonic(LDA)'], await instruction('a 1'));
+    });
+
+    it('should not recognize a non-opcode', async function() {
+      await test(['a .ismnemonic(foo)'], await instruction('a 0'));
+    });
+
+    it('should accept the .ismnem spelling', async function() {
+      await test(['a .ismnem(nop)'], await instruction('a 1'));
+    });
+  });
+
   describe('.match/.xmatch', function() {
     it('should match identical raw tokens', async function() {
       await test(['a .match(#, #)'], await instruction('a 1'));

--- a/test/preprocessor_test.ts
+++ b/test/preprocessor_test.ts
@@ -588,6 +588,32 @@ describe('Preprocessor', function() {
     });
   });
 
+  describe('.asize/.isize', function() {
+    it('should report 8-bit registers', async function() {
+      await test(['a .asize .isize'], await instruction('a 8 8'));
+    });
+  });
+
+  describe('.cpu', function() {
+    it('should report the supported instruction sets', async function() {
+      await test(['a .cpu'], await instruction('a 3')); // 6502 and 6502X
+    });
+
+    it('should be usable in an .if condition', async function() {
+      await test(['.if .cpu .bitand 2', // CPU_ISET_6502X
+            'yep',
+            '.else',
+            'nope',
+            '.endif'],
+           await instruction('yep'));
+    });
+
+    it('should not consume parentheses', async function() {
+      // ca65 rejects `.cpu()`, so the parens must survive as themselves.
+      await test(['a .cpu ( 1 )'], await instruction('a 3 ( 1 )'));
+    });
+  });
+
   describe('.ref/.referenced', function() {
     it('should report an unreferenced symbol as 0', async function() {
       await test(['a .referencedsymbol(foo)'], await instruction('a 0'));

--- a/test/preprocessor_test.ts
+++ b/test/preprocessor_test.ts
@@ -526,6 +526,32 @@ describe('Preprocessor', function() {
     });
   });
 
+  describe('.time', function() {
+    it('should substitute the current time in seconds', async function() {
+      // Nondeterministic by nature, so check if its within a range instead
+      const before = Math.floor(Date.now() / 1000);
+      const toks = new TokenStream();
+      toks.enter(new Tokenizer('a .time', 'input.s'));
+      const line = await new Preprocessor(toks, new Assembler()).next();
+      const after = Math.floor(Date.now() / 1000);
+      const tok = line![1];
+      expect(tok.token).toBe('num');
+      expect((tok as Tokens.NumberToken).num).toBeGreaterThanOrEqual(before);
+      expect((tok as Tokens.NumberToken).num).toBeLessThanOrEqual(after);
+    });
+  });
+
+  describe('.version', function() {
+    it('should substitute a bare pseudo-variable', async function() {
+      await test(['a .version'], await instruction('a 531')); // $0213
+    });
+
+    it('should not consume parentheses', async function() {
+      // ca65 rejects `.version()`, so the parens must survive as themselves.
+      await test(['a .version ( 1 )'], await instruction('a 531 ( 1 )'));
+    });
+  });
+
   describe('.ref/.referenced', function() {
     it('should report an unreferenced symbol as 0', async function() {
       await test(['a .referencedsymbol(foo)'], await instruction('a 0'));

--- a/test/preprocessor_test.ts
+++ b/test/preprocessor_test.ts
@@ -510,6 +510,22 @@ describe('Preprocessor', function() {
     });
   });
 
+  describe('.definedmacro', function() {
+    it('should find a .macro definition', async function() {
+      await test(['.macro foo', '  nop', '.endmacro', 'a .definedmacro(foo)'],
+           await instruction('a 1'));
+    });
+
+    it('should not find an undefined name', async function() {
+      await test(['a .definedmacro(foo)'], await instruction('a 0'));
+    });
+
+    it('should not find a plain symbol', async function() {
+      await test(['foo = 1', 'a .definedmacro(foo)'],
+           await assign('foo = 1'), await instruction('a 0'));
+    });
+  });
+
   describe('.match/.xmatch', function() {
     it('should match identical raw tokens', async function() {
       await test(['a .match(#, #)'], await instruction('a 1'));

--- a/test/tokenizer_test.ts
+++ b/test/tokenizer_test.ts
@@ -9,6 +9,7 @@ import * as Tokens from '../src/token.ts';
 import {Tokenizer, type Options} from '../src/tokenizer.ts';
 import * as util from '../src/util.ts';
 import { TokenStream } from '../src/tokenstream.ts';
+import { ErrorCollector } from '../src/assembler.ts';
 
 const [_] = [util];
 
@@ -29,9 +30,10 @@ async function expectSourceError(promise: Promise<unknown>, message: RegExp,
 
 //const MATCH = Symbol();
 
-async function tokenize(str: string, opts: Options = {}): Promise<Token[][]> {
+async function tokenize(str: string, opts: Options = {},
+                        errorCollector?: ErrorCollector): Promise<Token[][]> {
   const out : Token[][] = [];
-  const tokenizer = new Tokenizer(str, 'input.s', opts);
+  const tokenizer = new Tokenizer(str, 'input.s', opts, undefined, errorCollector);
   for (let line = await tokenizer.next(); line; line = await tokenizer.next()) {
     out.push(line.map(strip));
   }
@@ -271,8 +273,34 @@ describe('Tokenizer.line', function() {
     await expectSourceError(tokenize('  `abc'), /Syntax error/s, 1, 2);
   });
 
-  it('should fail to parse a bad string', function() {
-    expect(tokenize('  "abc')).rejects.toThrow(/EOF while looking for "/);
+  it('should fail to parse a string unterminated at eof', async function() {
+    await expectSourceError(tokenize('  "abc'), /Unterminated string, expected "/s, 1, 2);
+  });
+
+  it('should fail to parse a string unterminated at eol', async function() {
+    await expectSourceError(tokenize('  "abc\n  lda #$12\n'),
+                            /Unterminated string, expected "/s, 1, 2);
+  });
+
+  it('should fail to parse an unterminated char literal', async function() {
+    await expectSourceError(tokenize("  .byte 'a\n"),
+                            /Unterminated string, expected '/s, 1, 8);
+  });
+
+  it('should recover from an unterminated string when collecting errors', async function() {
+    const collector = new ErrorCollector();
+    const toks = await tokenize('  .byte "abc\n  lda #$12\n', {}, collector);
+    // The string is terminated at the end of the line and the next line is fine.
+    expect(toks).toEqual([
+      [{token: 'cs', str: '.byte', rawStr: '.byte'}, {token: 'str', str: 'abc'}],
+      [{token: 'ident', str: 'lda'}, {token: 'op', str: '#'},
+       {token: 'num', num: 0x12, width: 1}],
+    ]);
+    expect(collector.getMessages()).toMatchObject([{
+      level: 'error',
+      message: `Unterminated string, expected "`,
+      source: {file: 'input.s', line: 1, column: 8},
+    }]);
   });
 
   it('should not parse .2 as a directive', async function() {


### PR DESCRIPTION
This is another bulk drop of missing features from ca65. 

Some of these are effectively nop'd for now, but we should add them later (like all the .feature things)

Snuck into this batch are two commits that fix bugs I found while working on this.

* Fix operator precedence. There was an issue where `!` had the wrong precendence and caused some miscompliations. I switched to using the precedence values from ca65's table in the docs (well in the reverse direction since thats how js65 handles precedence)

* Fix hang when strings were unterminated. We didn't check for end of line properly when tokenizing a string literal, so leaving one open would cause a hang and a crash when you ran outta RAM. This ends the string at the end of the line and treats it as a recoverable error. 