### PR TITLE
Add ld65 linker file compatibility

### DIFF
--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -954,6 +954,7 @@ export class Assembler {
         case '.res': return this.res(...this.parseResArgs(tokens));
         case '.word': return this.word(...this.parseDataList(tokens));
         case '.dbyt': return this.dbyte(...this.parseDataList(tokens));
+        case '.faraddr': return this.faraddr(...this.parseDataList(tokens));
         case '.dword': return this.dword(...this.parseDataList(tokens));
         case '.free': return this.free(this.parseConst(tokens, 1));
         case '.segmentprefix': return this.segmentPrefix(this.parseStr(tokens, 1));
@@ -1645,6 +1646,25 @@ export class Assembler {
         this.writeNumber(chunk.data, 2, arg);
       } else {
         this.append(arg, 2);
+      }
+    }
+  }
+
+  /** `.faraddr`: a 24-bit little-endian address. */
+  faraddr(...args: Array<Expr|number>) {
+    const {chunk} = this;
+    this.markWritten(3 * args.length);
+
+    for (const arg of args) {
+      if (this.opts.generateDebugInfo && this._chunk?.sourceMap && this._source) {
+        for (let i = 0; i < 3; i++) {
+          this._chunk.sourceMap.set(chunk.data.length + i, this._source);
+        }
+      }
+      if (typeof arg === 'number') {
+        this.writeNumber(chunk.data, 3, arg);
+      } else {
+        this.append(arg, 3);
       }
     }
   }

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -28,7 +28,16 @@ function isSizeOfSymbol(name: string): boolean {
 }
 
 /**
- * List of CPUs that we support. 
+ * ca65 has some predefined segments, and normally this doesn't matter except for
+ * using the .code/.bss shortcuts, but for zeropage, we need to also set the
+ * addressing mode to `zp` as well.
+ */
+const PREDECLARED_SEGMENTS = new Map<string, mod.Segment>([
+  ['ZEROPAGE', {name: 'ZEROPAGE', addressing: 1}],
+]);
+
+/**
+ * List of CPUs that we support.
  * We aren't very strict about the difference between 6502 and 6502x.
  */
 const SUPPORTED_CPUS = new Set(['6502', '6502x']);
@@ -333,8 +342,13 @@ export class Assembler {
 
   /** Alignment constraint to stamp on the next chunk, from a pending `.align`. */
   private _pendingAlign: number|undefined = undefined;
-  /** TODO: use this to actually fill the alignment later. */
+  /** Fill byte for the pending `.align`, if it specified one. */
   private _pendingFill: number|undefined = undefined;
+  /**
+   * Chunk that was open when the pending `.align` was seen. If nothing follows
+   * the `.align` in that segment, this is the chunk that gets padded.
+   */
+  private _alignChunk: Chunk|undefined = undefined;
 
   /** Prefix to prepend to all segment names. */
   private _segmentPrefix = '';
@@ -397,6 +411,7 @@ export class Assembler {
         this._chunk.align = this._pendingAlign;
         this._pendingAlign = undefined;
         this._pendingFill = undefined;
+        this._alignChunk = undefined;
       }
       this._chunk.overwrite = this.overwriteMode;
 
@@ -486,9 +501,20 @@ export class Assembler {
         this.segments.every(s => this.segmentData.get(s)?.addressing === 1);
   }
 
+  /**
+   * When parsing symbols, we will need to be able to both resolve a symbol in the
+   * scope, and also size a symbol. Instead of sticking zeropage in as a second
+   * param everywhere, we can just roll it together with the symbol lookup. 
+   */
+  private readonly symbolLookup: Exprs.SymbolLookup = {
+    get: (name: string) => this.currentScope.symbols.get(name),
+    zeropage: (name: string) => this.isZeropageRef(name),
+  };
+
   // Returns an expr resolving to a symbol name (e.g. a label)
   symbol(name: string): Expr {
-    return Exprs.evaluate(Exprs.parseOnly([{token: 'ident', str: name}], 0, this.currentScope.symbols));
+    return Exprs.evaluate(
+        Exprs.parseOnly([{token: 'ident', str: name}], 0, this.symbolLookup));
   }
 
   where(): string {
@@ -653,8 +679,9 @@ export class Assembler {
       this.symbols.push(sym);
     }
 
-    // console.log(`resolve 1: ${JSON.stringify(sym)}`);
-    return {op: 'sym', num: sym.id};
+    const out: Expr = {op: 'sym', num: sym.id};
+    if (symbol.meta?.zeropage) out.meta = {zeropage: true};
+    return out;
   }
 
   // No banks are resolved yet.
@@ -793,6 +820,8 @@ export class Assembler {
   }
 
   module(): Module {
+    // A `.align` at the very end of the source still pads its segment in ca65.
+    this.flushPendingAlign();
     this.closeScopes();
 
     // TODO - handle imports and exports out of the scope
@@ -1000,10 +1029,9 @@ export class Assembler {
           // NOTE: Will need to be actually implemented if 16-bit CPU support is added.
           return;
 
-        // Segment shorthands: ca65 predeclares these named segments.
-        // ZEROPAGE is predeclared with zeropage addressing, same as `:zeropage`.
-        case '.zeropage': return this.parseNoArgs(tokens, 1),
-          this.segment({name: 'ZEROPAGE', addressing: 1});
+        // ca65 predeclares these named segments. The attributes come from
+        // PREDECLARED_SEGMENTS, so `.zeropage` and `.segment "ZEROPAGE"` are the same thing.
+        case '.zeropage': return this.parseNoArgs(tokens, 1), this.segment('ZEROPAGE');
         case '.code': return this.parseNoArgs(tokens, 1), this.segment('CODE');
         case '.data': return this.parseNoArgs(tokens, 1), this.segment('DATA');
         case '.rodata': return this.parseNoArgs(tokens, 1), this.segment('RODATA');
@@ -1232,9 +1260,9 @@ export class Assembler {
       // console.log(`before resolving: ${JSON.stringify(expr)}`);
       // expr = this.resolve(expr);
       
-      // If the size is unknown, but it was declared zp through
-      // importzp/globalzp then we force it to 1 byte.
-      const s = expr.meta?.size ?? (this.isZeropageRef(expr) ? 1 : 2);
+      // If the size is unknown, fall back to the operand's address size, which
+      // is zeropage only if it was tracked all the way here from the definition.
+      const s = expr.meta?.size ?? (expr.meta?.zeropage ? 1 : 2);
       // console.log(`sizing up 'add' expr: ${JSON.stringify(expr)}`);
       if (m === 'add' && s === 1 && 'zpg' in ops) {
         return this.opcode(ops.zpg!, 1, expr);
@@ -1410,12 +1438,14 @@ export class Assembler {
       this._org + this._chunk.data.length === addr) {
       return; // nothing to do?
     }
+    this.flushPendingAlign();
     this._org = addr;
     this._chunk = undefined;
     this._name = name;
   }
 
   reloc(name?: string) {
+    this.flushPendingAlign();
     this._org = undefined;
     this._chunk = undefined;
     this._name = name;
@@ -1423,11 +1453,20 @@ export class Assembler {
 
   segment(...segments: Array<string|mod.Segment>) {
     // Usage: .segment "1a", "1b", ...
+    // A trailing `.align` belongs to the segment it appeared in, so pad it out
+    // here rather than letting it leak onto the next segment's chunk.
+    this.flushPendingAlign();
     this.segments = segments.map(s => typeof s === 'string' ? s : s.name);
     for (const s of segments) {
+      const name = typeof s === 'string' ? s : s.name;
+      let data = this.segmentData.get(name);
+      if (!data) {
+        // Copy, so that later merges/`.free` don't mutate the shared template.
+        const predeclared = PREDECLARED_SEGMENTS.get(name);
+        if (predeclared) this.segmentData.set(name, data = {...predeclared});
+      }
       if (typeof s === 'object') {
-        const data = this.segmentData.get(s.name) || {name: s.name};
-        this.segmentData.set(s.name, mod.Segment.merge(data, s));
+        this.segmentData.set(name, mod.Segment.merge(data || {name}, s));
       }
     }
     this._chunk = undefined;
@@ -1541,10 +1580,33 @@ export class Assembler {
       if (pad) this.res(pad, fill);
       return;
     }
-    // Relocatable mode means we just delay this until link time instead
+    // Relocatable mode means we just delay this until link time instead.
+    if (this._pendingAlign == null) this._alignChunk = this._chunk;
+    this._pendingAlign = Math.max(this._pendingAlign ?? 1, boundary);
+    this._pendingFill = fill ?? this._pendingFill;
     this._chunk = undefined;
-    this._pendingAlign = boundary;
-    this._pendingFill = fill;
+  }
+
+  /**
+   * If an `.align` was used at the end of a chunk, and no data follows it,
+   * then we need to align the current chunk. This needs to be called whenever
+   * starting a new chunk then to see if we need to align the old one, and then
+   * clearing the pending alignment.
+   */
+  private flushPendingAlign() {
+    const boundary = this._pendingAlign;
+    const fill = this._pendingFill;
+    const chunk = this._alignChunk;
+    this._pendingAlign = undefined;
+    this._pendingFill = undefined;
+    this._alignChunk = undefined;
+    if (boundary == null || !chunk?.data.length) return;
+    // A relocatable chunk that must end on a boundary must also start on one,
+    // so padding its length up to a multiple leaves the end aligned as well.
+    const pc = chunk.org != null ? chunk.org + chunk.data.length : chunk.data.length;
+    const pad = (boundary - (pc % boundary)) % boundary;
+    if (chunk.org == null) chunk.align = Math.max(chunk.align ?? 1, boundary);
+    for (let i = 0; i < pad; i++) chunk.data.push(fill ?? 0);
   }
 
   // CA65 compatible 1:1 character mapping. Given a single char byte or a byte literal,
@@ -1746,9 +1808,38 @@ export class Assembler {
     this._segmentPrefix = prefix;
   }
 
-  /** Whether an operand is a bare reference to a symbol declared zeropage. */
-  private isZeropageRef(expr: Expr): boolean {
-    return expr.op === 'sym' && expr.sym != null && this.zeropageGlobals.has(expr.sym);
+  /**
+   * Whether a reference to `name` from the current scope lands in the zeropage.
+   * Steps through the scope tree to try and find the symbol in parent scopes
+   * so we can properly size it.
+   */
+  private isZeropageRef(name: string): boolean {
+    if (this.zeropageGlobals.has(name)) return true;
+    return Boolean(this.lookupSymbol(name)?.expr?.meta?.zeropage);
+  }
+
+  /**
+   * Run through the scope tree looking for the named symbol without
+   * creating a forward reference if its not found. We are just interested
+   * in finding this information for sizing.
+   */
+  private lookupSymbol(name: string): Symbol|undefined {
+    try {
+      if (name.startsWith('@')) {
+        return this.cheapLocals.resolve(name, {allowForwardRef: false});
+      }
+      let scope: Scope|undefined = this.currentScope;
+      const unscoped = !name.includes('::');
+      do {
+        const sym = scope.resolve(name, {allowForwardRef: false});
+        if (sym?.expr) return sym;
+        if (sym?.scoped) return sym; // explicitly scoped: no outer name applies
+      } while (unscoped && (scope = scope.parent));
+    } catch {
+      // An unresolvable explicit scope shouldn't throw here. The symbol
+      // gets resolved for real (and fails there) once the operand is emitted.
+    }
+    return undefined;
   }
 
   private declareGlobal(ident: string, kind: 'export'|'import'|'global', weak = false) {
@@ -1837,6 +1928,7 @@ export class Assembler {
   }
 
   pushSeg(...segments: Array<string|mod.Segment>) {
+    this.flushPendingAlign();
     this.segmentStack.push([this.segments, this._chunk]);
     // If pushseg was called without any segments, just keep the current segment
     if (segments) {
@@ -1846,6 +1938,7 @@ export class Assembler {
 
   popSeg() {
     if (!this.segmentStack.length) this.fail(`.popseg without .pushseg`);
+    this.flushPendingAlign();
     [this.segments, this._chunk] = this.segmentStack.pop()!;
     this._org = this._chunk?.org;
   }
@@ -1899,7 +1992,7 @@ export class Assembler {
     Tokens.expectEol(tokens[1]);
   }
   parseExpr(tokens: Token[], start: number): Expr {
-    return Exprs.parseOnly(tokens, start, this.currentScope.symbols, this.encodeChar);
+    return Exprs.parseOnly(tokens, start, this.symbolLookup, this.encodeChar);
   }
 
   /**

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -1915,6 +1915,29 @@ export class Assembler {
     return undefined;
   }
 
+  /**
+   * A boolean segment attribute. If a param is not provided, it defaults to true
+   * otherwise is uses the value after it (as a const value).
+   */
+  parseFlag(tokens: Token[], key: string): boolean {
+    if (!tokens.length) return true;
+    const val = this.parseConst(tokens, 0);
+    if (val !== 0 && val !== 1) {
+      this.fail(`Segment attr ${key} must be 0 or 1: ${val}`, tokens[0]);
+    }
+    return val !== 0;
+  }
+
+  /** An alignment segment attribute which must be a positive power of two. */
+  parseAlign(tokens: Token[], key: string): number {
+    if (!tokens.length) this.fail(`Segment attr ${key} needs a value`);
+    const val = this.parseConst(tokens, 0);
+    if (val < 1 || (val & (val - 1)) !== 0) {
+      this.fail(`Segment attr ${key} must be a power of two: ${val}`, tokens[0]);
+    }
+    return val;
+  }
+
   parseSegmentList(tokens: Token[], start: number, allowEmptySegmentList: boolean): Array<string|mod.Segment> {
     if (tokens.length < start + 1) {
       if (allowEmptySegmentList) {
@@ -1937,10 +1960,22 @@ export class Assembler {
           case 'size': seg.size = this.parseConst(val, 0); break;
           case 'off': seg.offset = this.parseConst(val, 0); break;
           case 'mem': seg.memory = this.parseConst(val, 0); break;
-          case 'fill': seg.fill = this.parseConst(val, 0); break;
+          // `:fill` with no value fills with zeros, like ld65's `fill = yes`.
+          case 'fill': seg.fill = val.length ? this.parseConst(val, 0) : 0; break;
           case 'out': seg.out = this.parseOptionalStr(val, 0) ?? '%O'; break;
-          case 'overlay': seg.overlay = this.parseStr(val, 0); break;
-          case 'zp': case 'zeropage': seg.addressing = 1; break;
+          case 'align': seg.align = this.parseAlign(val, key); break;
+          case 'alignload': seg.alignLoad = this.parseAlign(val, key); break;
+          case 'load': seg.load = this.parseStr(val, 0); break;
+          case 'run': seg.run = this.parseStr(val, 0); break;
+          // ld65's `type = zp` is both an addressing size and a bss segment.
+          case 'zp': case 'zeropage': seg.addressing = 1; seg.bss = true; break;
+          case 'bss': seg.bss = this.parseFlag(val, key); break;
+          case 'define': seg.define = this.parseFlag(val, key); break;
+          case 'optional': seg.optional = this.parseFlag(val, key); break;
+          case 'dedupe': seg.dedupe = this.parseFlag(val, key); break;
+          case 'default': seg.default = this.parseFlag(val, key); break;
+          // js65 has no read-only concept, so accept and ignore ld65's types.
+          case 'ro': case 'rw': break;
           default: this.fail(`Unknown segment attr: ${key}`);
         }
       }

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -504,10 +504,10 @@ export class Assembler {
   /**
    * When parsing symbols, we will need to be able to both resolve a symbol in the
    * scope, and also size a symbol. Instead of sticking zeropage in as a second
-   * param everywhere, we can just roll it together with the symbol lookup. 
+   * param everywhere, we can just roll it together with the symbol lookup.
    */
   private readonly symbolLookup: Exprs.SymbolLookup = {
-    get: (name: string) => this.currentScope.symbols.get(name),
+    get: (name: string) => this.lookupSymbol(name),
     zeropage: (name: string) => this.isZeropageRef(name),
   };
 
@@ -1254,12 +1254,14 @@ export class Assembler {
     if (m === 'add' || m === 'a,x' || m === 'a,y') {
       // Special case for address mnemonics
       let expr = arg[1]!;
-      // Attempt to resolve the expression first. If we are able to, then
-      // we can appropriately size the expression
+      // Before choosing an addressing mode, we need to try and fold any
+      // arithmetic to see if the address is known, and if its ZP or ABS
+      // This way, a value like $0f + 1 will end up in ZP, but something like
+      // $80 + $8000 will end up in ABS still.
+      if (expr.meta?.size == null && expr.args) {
+        expr = Exprs.traversePost(expr, Exprs.evaluate);
+      }
 
-      // console.log(`before resolving: ${JSON.stringify(expr)}`);
-      // expr = this.resolve(expr);
-      
       // If the size is unknown, fall back to the operand's address size, which
       // is zeropage only if it was tracked all the way here from the definition.
       const s = expr.meta?.size ?? (expr.meta?.zeropage ? 1 : 2);
@@ -1820,26 +1822,32 @@ export class Assembler {
 
   /**
    * Run through the scope tree looking for the named symbol without
-   * creating a forward reference if its not found. We are just interested
-   * in finding this information for sizing.
+   * creating a forward reference if its not found. We need to walk
+   * through the tree here to see if we can properly size the value
+   * now instead of deferring it to link time which would force this
+   * to get pessimized to an ABS addressing mode.
    */
   private lookupSymbol(name: string): Symbol|undefined {
-    try {
-      if (name.startsWith('@')) {
-        return this.cheapLocals.resolve(name, {allowForwardRef: false});
-      }
-      let scope: Scope|undefined = this.currentScope;
-      const unscoped = !name.includes('::');
-      do {
-        const sym = scope.resolve(name, {allowForwardRef: false});
+    if (name.startsWith('@')) return this.cheapLocals.symbols.get(name);
+    // This runs for every identifier in every expression, so shortcut
+    // checking for the symbol if it isn't explicitly scoped and jump
+    // straight to the symbol map lookup.
+    if (!name.includes('::')) {
+      for (let scope: Scope|undefined = this.currentScope; scope;
+           scope = scope.parent) {
+        const sym = scope.symbols.get(name);
         if (sym?.expr) return sym;
         if (sym?.scoped) return sym; // explicitly scoped: no outer name applies
-      } while (unscoped && (scope = scope.parent));
+      }
+      return undefined;
+    }
+    try {
+      return this.currentScope.resolve(name, {allowForwardRef: false});
     } catch {
       // An unresolvable explicit scope shouldn't throw here. The symbol
       // gets resolved for real (and fails there) once the operand is emitted.
+      return undefined;
     }
-    return undefined;
   }
 
   private declareGlobal(ident: string, kind: 'export'|'import'|'global', weak = false) {

--- a/src/buffer.ts
+++ b/src/buffer.ts
@@ -9,30 +9,8 @@ class State {
               readonly match: Match|undefined) {}
 }
 
-// Optimization for the buffer to keep from needing to slice the same string multiple time
-// The tokenizer tends to move forward across the tokens calling substring to move to the
-// next part. But on the hermes frontned, the substring calls seemed to make an internal
-// copy of the string each time, whereas in the V8/browser JS engines, they have an
-// optimization to lazily handle substrings to reuse the original string buffer.
-// The fix I went with is to use the `y` sticky flag in the Regex engine as a cheaper
-// substring. Instead of needing to substring, we can "resume" the search from the lastIndex
-// to stop from needing to scan again from the start. This ends up making a large performance
-// improvement for hermes when processing large files.
-const stickySearchCache = new Map<string, RegExp>();
-function sticky(re: RegExp): RegExp {
-  const key = re.flags + ' ' + re.source;
-  let s = stickySearchCache.get(key);
-  if (!s) {
-    // A leading '^' anchors at start-of-input. With the sticky flag the match
-    // is already anchored at lastIndex, and '^' would *fail* at any pos > 0,
-    // so strip it. Drop any existing g/y flag and force sticky mode.
-    const flags = re.flags.replace(/[gy]/g, '') + 'y';
-    const source = re.source.replace(/^\^/, '');
-    s = new RegExp(source, flags);
-    stickySearchCache.set(key, s);
-  }
-  return s;
-}
+const RE_SPACE = /[ \t]+/y;
+const RE_NEWLINE = /(\r\n|\n|\r)/y;
 
 export class Buffer {
   pos = 0;
@@ -53,14 +31,6 @@ export class Buffer {
     this.column += lines[lines.length - 1].length;
   }
 
-  // Run a regex anchored at the current position without using substring
-  // which seemingly caused a full copy on hermes.
-  private execAt(re: RegExp): Match|null {
-    const s = sticky(re);
-    s.lastIndex = this.pos;
-    return s.exec(this.content) as Match|null;
-  }
-
   saveState(): State {
     return new State(this.line, this.column, this.pos, this.lastMatch);
   }
@@ -73,39 +43,40 @@ export class Buffer {
   }
 
   skip(re: RegExp): boolean {
-    const match = this.execAt(re);
+    re.lastIndex = this.pos;
+    const match = re.exec(this.content) as Match|null;
     if (!match) return false;
     this.advance(match[0]);
     return true;
   }
-  space(): boolean { return this.skip(/^[ \t]+/); }
-  newline(): boolean { return this.skip(/^(\r\n|\n|\r)/); }
+  space(): boolean { return this.skip(RE_SPACE); }
+  newline(): boolean { return this.skip(RE_NEWLINE); }
 
   lookingAt(re: RegExp|string): boolean {
     if (typeof re === 'string') return this.content.startsWith(re, this.pos);
-    const s = sticky(re);
-    s.lastIndex = this.pos;
-    return s.test(this.content);
+    re.lastIndex = this.pos;
+    return re.test(this.content);
   }
 
-  // NOTE: re should always be rooted with /^/ at the start.
-  token(re: RegExp|string): boolean {
-    let match: Match|null;
-    if (typeof re === 'string') {
-      if (!this.content.startsWith(re, this.pos)) return false;
-      match = [re] as Match;
-    } else {
-      match = this.execAt(re);
-    }
+  // NOTE: re should always be used with the /y sticky flag.
+  token(re: RegExp): boolean {
+    re.lastIndex = this.pos;
+    const match = re.exec(this.content) as Match|null;
     if (!match) return false;
     match.line = this.line;
     match.column = this.column;
     this.lastMatch = match;
     this.advance(match[0]);
-
-//    console.log(`TOKEN: ${re} "${match[0]}"`);
-//try{throw Error();}catch(e){console.log(e);}
-
+    return true;
+  }
+  tokenStr(s: string): boolean {
+    let match: Match|null;
+    if (!this.content.startsWith(s, this.pos)) return false;
+    match = [s] as Match;
+    match.line = this.line;
+    match.column = this.column;
+    this.lastMatch = match;
+    this.advance(match[0]);
     return true;
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,6 +35,7 @@ class Arguments {
   files : string[] = [];
   dbgfile = "";
   mapfile = "";
+  cfgfile = "";
   compileonly = false;
   patch : "ips" | "" = "";
   options: Js65Options = {
@@ -114,6 +115,12 @@ export class Cli {
         out.mapfile = args[++i];
       } else if (arg.startsWith('--mapfile=')) {
         out.mapfile = arg.substring('--mapfile='.length);
+      } else if (arg === '-C' || arg === '--config') {
+        if (out.cfgfile) this.usage();
+        out.cfgfile = args[++i];
+      } else if (arg.startsWith('--config=')) {
+        if (out.cfgfile) this.usage();
+        out.cfgfile = arg.substring('--config='.length);
       } else if (arg === '-g' || arg === '-g0') {
         out.options.debugLevel = 0; // Comments and labels only
         out.options.generateDebugInfo = true;
@@ -177,6 +184,8 @@ export class Cli {
         return this.usage(8, [new Error(`Cannot use --compileonly flag combined with --${args.patch}`)]);
       else if (args.mapfile)
         return this.usage(8, [new Error("Cannot use --compileonly flag combined with -m/--mapfile")]);
+      else if (args.cfgfile)
+        return this.usage(8, [new Error("Cannot use --compileonly flag combined with -C/--config")]);
     }
 
     if (args.mapfile) args.options.generateMapFile = true;
@@ -216,6 +225,13 @@ export class Cli {
         ...(args.options.includePaths ?? []),
       ];
 
+      // Load the ld65 linker config, if given. readSource caches the text so a
+      // parse error further in gets a source snippet like any other file.
+      if (args.cfgfile) {
+        args.options.linkerConfig = await this.readSource("", args.cfgfile);
+        args.options.linkerConfigName = args.cfgfile;
+      }
+
       // Load base ROM if specified
       let baseRom: Uint8Array | undefined;
       if (args.rom) {
@@ -244,6 +260,14 @@ export class Cli {
       const primary = result.outputs.find(o => o.type === 'binary' || o.type === 'object')
           ?? result.outputs[0];
       await this.callbacks.fsWriteBytes("", args.outfile, primary.data);
+
+      // A linker config can send segments to files of their own. Their names
+      // come from the config verbatim, so `%O` still has to be filled in.
+      for (const extra of result.outputs) {
+        if (extra === primary || extra.type !== 'binary') continue;
+        await this.callbacks.fsWriteBytes(
+            "", extra.name.replace(/%O/g, args.outfile), extra.data);
+      }
 
       // Write debug info if requested
       const debug = findOutput(result, 'debug');
@@ -396,6 +420,9 @@ optional arguments:
   --no-debuginfo          Disable debug info generation.
   --dbgfile FILE          Output debug symbols to the specified file.
   -m FILE/--mapfile=FILE  Output a linker map (free space / placed chunks) to the specified file. Cannot be used with --compileonly.
+  -C FILE/--config=FILE   Link using an ld65 linker config, in place of the built-in
+                          segment layout.
+                          Cannot be used with --compileonly.
   -I DIR/--include-dir=DIR
                           Add DIR to the \`.include\` search path. Directories are
                           searched in the order given, after the directory of the file doing the

--- a/src/expr.ts
+++ b/src/expr.ts
@@ -348,8 +348,15 @@ export function identifier(expr: Expr): string {
  */
 export type CharEncoder = (char: string) => number|undefined;
 
+export interface SymbolLookup {
+  /** Symbol table for already defined symbols. */
+  get(name: string): Symbol|undefined;
+  /** Check the scopes to size the symbol and return if its zeropage. */
+  zeropage?(name: string): boolean;
+}
+
 /** Parse a single expression, must occupy the rest of the line. */
-export function parseOnly(tokens: Token[], index = 0, symbols?: Map<string, Symbol>,
+export function parseOnly(tokens: Token[], index = 0, symbols?: SymbolLookup,
                           charEncoder?: CharEncoder): Expr {
   const [expr, i] = parse(tokens, index, symbols, charEncoder);
   if (i < tokens.length) {
@@ -364,10 +371,8 @@ export function parseOnly(tokens: Token[], index = 0, symbols?: Map<string, Symb
 // Returns [undefined, -1] if a bad parse.
 // Give up on normal parsing, just use a shunting yard again...
 //  - but handle parens recursively.
-export function parse(tokens: Token[], index = 0, symbols?: Map<string, Symbol>,
+export function parse(tokens: Token[], index = 0, symbols?: SymbolLookup,
                       charEncoder?: CharEncoder): [Expr|undefined, number] {
-//console.log('PARSE: tokens=', tokens, 'index=', index);
-//try { throw new Error(); } catch (e) { console.log(e.stack); }
   const ops: [string, OperatorMeta][] = [];
   const exprs: Expr[] = [];
 
@@ -434,7 +439,15 @@ export function parse(tokens: Token[], index = 0, symbols?: Map<string, Symbol>,
         // add symbol
         // use scope information to determine size
         const expr = symbols?.get(front.str)?.expr;
-        exprs.push((expr) ? expr : {op: 'sym', sym: front.str});
+        if (expr) {
+          exprs.push(expr);
+        } else {
+          // Nothing to inline, but the address size may still be known. Carry
+          // it on the reference so `+`/`-` and the operand sizing can see it.
+          const ref: Expr = {op: 'sym', sym: front.str};
+          if (symbols?.zeropage?.(front.str)) ref.meta = {zeropage: true};
+          exprs.push(ref);
+        }
         val = false;
       } else if (front.token === 'num') {
         // add number
@@ -565,7 +578,7 @@ function plus(expr: Expr): Expr {
   if (!out.meta?.rel && out.meta?.size == null) {
     (out.meta || (out.meta = {})).size = size(out.num!).size;
   }
-  return out;
+  return carryZeropage(out, '+', [a, b]);
 }
 
 function minus(expr: Expr): Expr {
@@ -592,7 +605,14 @@ function minus(expr: Expr): Expr {
   if (isBranch && out.op === 'num') {
     (out.meta || (out.meta = {})).branch = true;
   }
-  return out;
+  return carryZeropage(out, '-', [a, b]);
+}
+
+/** For +/- ops, we want things like ZP + 1 to also land in ZP */
+function carryZeropage(out: Expr, op: string, args: Expr[]): Expr {
+  if (out.meta?.zeropage || !isZeropage(op, args)) return out;
+  // Copy rather than mutate since `out.meta` may still be an operand's `meta`.
+  return {...out, meta: {...out.meta, zeropage: true}};
 }
 
 function isAbs(expr: Expr): boolean {
@@ -734,7 +754,29 @@ function fixSize(expr: Expr): Expr {
   const xform = SIZE_TRANSFORMS.get(expr.op);
   const size = xform?.(...expr.args!.map(e => Number(e.meta?.size)));
   if (size) (expr.meta || (expr.meta = {})).size = size;
+  if ((expr.op === '+' || expr.op === '-') && isZeropage(expr.op, expr.args!)) {
+    (expr.meta || (expr.meta = {})).zeropage = true;
+  }
   return expr;
+}
+
+function isAddress(expr: Expr): boolean {
+  switch (expr.op) {
+    case 'sym': case 'im': return true;
+    case 'num':
+      return Boolean(expr.meta?.rel || expr.meta?.zeropage ||
+                     expr.meta?.chunk != null);
+    case '+': case '-': return (expr.args ?? []).some(isAddress);
+    default: return false;
+  }
+}
+
+function isZeropage(op: string, args: Expr[]): boolean {
+  // Unary `-` negates, which no longer names an address; unary `+` is identity.
+  if (args.length === 1) return op === '+' && Boolean(args[0].meta?.zeropage);
+  if (op === '-' && isAddress(args[1])) return false;
+  const addrs = args.filter(isAddress);
+  return addrs.length === 1 && Boolean(addrs[0].meta?.zeropage);
 }
 
 export function size(num: number, token?: Token): Meta {
@@ -743,7 +785,3 @@ export function size(num: number, token?: Token): Meta {
   }
   return {size: 0 <= num && num < 256 ? 1 : 2};
 }
-
-// function fail(msg: string): never {
-//   throw new Error(msg);
-// }

--- a/src/expr.ts
+++ b/src/expr.ts
@@ -576,7 +576,7 @@ function plus(expr: Expr): Expr {
     }
   }
   if (!out.meta?.rel && out.meta?.size == null) {
-    (out.meta || (out.meta = {})).size = size(out.num!).size;
+    (out.meta || (out.meta = {})).size = foldedSize(out.num!, a, b);
   }
   return carryZeropage(out, '+', [a, b]);
 }
@@ -599,13 +599,18 @@ function minus(expr: Expr): Expr {
   }
   if (a.meta?.rel) out.meta = a.meta;
   if (!out.meta?.rel && out.meta?.size == null) {
-    (out.meta || (out.meta = {})).size = size(out.num!).size;
+    (out.meta || (out.meta = {})).size = foldedSize(out.num!, a, b);
   }
   // Preserve branch flag even for non-relative subtractions
   if (isBranch && out.op === 'num') {
     (out.meta || (out.meta = {})).branch = true;
   }
   return carryZeropage(out, '-', [a, b]);
+}
+
+function foldedSize(num: number, ...args: Expr[]): number {
+  return Math.max(size(num).size!,
+                  ...args.map(a => Number(a.meta?.size) || 0));
 }
 
 /** For +/- ops, we want things like ZP + 1 to also land in ZP */

--- a/src/libassembler.ts
+++ b/src/libassembler.ts
@@ -81,6 +81,10 @@ export interface LinkerOptions {
   target?: string;
   baseRom?: Uint8Array;
   baseRomOffset?: number;
+  /** Full text of an ld65 linker config, which replaces `target`. */
+  linkerConfig?: string;
+  /** Name to report `linkerConfig` parse errors against. */
+  linkerConfigName?: string;
   /** Debug level for debug info generation:
    * -1 = disabled
    *  0 = comments/labels only
@@ -112,6 +116,10 @@ export interface Js65Options {
   baseRomOffset?: number;
   outputFormat?: OutputFormat;
   generateMapFile?: boolean;
+  /** Full text of an ld65 linker config. Replaces `target` when given. */
+  linkerConfig?: string;
+  /** Name to report `linkerConfig` parse errors against. */
+  linkerConfigName?: string;
 }
 
 /**
@@ -354,6 +362,8 @@ export interface LinkResult {
   success: boolean;
   /** Binary output or IPS patch (empty if errors) */
   data: Uint8Array;
+  /** Any outputs named in a linker config that was the original %o output */
+  extraOutputs: {name: string, data: Uint8Array}[];
   /** Debug information in MLB format (empty string if sourceContents not provided or errors) */
   debugInfo: string;
   /** Linker map (empty unless requested or on errors) */
@@ -384,7 +394,11 @@ export function link(
   const allMessages = [...messages];
 
   try {
-    const linker = new Linker({ target: options?.target });
+    const linker = new Linker({
+      target: options?.target,
+      linkerConfig: options?.linkerConfig,
+      linkerConfigName: options?.linkerConfigName,
+    });
 
     // Load base ROM if provided and not generating IPS
     let data: Uint8Array | null = null;
@@ -398,10 +412,18 @@ export function link(
     }
 
     const out = linker.link(signal);
+    // A config can send segments to files of their own; only the main output
+    // is patched into the base ROM.
+    const extraOutputs = linker.outputFiles();
 
     // Generate output based on format
     let binaryData: Uint8Array;
     if (outputFormat === 'ips') {
+      if (extraOutputs.length) {
+        throw new Error(`Cannot write an IPS patch from a linker config with ${
+                        ''}more than one output file (${
+                        extraOutputs.map(o => o.name).join(', ')})`);
+      }
       binaryData = out.toIpsPatch();
     } else {
       if (!data) data = new Uint8Array(out.length);
@@ -417,6 +439,7 @@ export function link(
     return {
       success: !hasErrors,
       data: binaryData,
+      extraOutputs,
       debugInfo,
       mapFile,
       messages: allMessages
@@ -428,6 +451,7 @@ export function link(
     return {
       success: false,
       data: new Uint8Array(0),
+      extraOutputs: [],
       debugInfo: '',
       mapFile: '',
       messages: allMessages
@@ -584,6 +608,8 @@ export async function compile(
       baseRomOffset: options.baseRomOffset,
       debugLevel: options.debugLevel,
       generateMapFile: options.generateMapFile,
+      linkerConfig: options.linkerConfig,
+      linkerConfigName: options.linkerConfigName,
     };
     const outputFormat: OutputFormat = options.outputFormat ?? 'binary';
     const sourceContents = options.generateDebugInfo ? new SourceContents() : undefined;
@@ -620,7 +646,12 @@ export async function compile(
 
     const lr = link(asm.modules, linkerOpts, outputFormat, sourceContents, asm.messages, signal);
     const outputName = outputFormat === 'ips' ? 'out.ips' : 'out.nes';
+    // The main output comes first, so anything picking "the binary" out of the
+    // list still gets the ROM rather than one of the config's extra files.
     const outputs: OutputFile[] = [{ name: outputName, data: lr.data, type: 'binary' }];
+    for (const extra of lr.extraOutputs) {
+      outputs.push({ name: extra.name, data: extra.data, type: 'binary' });
+    }
     // Debug info rides as a sidecar output (type 'debug') rather than a separate field.
     if (lr.debugInfo) {
       outputs.push({ name: 'out.mlb', data: new TextEncoder().encode(lr.debugInfo), type: 'debug' });

--- a/src/linker.ts
+++ b/src/linker.ts
@@ -5,7 +5,7 @@ import { Assembler } from './assembler.ts';
 import { Cpu } from './cpu.ts';
 import type { Expr } from './expr.ts';
 import * as Exprs from './expr.ts';
-import { type LinkerConfig, lowerLinkerConfig, parseLinkerConfig } from './linkerconfig.ts';
+import { type CfgSymbols, type LinkerConfig, configSymbols, lowerLinkerConfig, parseLinkerConfig, resolveCfgExpr } from './linkerconfig.ts';
 import { type Chunk, type Module, type OverwriteMode, Segment, type Substitution, type Symbol } from './module.ts';
 import { Targets } from "./preamble.ts";
 import { Preprocessor } from './preprocessor.ts';
@@ -93,6 +93,10 @@ export class Linker {
 
   report(verbose = false): string {
     return this._link.report(verbose);
+  }
+
+  outputFiles(): Array<{name: string, data: Uint8Array}> {
+    return this._link.outputFiles();
   }
 
   exports(): Map<string, Export> {
@@ -292,14 +296,20 @@ export class Linker {
         ? this._link.chunks[meta.chunk]
         : undefined;
 
+      // A symbol defined over a label (`P1_HELD = Buttons+2`) is resolved
+      // before the chunk is placed, so its value is still relative to the
+      // chunk. Only the chunk knows where that ended up.
+      const value = chunk && meta?.rel ?
+          (chunk.org ?? 0) + (s.expr.num ?? 0) : (s.expr.num ?? 0);
+
       if (chunk?.segment?.isRam || !chunk) {
         // For chunks that are not output to the final ROM, use a heuristic to determine address
-        const result = Linker.getLabelTypeAndAddress(s.expr.num ?? 0);
+        const result = Linker.getLabelTypeAndAddress(value);
         labelType = result.type;
         addr = result.address;
       } else {
         // For chunks that are output, use the resolved address instead
-        const offsetInChunk: number = s.expr.num! - ((meta?.rel) ? 0 : (chunk.org ?? 0));
+        const offsetInChunk: number = value - (chunk.org ?? 0);
         const fileOffset = (chunk.offset ?? 0) + offsetInChunk;
         addr = fileOffset - prgBaseOffset;
         labelType = "NesPrgRom";
@@ -536,6 +546,8 @@ class LinkSegment {
   readonly addressing: number;
   /** Byte to fill unused space with, or undefined to leave it alone. */
   readonly fill: number|undefined;
+  /** Output file the segment's bytes go to, `%O` (or unset) being the main one. */
+  readonly out: string|undefined;
   /** Whether chunks placed here may share bytes with identical data. */
   readonly dedupe: boolean;
   readonly isRam: boolean;
@@ -563,6 +575,7 @@ class LinkSegment {
     // Allow memory offset to be null for non-prg segments
     this.memory = segment.memory ?? 0;
     this.fill = segment.fill;
+    this.out = segment.out;
     this.dedupe = segment.dedupe ?? false;
     this.used = used;
   }
@@ -910,6 +923,25 @@ class Link {
   private segmentMappings = new Set<string>();
   /** Track the `used` values for each mapped segment */
   private segmentUsed = new Map<string, number>();
+  /** Org ranges of each mapped segment that placement may still use. */
+  private segmentFree = new Map<string, Array<readonly [number, number]>>();
+  /**
+   * Address a lowered segment loads at, in its load mapping's address space.
+   * Only differs from the segment's own `memory` when load != run.
+   */
+  private segmentLoad = new Map<string, number>();
+  /** Bytes accounted for in each segment once its geometry was fixed. */
+  private segmentExtent = new Map<string, number>();
+  /** Effective alignment of each segment's start, for the map file. */
+  private segmentAlign = new Map<string, number>();
+  /** Internal offset base for each output file. The main file is always 0. */
+  private fileBases = new Map<string, number>([['%O', 0]]);
+  /** Bytes written to each output file, keyed the same way as `fileBases`. */
+  private outputs = new Map<string, SparseByteArray>();
+  /** The ld65 config in use, kept around for its SYMBOLS block. */
+  private config?: LinkerConfig;
+  /** Symbols the object files export, captured when the config was set. */
+  private objectExports: ReadonlySet<string> = new Set();
 
   watches: number[] = []; // debugging aid: offsets to watch.
   placed: Array<[number, LinkChunk]> = [];
@@ -1038,15 +1070,13 @@ class Link {
           this.data.splice(start + s.delta, end - start);
         }
       } else if (s.size > 0) {
-        // Mark the entire segment as free if it was originally a mapped
-        // segment. We don't want originally unmapped segments to be
-        // automatically freed since they don't "own" the space
-        // There is an exception to this, a mapped segment holding chunks of
-        // that the user wrote directly, owns whatever that data.
-        const from = this.segmentMappings.has(name) ?
-            this.segmentUsed.get(name) : 0;
-        if (from != null && from < s.size) {
-          this.free.add(s.memory + from + s.delta, s.memory + s.size + s.delta);
+        // Otherwise the whole segment is free, except that a mapped segment
+        // only owns what it did not hand out to the segments lowered into it.
+        // lowerSegments works out which parts of it those are.
+        const ranges = this.segmentFree.get(name) ??
+            [[s.memory, s.memory + s.size] as const];
+        for (const [start, end] of ranges) {
+          if (end > start) this.free.add(start + s.delta, end + s.delta);
         }
       }
     }
@@ -1067,6 +1097,10 @@ class Link {
         this.exports.set(symbol.export, i);
       }
     }
+    // Publish the linker's own symbols here: geometry is final, the object
+    // files' exports are all registered, and nothing has been resolved yet, so
+    // a forward reference into a later segment's defines just works.
+    this.defineConfigSymbols(this.defineSegmentSymbols(merged));
     // Resolve all the imports in all symbol and chunk.subs exprs.
     for (const symbol of this.symbols) {
       symbol.expr = this.resolveSymbols(symbol.expr!);
@@ -1121,14 +1155,17 @@ class Link {
 
 
     // At this point, everything should be placed, so do one last resolve.
-    const patch = new SparseByteArray();
+    // Each output file collects its own bytes, at offsets relative to itself
+    // rather than the internal space the linker placed them in.
+    const patch = this.output('%O');
     // Before placing the data, add the fill bytes to segments with fill
     for (const [_name, seg] of this.segments) {
       if (seg.isRam) continue;  // RAM segments don't need fill
       if (seg.fill != null) {  // NOTE: fill = 0 still fills.
         const buf = new Uint8Array(new ArrayBuffer(seg.size));
         buf.fill(seg.fill);
-        patch.set(seg.offset, buf);
+        this.output(seg.out).set(seg.offset - this.fileBase(seg.out || '%O'),
+                                 buf);
       }
     }
     for (const c of this.chunks) {
@@ -1140,7 +1177,10 @@ class Link {
       }
       if (c.overlaps) continue;
       if (c.segment?.isRam) continue;  // RAM chunks not in output
-      patch.set(c.offset!, Uint8Array.from(this.data.slice(c.offset!, c.offset! + c.size!)));
+      const base = this.fileBase(c.segment?.out || '%O');
+      this.output(c.segment?.out).set(
+          c.offset! - base,
+          Uint8Array.from(this.data.slice(c.offset!, c.offset! + c.size!)));
     }
     if (DEBUG) console.log(this.report(true));
     return patch;
@@ -1184,11 +1224,25 @@ class Link {
       list.push(chunk);
     }
 
+    /** Get a rough estimate for the size of the output */
+    const measure = (chunks: readonly LinkChunk[]): number => {
+      let cursor = 0;
+      const bySize =
+          [...chunks].sort((a, b) => b.size - a.size || a.index - b.index);
+      for (const c of bySize) {
+        if (c.org != null) continue;
+        cursor = alignUp(cursor, c.align ?? 1) + c.size;
+      }
+      return cursor;
+    };
+
     // Phase 1: measure each unmapped segment against its contents.
     // Sizing isn't dependant on final org, its just using the relative size
     // of the chunks in it.
     const sizes = new Map<string, number>();
     const aligns = new Map<string, number>();
+    /** Mapped segment -> room its own chunks need, when it holds any. */
+    const selfSizes = new Map<string, number>();
     const unmapped: Segment[] = [];
     for (const name of order) {
       const seg = merged.get(name)!;
@@ -1204,16 +1258,8 @@ class Link {
       let align = seg.align ?? 1;
       for (const c of chunks) align = Math.max(align, c.align ?? 1);
       aligns.set(name, align);
-      let size = seg.size;
-      if (size == null) {
-        let cursor = 0;
-        const bySize =
-            [...chunks].sort((a, b) => b.size - a.size || a.index - b.index);
-        for (const c of bySize) {
-          cursor = alignUp(cursor, c.align ?? 1) + c.size;
-        }
-        size = cursor;
-      }
+      this.segmentAlign.set(name, align);
+      let size = seg.size ?? measure(chunks);
       for (const c of chunks) {
         if (c.org == null) continue;
         if (seg.memory == null) {
@@ -1224,6 +1270,19 @@ class Link {
         size = Math.max(size, c.org + c.size - seg.memory);
       }
       sizes.set(name, size);
+    }
+
+    // Now do the same measurement for the chunks that are in a mapped segment itself,
+    // which is the room it has to be given before the next segment lowered into it.
+    for (const name of order) {
+      const seg = merged.get(name);
+      if (!seg || needsLowering(seg)) continue;
+      let align = seg.align ?? 1;
+      const own = contents.get(name) ?? [];
+      for (const c of own) align = Math.max(align, c.align ?? 1);
+      this.segmentAlign.set(name, align);
+      const size = measure(own);
+      if (size) selfSizes.set(name, size);
     }
 
     const used = new Map<string, number>(); // mapped seg name -> # of allocated bytes
@@ -1264,8 +1323,28 @@ class Link {
     
     // Build out the new mappings for the unmapped segments, tracking the total
     // size of data needed in the other segment, and also keep track of where the
-    // load/run addresses end up at.
-    for (const seg of unmapped) {
+    // load/run addresses end up at. A mapped segment that holds chunks of its
+    // own takes its turn here too, rather than being left whatever the segments
+    // lowered into it did not use.
+    const selfStarts = new Map<string, number>();
+    // Mapped segments that other segments are lowered into.
+    const backing = new Set<string>(
+        unmapped.flatMap(s => [s.load, s.run].filter(n => n != null)));
+    for (const name of this.allocationOrder(order)) {
+      const seg = merged.get(name);
+      if (!seg) continue;
+      if (!needsLowering(seg)) {
+        // Only worth reserving in a segment that is sharing its space.
+        const size = selfSizes.get(name);
+        const align = this.segmentAlign.get(name) ?? 1;
+        if (!size || !backing.has(name)) continue;
+        const base = seg.memory ?? 0;
+        const start = alignUp(base + (used.get(name) ?? 0), align);
+        const room = base + (seg.size ?? 0) - start;
+        if (room <= 0) continue;
+        selfStarts.set(name, allocate(seg, seg, Math.min(size, room), align));
+        continue;
+      }
       const size = sizes.get(seg.name)!;
       const align = aligns.get(seg.name)!;
       const runSeg = mappingOf(seg, 'run');
@@ -1276,6 +1355,20 @@ class Link {
           run : allocate(seg, loadSeg, size, seg.alignLoad ?? align);
       runs.set(seg.name, run);
       loads.set(seg.name, load);
+      this.segmentLoad.set(seg.name, load);
+      this.segmentExtent.set(seg.name, size);
+    }
+
+    // Build out a map of how far into each segment we've gotten so far
+    for (const name of order) {
+      const seg = merged.get(name);
+      if (!seg || needsLowering(seg)) continue;
+      let extent = used.get(name) ?? 0;
+      for (const c of contents.get(name) ?? []) {
+        if (c.org == null) continue;
+        extent = Math.max(extent, c.org + c.size - (seg.memory ?? 0));
+      }
+      this.segmentExtent.set(name, Math.min(extent, seg.size ?? extent));
     }
 
     // Now start building out the file offsets `:off` that we will give to unmapped segments.
@@ -1289,12 +1382,13 @@ class Link {
       // These are RAM, which takes no file space.
       if (seg.out == null && seg.offset == null) continue;
       const file = seg.out || '%O';
+      const base = this.fileBase(file);
       let cursor = fileLocations.get(file) ?? 0;
-      if (seg.offset != null) {
-        cursor = seg.offset;
-      } else {
-        seg.offset = cursor;
-      }
+      // An explicit `:off` is relative to the file it writes to, and puts the
+      // cursor there. Everything downstream sees the internal offset instead,
+      // which is the file's own base plus that.
+      if (seg.offset != null) cursor = seg.offset;
+      seg.offset = base + cursor;
       // A filled segment writes its whole size, but an unfilled mapped segment
       // only writes as far as the segments lowered into it actually reached.
       // Unless it holds chunks of its own, which can land anywhere it has space.
@@ -1325,10 +1419,160 @@ class Link {
       seg.bss = seg.bss ?? !emits;
     }
 
-    // A mapped segment that chunks name directly keeps whatever the segments
-    // lowered into it left over.
-    for (const name of this.segmentMappings) {
-      if (referenced.has(name)) this.segmentUsed.set(name, used.get(name) ?? 0);
+    // Finally, work out what part of each mapped segment is still up for grabs.
+    for (const name of order) {
+      const seg = merged.get(name);
+      if (!seg || needsLowering(seg)) continue;
+      const memory = seg.memory ?? 0;
+      const size = seg.size ?? 0;
+      if (!this.segmentMappings.has(name)) {
+        this.segmentFree.set(name, [[memory, memory + size]]);
+        continue;
+      }
+      const ranges: Array<readonly [number, number]> = [];
+      const self = selfStarts.get(name);
+      if (self != null) {
+        ranges.push([self, self + selfSizes.get(name)!]);
+        // Chunks are placed from `used` forward, so that is where its own
+        // space starts as far as the placer is concerned.
+        this.segmentUsed.set(name, self - memory);
+      } else {
+        this.segmentUsed.set(name, used.get(name) ?? 0);
+      }
+      ranges.push([memory + (used.get(name) ?? 0), memory + size]);
+      this.segmentFree.set(name, ranges);
+    }
+  }
+
+  /**
+   * The order segments are given room in the mapped segments they share.
+   * A linker config declares its MEMORY areas and its SEGMENTS separately, and
+   * it is the SEGMENTS order that decides who gets the front of an area - even
+   * for an entry merged into the area of the same name, whose place in
+   * `segmentOrder` is the area's (that order writes the output files).
+   */
+  private allocationOrder(order: readonly string[]): readonly string[] {
+    if (!this.config) return order;
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const name of [...this.config.segments.map(s => s.name), ...order]) {
+      if (seen.has(name) || !order.includes(name)) continue;
+      seen.add(name);
+      out.push(name);
+    }
+    return out;
+  }
+
+  /**
+   * Base of an output file in the linker's internal offset space.
+   *
+   * Every file's own offsets start at zero, but chunks, free space and the
+   * base image all share one address space here, so each extra file is handed
+   * a slice of its own well above anything a real ROM reaches. The main file
+   * keeps base 0 so a patch build's offsets stay the file offsets it read.
+   */
+  private fileBase(file: string): number {
+    let base = this.fileBases.get(file);
+    if (base == null) {
+      base = Link.FILE_SPACE * this.fileBases.size;
+      if (base >= LinkSegment.RAM_OFFSET) fail(`Too many output files`);
+      this.fileBases.set(file, base);
+    }
+    return base;
+  }
+
+  private static readonly FILE_SPACE = 0x1000000;
+
+  /** The bytes written to one output file, `undefined` meaning the main one. */
+  private output(file: string|undefined): SparseByteArray {
+    const name = file || '%O';
+    let out = this.outputs.get(name);
+    if (!out) this.outputs.set(name, out = new SparseByteArray());
+    return out;
+  }
+
+  /**
+   * Everything a `file =`/`:out` sent somewhere other than the main output,
+   * which `link()` returns. Only meaningful after `link()`.
+   */
+  outputFiles(): Array<{name: string, data: Uint8Array}> {
+    const out: Array<{name: string, data: Uint8Array}> = [];
+    for (const [name, bytes] of this.outputs) {
+      if (name === '%O') continue;
+      const data = new Uint8Array(bytes.length);
+      bytes.apply(data);
+      out.push({name, data});
+    }
+    return out;
+  }
+
+  /**
+   * Adds a symbol the linker itself defines (a segment `define`, or a config
+   * SYMBOLS entry). An object file's own definition always wins, since ld65
+   * treats these as defaults. Returns whether the symbol was actually added.
+   */
+  private addLinkerSymbol(name: string, value: number): boolean {
+    if (this.exports.has(name)) return false;
+    this.exports.set(name, this.symbols.length);
+    this.symbols.push({export: name, expr: {op: 'num', num: value}});
+    return true;
+  }
+
+  /**
+   * Creates the START/RUN/ETC symbols for each of the segments.
+   * This happens after mapping all segments, so it applies to all segment
+   * types (mapped, unmapped, ld65)
+   * Returns the symbols it defined, so a config SYMBOLS entry can refer to
+   * them.
+   */
+  private defineSegmentSymbols(merged: Map<string, Segment>): CfgSymbols {
+    const defined: CfgSymbols = new Map();
+    const define = (name: string, value: number) => {
+      if (this.addLinkerSymbol(name, value)) defined.set(name, value);
+    };
+    for (const name of this.segmentOrder) {
+      const seg = merged.get(name);
+      if (!seg?.define) continue;
+      const start = seg.memory ?? 0;
+      const size = seg.size ?? 0;
+      define(`__${name}_START__`, start);
+      define(`__${name}_RUN__`, start);
+      define(`__${name}_LOAD__`, this.segmentLoad.get(name) ?? start);
+      define(`__${name}_SIZE__`, size);
+      // _LAST__ is the end of what is actually used, which for a mapped
+      // segment is only as far as the geometry pass could account for.
+      define(`__${name}_LAST__`, start + (this.segmentExtent.get(name) ?? size));
+      if (!seg.bss && seg.offset != null) {
+        define(`__${name}_FILEOFFS__`, seg.offset);
+      }
+    }
+    return defined;
+  }
+
+  /**
+   * The config's SYMBOLS block. Entries resolve in declaration order against
+   * the earlier ones and against every segment `define`, so
+   * `value = __RAM_LAST__` works.
+   */
+  private defineConfigSymbols(defines: CfgSymbols) {
+    if (!this.config) return;
+    const symbols: CfgSymbols =
+        new Map([...configSymbols(this.config, this.objectExports), ...defines]);
+    for (const sym of this.config.symbols) {
+      if (sym.type === 'import') {
+        if (!this.exports.has(sym.name)) {
+          fail(`Symbol ${sym.name} is imported by the linker config but is ${
+               ''}never exported`);
+        }
+        continue;
+      }
+      // An object file's definition wins, which is what `weak` asks for and
+      // what js65 does for `export` too (ld65 would call that a conflict).
+      if (this.exports.has(sym.name)) continue;
+      const value =
+          resolveCfgExpr(sym.value!, symbols, `Value of '${sym.name}'`);
+      symbols.set(sym.name, value);
+      this.addLinkerSymbol(sym.name, value);
     }
   }
 
@@ -1497,6 +1741,8 @@ class Link {
     for (const symbol of this.symbols) {
       if (symbol.export != null) exported.add(symbol.export);
     }
+    this.config = cfg;
+    this.objectExports = exported;
     for (const segment of lowerLinkerConfig(cfg, exported)) {
       this.addRawSegment(segment);
       this.segmentOrder.push(segment.name);
@@ -1528,9 +1774,43 @@ class Link {
     return map;
   }
 
+  /**
+   * Bare bones segment list report used for comparing against ca65 built projects.
+   */
+  private segmentReport(): string {
+    if (!this.segments.size) return '';
+    const hex = (n: number, w = 6) => n.toString(16).toUpperCase().padStart(w, '0');
+    // How far the chunks actually placed in each segment reach. `Size` is what
+    // the segment was given, `Used` is what it needed - the two differ because
+    // a segment is measured before placement gets to backfill alignment gaps.
+    const used = new Map<string, number>();
+    for (const chunk of this.chunks) {
+      const seg = chunk.segment;
+      if (!seg || chunk.org == null) continue;
+      const end = chunk.org + chunk.size - seg.memory;
+      used.set(seg.name, Math.max(used.get(seg.name) ?? 0, end));
+    }
+    let out = 'Segment list:\n-------------\n';
+    out += 'Name                   Start     End    Size    Used  Align  FileOffs  File\n';
+    out += '----------------------------------------------------------------------------\n';
+    for (const name of this.segmentOrder) {
+      const s = this.segments.get(name);
+      if (!s) continue;
+      const end = s.memory + Math.max(s.size - 1, 0);
+      // A segment that emits nothing has no offset worth printing.
+      const file = s.isRam ? '' : (s.out || '%O');
+      const offs = s.isRam ?
+          '      ' : hex(s.offset - (this.fileBases.get(file) ?? 0));
+      out += `${name.padEnd(20)}  ${hex(s.memory)}  ${hex(end)}  ${
+             hex(s.size)}  ${hex(used.get(name) ?? 0)}  ${
+             hex(this.segmentAlign.get(name) ?? 1, 5)}  ${offs}  ${file}\n`;
+    }
+    return out + '\n';
+  }
+
   report(verbose = false): string {
     // TODO - accept a segment to filter?
-    let out = '';
+    let out = this.segmentReport();
     for (const [s, e] of this.free) {
       out += `Free: ${s.toString(16)}..${e.toString(16)}: ${e - s} bytes\n`;
     }

--- a/src/linker.ts
+++ b/src/linker.ts
@@ -885,6 +885,8 @@ class Link {
    */
   segmentOrder: string[] = [];
   private segmentIndex = new Map<string, number>();
+  /** Names of mapped segments that other unmapped segments are written to. */
+  private segmentMappings = new Set<string>();
 
   watches: number[] = []; // debugging aid: offsets to watch.
   placed: Array<[number, LinkChunk]> = [];
@@ -978,24 +980,45 @@ class Link {
       this.segmentIndex.set(name, this.segmentIndex.size);
     }
     this.segmentOrder = [...this.segmentIndex.keys()];
-    // Build up the LinkSegment objects
+    // Merge all segments (mapped and unmapped) into a single Segment each.
+    // Note that we intentionally copy the segments into `s` so we don't overwrite
+    // the original data.
+    const merged = new Map<string, Segment>();
     for (const [name, segments] of this.rawSegments) {
-      let s = segments[0];
+      let s = {...segments[0]};
       for (let i = 1; i < segments.length; i++) {
         s = Segment.merge(s, segments[i]);
       }
+      merged.set(name, s);
+    }
+    // Resolve unmapped segments and hand out file offsets, so that everything
+    // below sees plain memory/offset/size.
+    this.lowerSegments(merged);
+
+    // Build up the LinkSegment objects
+    for (const [name, s] of merged) {
       this.segments.set(name, new LinkSegment(s));
     }
     // Add the free space
-    for (const [name, segments] of this.rawSegments) {
-      const s = this.segments.get(name)!;
-      for (const segment of segments) {
-        const free = segment.free;
-        // Add the free space
-        for (const [start, end] of free || []) {
+    for (const [name, s] of this.segments) {
+      // Check to see if the user has declared any space free in the segment,
+      // if not then we treat the entire segment as free'd
+      const explicit =
+          (this.rawSegments.get(name) ?? []).flatMap(seg => seg.free ?? []);
+      if (explicit.length) {
+        for (const [start, end] of explicit) {
+          if (end <= start) continue;
           this.free.add(start + s.delta, end + s.delta);
+          // Only an explicitly declared free range takes its bytes out of the
+          // base image - a synthesized one would wipe out the very bytes a
+          // patch build searches for.
           this.data.splice(start + s.delta, end - start);
         }
+      } else if (s.size > 0 && !this.segmentMappings.has(name)) {
+        // Mark the entire segment as free if it was originally a mapped segment
+        // We don't want originally unmapped segments to be automatically
+        // freed since they don't "own" the space.
+        this.free.add(s.memory + s.delta, s.memory + s.size + s.delta);
       }
     }
     // Set up all the initial placements.
@@ -1092,6 +1115,183 @@ class Link {
     }
     if (DEBUG) console.log(this.report(true));
     return patch;
+  }
+
+  /**
+   * We have two basic types of segments which share the `segment` name.
+   * The first acts as a MEMORY section in the ld65, but where the user can still use it
+   * as a segment and put data into it. In ld65 terms, doing `.segment :mem ...` creates
+   * both a MEMORY and SEGMENT section that can had data added to it.
+   * These are referred to as `mapped` segments.
+   * 
+   * The second type `.segment :load` gets converted/mapped into the first type
+   * to allow the same style of `1 : N` memory : segment mapping that ld65 supports.
+   * These are referred to as `unmapped` segments.
+   * 
+   * Things get complicated when supporting different load / run addresses.
+   * We need to place the data at a `load` address, but set the pc at the run address.
+   * This is the mega function that maps the unmapped type of segments into the mapped
+   * typed which greatly simplifies the later linking code, since we will have actual
+   * file offsets / :mem addresses to use.
+   * 
+   * If a segment already has the :mem/:size etc, then this phase doesn't do anything.
+   * Its just for lowering the `:load/:run` type segments to fill out the :mem for them.
+   */
+  private lowerSegments(merged: Map<string, Segment>) {
+    const order = this.segmentOrder.filter(name => merged.has(name));
+    const needsLowering = (s: Segment) => s.load != null || s.run != null;
+
+    // Build a map of segment names -> chunks with the chunks preferring
+    // to land in the first segment that it lists.
+    const contents = new Map<string, LinkChunk[]>();
+    const referenced = new Set<string>();
+    for (const chunk of this.chunks) {
+      const eligible = this.eligibleSegments(chunk);
+      for (const name of eligible) referenced.add(name);
+      const [first] = eligible;
+      if (first == null) continue;
+      let list = contents.get(first);
+      if (!list) contents.set(first, list = []);
+      list.push(chunk);
+    }
+
+    // Phase 1: measure each unmapped segment against its contents.
+    // Sizing isn't dependant on final org, its just using the relative size
+    // of the chunks in it.
+    const sizes = new Map<string, number>();
+    const aligns = new Map<string, number>();
+    const unmapped: Segment[] = [];
+    for (const name of order) {
+      const seg = merged.get(name)!;
+      if (!needsLowering(seg)) continue;
+      const chunks = contents.get(name) ?? [];
+      if (seg.optional && !referenced.has(name)) {
+        merged.delete(name);
+        continue;
+      }
+      unmapped.push(seg);
+      // Enforcing the widest chunk alignment on the segment start is what
+      // makes a segment-relative chunk alignment equal an absolute one.
+      let align = seg.align ?? 1;
+      for (const c of chunks) align = Math.max(align, c.align ?? 1);
+      aligns.set(name, align);
+      let size = seg.size;
+      if (size == null) {
+        let cursor = 0;
+        const bySize =
+            [...chunks].sort((a, b) => b.size - a.size || a.index - b.index);
+        for (const c of bySize) {
+          cursor = alignUp(cursor, c.align ?? 1) + c.size;
+        }
+        size = cursor;
+      }
+      for (const c of chunks) {
+        if (c.org == null) continue;
+        if (seg.memory == null) {
+          fail(`Segment ${name} holds a .org chunk${
+              c.name ? ` (${c.name})` : ''} but has no address of its own. ${''
+              }.org can only be used in segments with :mem`);
+        }
+        size = Math.max(size, c.org + c.size - seg.memory);
+      }
+      sizes.set(name, size);
+    }
+
+    const used = new Map<string, number>(); // mapped seg name -> # of allocated bytes
+    const runs = new Map<string, number>(); // mapped seg name -> next start addr for RUN
+    const loads = new Map<string, number>(); // mapped seg name -> next start addr for LOAD
+    // Helper function to validate and find the mapped segment that backs
+    // this unmapped segment.
+    const mappingOf = (seg: Segment, which: 'load'|'run'): Segment => {
+      const name = (which === 'load' ? seg.load ?? seg.run : seg.run ?? seg.load)!;
+      const mapped = merged.get(name);
+      if (!mapped) {
+        fail(`Segment ${seg.name} has ${which} "${name}", which is not a segment`);
+      }
+      if (needsLowering(mapped)) {
+        fail(`Segment ${seg.name} has ${which} "${name}", which is already mapped to memory`);
+      }
+      this.segmentMappings.add(name);
+      return mapped;
+    };
+    // Helper function that adds the unmapped segments data to the `used` map for
+    // the mapped segment. We will go through this `used` map later to build out the
+    // :mem and other related fields for mapping the unmapped segment.
+    // The goal is to allocate a chunk of space from the mapped segment so we can place
+    // in this allocated space later (effectively creates a :mem :start pair for this segment)
+    const allocate = (seg: Segment, mapped: Segment, size: number, align: number,
+                      memory?: number): number => {
+      const base = mapped.memory ?? 0;
+      const start = memory ?? alignUp(base + (used.get(mapped.name) ?? 0), align);
+      if (start < base ||
+          (mapped.size != null && start + size > base + mapped.size)) {
+        fail(`Segment ${seg.name} ($${size.toString(16)} bytes at $${
+             start.toString(16)}) does not fit in ${mapped.name}`);
+      }
+      used.set(mapped.name,
+               Math.max(used.get(mapped.name) ?? 0, start + size - base));
+      return start;
+    };
+    
+    // Build out the new mappings for the unmapped segments, tracking the total
+    // size of data needed in the other segment, and also keep track of where the
+    // load/run addresses end up at.
+    for (const seg of unmapped) {
+      const size = sizes.get(seg.name)!;
+      const align = aligns.get(seg.name)!;
+      const runSeg = mappingOf(seg, 'run');
+      const loadSeg = mappingOf(seg, 'load');
+      // An explicit :mem places the run address instead of allocating one.
+      const run = allocate(seg, runSeg, size, align, seg.memory);
+      const load = loadSeg === runSeg ?
+          run : allocate(seg, loadSeg, size, seg.alignLoad ?? align);
+      runs.set(seg.name, run);
+      loads.set(seg.name, load);
+    }
+
+    // Now start building out the file offsets `:off` that we will give to unmapped segments.
+    // Map of file out name -> next start addr as an offset into the segment (or :size if its :fill)
+    const fileLocations = new Map<string, number>();
+    for (const name of order) {
+      const seg = merged.get(name);
+      // Skip over unmapped segments here.
+      if (!seg || needsLowering(seg) || seg.bss) continue;
+      // Any anything without an output file nor an offset.
+      // These are RAM, which takes no file space.
+      if (seg.out == null && seg.offset == null) continue;
+      const file = seg.out || '%O';
+      let cursor = fileLocations.get(file) ?? 0;
+      if (seg.offset != null) {
+        cursor = seg.offset;
+      } else {
+        seg.offset = cursor;
+      }
+      // A filled segment writes its whole size, but an unfilled host only
+      // writes as far as the segments loaded into it actually reached.
+      const extent = seg.fill == null && this.segmentMappings.has(name) ?
+          (used.get(name) ?? 0) : (seg.size ?? 0);
+      fileLocations.set(file, cursor + extent);
+    }
+
+    // FINALLY we have all the data we need to map the segment to turn an unmapped
+    // segment into a mapped one. Add all of the :out/:fill/ etc data to map it.
+    for (const seg of unmapped) {
+      const runSeg = mappingOf(seg, 'run');
+      const loadSeg = mappingOf(seg, 'load');
+      // The loadSeg is what decides whether any bytes are emitted at all.
+      const emits = !loadSeg.bss && loadSeg.offset != null;
+      seg.size = sizes.get(seg.name)!;
+      seg.memory = runs.get(seg.name)!;
+      if (emits) {
+        seg.offset =
+            loadSeg.offset! + (loads.get(seg.name)! - (loadSeg.memory ?? 0));
+      }
+      seg.out = seg.out ?? loadSeg.out;
+      seg.bank = seg.bank ?? loadSeg.bank;
+      seg.fill = seg.fill ?? loadSeg.fill;
+      seg.addressing = seg.addressing ?? runSeg.addressing;
+      seg.bss = seg.bss ?? !emits;
+    }
   }
 
   /**

--- a/src/linker.ts
+++ b/src/linker.ts
@@ -5,6 +5,7 @@ import { Assembler } from './assembler.ts';
 import { Cpu } from './cpu.ts';
 import type { Expr } from './expr.ts';
 import * as Exprs from './expr.ts';
+import { type LinkerConfig, lowerLinkerConfig, parseLinkerConfig } from './linkerconfig.ts';
 import { type Chunk, type Module, type OverwriteMode, Segment, type Substitution, type Symbol } from './module.ts';
 import { Targets } from "./preamble.ts";
 import { Preprocessor } from './preprocessor.ts';
@@ -75,9 +76,17 @@ export class Linker {
   }
 
   link(signal?: { readonly aborted: boolean }): SparseByteArray {
-    const target = Targets.get(this.opts.target?.toLowerCase())
-    if (target) {
-      target.segments.forEach( seg => this._link.addRawSegment(seg) );
+    // An ld65 config replaces the built-in segment configuration.
+    // I don't think its worth trying to sort out using both for now.
+    // Maybe at some point we start issuing warnings if they mix the two.
+    if (this.opts.linkerConfig != null) {
+      this._link.setConfig(parseLinkerConfig(this.opts.linkerConfig,
+                                             this.opts.linkerConfigName));
+    } else {
+      const target = Targets.get(this.opts.target?.toLowerCase())
+      if (target) {
+        target.segments.forEach( seg => this._link.addRawSegment(seg) );
+      }
     }
     return this._link.link(signal);
   }
@@ -490,6 +499,10 @@ export class Linker {
 
 export interface Options {
   target?: string;
+  /** Full text of the linker config file. */
+  linkerConfig?: string;
+  /** Name to report `linkerConfig` parse errors against. */
+  linkerConfigName?: string;
 }
 
 // TODO - link-time only function for getting either the original or the
@@ -526,8 +539,15 @@ class LinkSegment {
   /** Whether chunks placed here may share bytes with identical data. */
   readonly dedupe: boolean;
   readonly isRam: boolean;
+  /**
+   * Space reserved by unmapped segments within a mapped segment.
+   * Only applies to a scenario where you have chunks directly written
+   * through an unmapped segment AND chunks written directly to this
+   * mapped segment.
+   */
+  readonly used: number;
 
-  constructor(segment: Segment) {
+  constructor(segment: Segment, used = 0) {
     const name = this.name = segment.name;
     this.bank = segment.bank ?? 0;
     this.addressing = segment.addressing ?? 2;
@@ -544,6 +564,7 @@ class LinkSegment {
     this.memory = segment.memory ?? 0;
     this.fill = segment.fill;
     this.dedupe = segment.dedupe ?? false;
+    this.used = used;
   }
 
   // offset = org + delta
@@ -887,6 +908,8 @@ class Link {
   private segmentIndex = new Map<string, number>();
   /** Names of mapped segments that other unmapped segments are written to. */
   private segmentMappings = new Set<string>();
+  /** Track the `used` values for each mapped segment */
+  private segmentUsed = new Map<string, number>();
 
   watches: number[] = []; // debugging aid: offsets to watch.
   placed: Array<[number, LinkChunk]> = [];
@@ -997,7 +1020,7 @@ class Link {
 
     // Build up the LinkSegment objects
     for (const [name, s] of merged) {
-      this.segments.set(name, new LinkSegment(s));
+      this.segments.set(name, new LinkSegment(s, this.segmentUsed.get(name)));
     }
     // Add the free space
     for (const [name, s] of this.segments) {
@@ -1014,11 +1037,17 @@ class Link {
           // patch build searches for.
           this.data.splice(start + s.delta, end - start);
         }
-      } else if (s.size > 0 && !this.segmentMappings.has(name)) {
-        // Mark the entire segment as free if it was originally a mapped segment
-        // We don't want originally unmapped segments to be automatically
-        // freed since they don't "own" the space.
-        this.free.add(s.memory + s.delta, s.memory + s.size + s.delta);
+      } else if (s.size > 0) {
+        // Mark the entire segment as free if it was originally a mapped
+        // segment. We don't want originally unmapped segments to be
+        // automatically freed since they don't "own" the space
+        // There is an exception to this, a mapped segment holding chunks of
+        // that the user wrote directly, owns whatever that data.
+        const from = this.segmentMappings.has(name) ?
+            this.segmentUsed.get(name) : 0;
+        if (from != null && from < s.size) {
+          this.free.add(s.memory + from + s.delta, s.memory + s.size + s.delta);
+        }
       }
     }
     // Set up all the initial placements.
@@ -1266,9 +1295,12 @@ class Link {
       } else {
         seg.offset = cursor;
       }
-      // A filled segment writes its whole size, but an unfilled host only
-      // writes as far as the segments loaded into it actually reached.
-      const extent = seg.fill == null && this.segmentMappings.has(name) ?
+      // A filled segment writes its whole size, but an unfilled mapped segment
+      // only writes as far as the segments lowered into it actually reached.
+      // Unless it holds chunks of its own, which can land anywhere it has space.
+      const extent =
+          seg.fill == null && this.segmentMappings.has(name) &&
+              !referenced.has(name) ?
           (used.get(name) ?? 0) : (seg.size ?? 0);
       fileLocations.set(file, cursor + extent);
     }
@@ -1291,6 +1323,12 @@ class Link {
       seg.fill = seg.fill ?? loadSeg.fill;
       seg.addressing = seg.addressing ?? runSeg.addressing;
       seg.bss = seg.bss ?? !emits;
+    }
+
+    // A mapped segment that chunks name directly keeps whatever the segments
+    // lowered into it left over.
+    for (const name of this.segmentMappings) {
+      if (referenced.has(name)) this.segmentUsed.set(name, used.get(name) ?? 0);
     }
   }
 
@@ -1353,9 +1391,13 @@ class Link {
     for (const name of segments) {
       const segment = this.segment(name);
       // For RAM segments, free space is tracked with RAM_OFFSET added to memory addresses
-      // For ROM segments, free space is tracked in file offset coordinates
-      const s0 = segment.isRam ? segment.memory + LinkSegment.RAM_OFFSET : segment.offset;
-      const s1 = s0 + segment.size;
+      // For ROM segments, free space is tracked in file offset coordinates.
+      // Adjacent free ranges merge, so the space a mapped segment handed to the
+      // ones lowered into it has to be excluded here rather than left out of
+      // `free`.
+      const base = segment.isRam ? segment.memory + LinkSegment.RAM_OFFSET : segment.offset;
+      const s0 = base + segment.used;
+      const s1 = base + segment.size;
       let found: number|undefined;
       let smallest = Infinity;
       for (const [f0, f1] of this.free.tail(s0)) {
@@ -1448,6 +1490,18 @@ class Link {
   //   // TODO - add all the things
   //   return patch;
   // }
+
+  setConfig(cfg: LinkerConfig) {
+    const exported = new Set<string>();
+    // Check the symbol exports here to see if any override linker weak symbols
+    for (const symbol of this.symbols) {
+      if (symbol.export != null) exported.add(symbol.export);
+    }
+    for (const segment of lowerLinkerConfig(cfg, exported)) {
+      this.addRawSegment(segment);
+      this.segmentOrder.push(segment.name);
+    }
+  }
 
   addRawSegment(segment: Segment) {
     let list = this.rawSegments.get(segment.name);

--- a/src/linker.ts
+++ b/src/linker.ts
@@ -514,7 +514,8 @@ class LinkSegment {
   readonly offset: number;
   readonly memory: number;
   readonly addressing: number;
-  readonly fill: number;
+  /** Byte to fill unused space with, or undefined to leave it alone. */
+  readonly fill: number|undefined;
   readonly isRam: boolean;
 
   constructor(segment: Segment) {
@@ -522,15 +523,17 @@ class LinkSegment {
     this.bank = segment.bank ?? 0;
     this.addressing = segment.addressing ?? 2;
     this.size = segment.size ?? fail(`Size must be specified: ${name}`);
-    // A segment is RAM if it has no output file and no offset specified
-    // If out is specified (any string), it outputs. If offset is specified without out, it outputs to main file.
-    this.isRam = !segment.out && segment.offset == null;
+    // A segment is RAM if it emits no bytes, declared `bss`/`zp`, or
+    // (the legacy heuristic) it has no output file and no offset specified.
+    // If out is specified (any string), it outputs.
+    // If offset is specified without out, it outputs to main file.
+    this.isRam = segment.bss ?? (!segment.out && segment.offset == null);
     // For RAM segments, offset defaults to memory (so delta=0, org space = tracking space)
     this.offset = segment.offset ?? (this.isRam ? segment.memory ?? 0 : fail(`Offset must be specified: ${name}`));
     // this.memory = segment.memory ?? fail(`Memory must be specified: ${name}`);
     // Allow memory offset to be null for non-prg segments
     this.memory = segment.memory ?? 0;
-    this.fill = segment.fill ?? 0;
+    this.fill = segment.fill;
   }
 
   // offset = org + delta
@@ -543,6 +546,8 @@ class LinkSegment {
 class LinkChunk {
   readonly name: string|undefined;
   readonly size: number;
+  /** Alignment (a power of two) for placing this chunk. */
+  readonly align: number|undefined;
   segments: readonly string[];
   asserts: Expr[];
 
@@ -585,6 +590,7 @@ class LinkChunk {
               symbolOffset: number) {
     this.name = chunk.name;
     this.size = chunk.data.length;
+    this.align = chunk.align;
     this.segments = chunk.segments;
     this.labelIndex = chunk.labelIndex && new Map(chunk.labelIndex);
     this.sourceMap = chunk.sourceMap && new Map(chunk.sourceMap);
@@ -1106,7 +1112,7 @@ class Link {
     // Before placing the data, add the fill bytes to segments with fill
     for (const [_name, seg] of this.segments) {
       if (seg.isRam) continue;  // RAM segments don't need fill
-      if (seg.fill) {
+      if (seg.fill != null) {  // NOTE: fill = 0 still fills.
         const buf = new Uint8Array(new ArrayBuffer(seg.size));
         buf.fill(seg.fill);
         patch.set(seg.offset, buf);

--- a/src/linker.ts
+++ b/src/linker.ts
@@ -507,6 +507,13 @@ function fail(msg: string): never {
   throw new Error(msg);
 }
 
+/** Rounds up to the next multiple of `align`, which must be positive. */
+function alignUp(value: number, align: number): number {
+  // NOTE: arithmetic rather than bit twiddling, since offsets in RAM segments
+  // are past the 32-bit sign bit (see LinkSegment.RAM_OFFSET).
+  return align > 1 ? Math.ceil(value / align) * align : value;
+}
+
 class LinkSegment {
   readonly name: string;
   readonly bank: number;
@@ -516,6 +523,8 @@ class LinkSegment {
   readonly addressing: number;
   /** Byte to fill unused space with, or undefined to leave it alone. */
   readonly fill: number|undefined;
+  /** Whether chunks placed here may share bytes with identical data. */
+  readonly dedupe: boolean;
   readonly isRam: boolean;
 
   constructor(segment: Segment) {
@@ -534,6 +543,7 @@ class LinkSegment {
     // Allow memory offset to be null for non-prg segments
     this.memory = segment.memory ?? 0;
     this.fill = segment.fill;
+    this.dedupe = segment.dedupe ?? false;
   }
 
   // offset = org + delta
@@ -554,8 +564,6 @@ class LinkChunk {
   subs = new Set<Substitution>();
   selfSubs = new Set<Substitution>();
 
-  /** Global IDs of chunks needed to locate before we can complete this one. */
-  deps = new Set<number>();
   /** Symbols that are imported into this chunk (these are also deps). */
   imports = new Set<string>();
   // /** Symbols that are exported from this chunk. */
@@ -740,7 +748,6 @@ class LinkChunk {
   addDep(sub: Substitution, dep: number) {
     if (dep === this.index && this.subs.delete(sub)) this.selfSubs.add(sub);
     this.linker.chunks[dep].follow.set(sub, this);
-    this.deps.add(dep);
   }
 
   // Returns a list of dependent chunks, or undefined if successful.
@@ -791,18 +798,6 @@ class LinkChunk {
     }
     if (del) {
       this.subs.delete(sub) || this.selfSubs.delete(sub);
-      if (!this.subs.size) { // NEW: ignores self-subs now
-      // if (!this.subs.size || (deps.size === 1 && deps.has(this.index)))  {
-        // add to resolved queue - ready to be placed!
-        // Question: should we place it right away?  We place the fixed chunks
-        // immediately in the ctor, but there's no choice to defer.  For reloc
-        // chunks, it's better to wait until we've resolved as much as possible
-        // before placing anything.  Fortunately, placing a chunk will
-        // automatically resolve all deps now!
-        if (this.linker.unresolvedChunks.delete(this)) {
-          this.linker.insertResolved(this);
-        }
-      }
     }
   }
 
@@ -882,18 +877,18 @@ class Link {
   rawSegments = new Map<string, Segment[]>();
   segments = new Map<string, LinkSegment>();
 
-  resolvedChunks: LinkChunk[] = [];
-  unresolvedChunks = new Set<LinkChunk>();
+  /**
+   * Names of the segments in the order they are filled.
+   * This comes from first, the order they appear in the ld65 linker script,
+   * and then second the order they appear in object files (parsed in the
+   * order they are passed into the link command)
+   */
+  segmentOrder: string[] = [];
+  private segmentIndex = new Map<string, number>();
 
   watches: number[] = []; // debugging aid: offsets to watch.
   placed: Array<[number, LinkChunk]> = [];
   initialReport = '';
-
-  // TODO - deferred - store some sort of dependency graph?
-
-  insertResolved(chunk: LinkChunk) {
-    binaryInsert(this.resolvedChunks, c => c.size, chunk);
-  }
 
   base(data: Uint8Array, offset = 0) {
     this.data.set(offset, data);
@@ -977,6 +972,12 @@ class Link {
   }
 
   link(signal?: { readonly aborted: boolean }): SparseByteArray {
+    // Preserve the order that the segments are declared
+    for (const name of [...this.segmentOrder, ...this.rawSegments.keys()]) {
+      if (this.segmentIndex.has(name)) continue;
+      this.segmentIndex.set(name, this.segmentIndex.size);
+    }
+    this.segmentOrder = [...this.segmentIndex.keys()];
     // Build up the LinkSegment objects
     for (const [name, segments] of this.rawSegments) {
       let s = segments[0];
@@ -1032,82 +1033,42 @@ class Link {
       c.resolveSubs(true);
     }
 
-    // TODO - fill (un)resolvedChunks
-    //   - gets 
-
-    const chunks = [...this.chunks];
-    chunks.sort((a, b) => b.size - a.size);
-
-    for (const chunk of chunks) {
+    // Resolve everything that can be resolved without knowing where the
+    // relocatable chunks will land.
+    for (const chunk of this.chunks) {
       chunk.resolveSubs();
-      if (chunk.subs.size) {
-        this.unresolvedChunks.add(chunk);
-      } else {
-        this.insertResolved(chunk);
-      }
     }
 
-    let count = this.resolvedChunks.length + 2 * this.unresolvedChunks.size;
-    while (count) {
-      if (signal?.aborted) throw new Error('Compilation cancelled');
-      const c = this.resolvedChunks.pop();
-      if (c) {
-        this.placeChunk(c);
-      } else {
-        // resolve all the first unresolved chunks' deps
-        const [first] = this.unresolvedChunks;
-        for (const dep of first.deps) {
-          const chunk = this.chunks[dep];
-          if (chunk.org == null) this.placeChunk(chunk);
-        }
+    // Now place them. Segments are filled by declaration order first,
+    // and within the segment, filled from largest to smalled. Anything that
+    // still depends on a different segment can be resolved later.
+    const candidates = new Map<string, LinkChunk[]>();
+    for (const chunk of this.chunks) {
+      if (chunk.org != null) continue;  // already placed by initialPlacement
+      const [first] = this.eligibleSegments(chunk);
+      if (first == null) continue;      // no segment at all: reported below
+      let list = candidates.get(first);
+      if (!list) candidates.set(first, list = []);
+      list.push(chunk);
+    }
+    for (const name of this.segmentOrder) {
+      const list = candidates.get(name);
+      if (!list) continue;
+      list.sort((a, b) => b.size - a.size || a.index - b.index);
+      for (const chunk of list) {
+        if (signal?.aborted) throw new Error('Compilation cancelled');
+        chunk.resolveSubs();
+        this.placeChunk(chunk);
       }
-      const next = this.resolvedChunks.length + 2 * this.unresolvedChunks.size;
-      if (next === count) {
-        console.error(this.resolvedChunks, this.unresolvedChunks);
-        throw new Error(`Not making progress`);
-      }
-      count = next;
+    }
+    // Anything eligible for no segment at all never got a chance above, so
+    // let placeChunk report it.
+    for (const chunk of this.chunks) {
+      if (chunk.org == null) this.placeChunk(chunk);
     }
 
-    // if (!chunk.org && !chunk.subs.length) this.placeChunk(chunk);
 
-    // At this point the dep graph is built - now traverse it.
-
-    // const place = (i: number) => {
-    //   const chunk = this.chunks[i];
-    //   if (chunk.org != null) return;
-    //   // resolve first
-    //   const remaining: Substitution[] = [];
-    //   for (const sub of chunk.subs) {
-    //     if (this.resolveSub(chunk, sub)) remaining.push(sub);
-    //   }
-    //   chunk.subs = remaining;
-    //   // now place the chunk
-    //   this.placeChunk(chunk); // TODO ...
-    //   // update the graph; don't bother deleting form blocked.
-    //   for (const revDep of revDeps[i]) {
-    //     const fwd = fwdDeps[revDep];
-    //     fwd.delete(i);
-    //     if (!fwd.size) insert(unblocked, revDep);
-    //   }
-    // }
-    // while (unblocked.length || blocked.length) {
-    //   let next = unblocked.shift();
-    //   if (next) {
-    //     place(next);
-    //     continue;
-    //   }
-    //   next = blocked[0];
-    //   for (const rev of revDeps[next]) {
-    //     if (this.chunks[rev].org != null) { // already placed
-    //       blocked.shift();
-    //       continue;
-    //     }
-    //     place(rev);
-    //   }
-    // }
     // At this point, everything should be placed, so do one last resolve.
-
     const patch = new SparseByteArray();
     // Before placing the data, add the fill bytes to segments with fill
     for (const [_name, seg] of this.segments) {
@@ -1133,29 +1094,53 @@ class Link {
     return patch;
   }
 
+  /**
+   * The segments a chunk may go in, ordered by segment declaration.
+   * The chunk is placed in the first one it fits in, and defers to the rest in turn.
+   * A chunk that named no segment at all falls back to the default segment.
+   */
+  eligibleSegments(chunk: LinkChunk): readonly string[] {
+    let segments = chunk.segments;
+    if (!segments.length) {
+      // if this chunk doesn't have a predefined segment, and there is a default segment defined, then use that one
+      for (const [name, raw] of this.rawSegments) {
+        if (raw.some(s => s.default)) {
+          chunk.segments = segments = [name];
+          break;
+        }
+      }
+    }
+    if (segments.length < 2) return segments;
+    const order = (name: string) =>
+        this.segmentIndex.get(name) ?? this.segmentIndex.size;
+    return [...segments].sort((a, b) => order(a) - order(b));
+  }
+
   placeChunk(chunk: LinkChunk) {
     if (chunk.org != null) return; // don't re-place.
-    // if this chunk doesn't have a predefined segment, and there is a default segment defined, then use that one
-    if (chunk.segments.length == 0) {
-      this.rawSegments.forEach((segments, name) => {
-        for (const seg of segments) {
-          if (seg.default) {
-            chunk.segments = [ name ];
-            break;
-          }
-        }
-      })
-    }
     const size = chunk.size;
-    // Hueristic, don't search for duplicates for large chunk sizes
-    if (chunk.size < 256 && !chunk.subs.size && !chunk.selfSubs.size) {
+    const align = chunk.align ?? 1;
+    const segments = this.eligibleSegments(chunk);
+    // An empty chunk like a bare label needs no space at all, 
+    // so place it at the start of its segment.
+    // TODO is there a better way to handle this case?
+    if (!size && segments.length) {
+      const segment = this.segment(segments[0]);
+      chunk.place(segment.memory, segment);
+      chunk.overlaps = true;
+      return;
+    }
+    // Check if the chunk can be deduped but placing it at a data segment that overlaps
+    // Hueristic, don't search for duplicates for large chunk sizes.
+    if (align === 1 && size < 256 && !chunk.subs.size && !chunk.selfSubs.size) {
       // chunk is resolved: search for an existing copy of it first
       const pattern = this.data.pattern(chunk.data);
-      for (const name of chunk.segments) {
-        const segment = this.segments.get(name) ?? fail(`Segment not found with name: ${name}`);
+      for (const name of segments) {
+        const segment = this.segment(name);
+        if (!segment.dedupe) continue;
         if (segment.isRam) continue;  // Skip pattern matching for RAM segments
-        const start = segment.offset!;
-        const end = start + segment.size!;
+        const start = segment.offset;
+        const end = start + segment.size;
         const index = pattern.search(start, end);
         if (index < 0) continue;
         chunk.place(index - segment.delta, segment);
@@ -1165,20 +1150,24 @@ class Link {
     }
     // either unresolved, or didn't find a match; just allocate space.
     // look for the smallest possible free block.
-    for (const name of chunk.segments) {
-      const segment = this.segments.get(name) ?? fail(`Segment not found with name: ${name}`);
+    for (const name of segments) {
+      const segment = this.segment(name);
       // For RAM segments, free space is tracked with RAM_OFFSET added to memory addresses
       // For ROM segments, free space is tracked in file offset coordinates
-      const s0 = segment.isRam ? segment.memory + LinkSegment.RAM_OFFSET : segment.offset!;
-      const s1 = s0 + segment.size!;
+      const s0 = segment.isRam ? segment.memory + LinkSegment.RAM_OFFSET : segment.offset;
+      const s1 = s0 + segment.size;
       let found: number|undefined;
       let smallest = Infinity;
       for (const [f0, f1] of this.free.tail(s0)) {
         if (f0 >= s1) break;
-        const df = Math.min(f1, s1) - f0;
-        if (df < size) continue;
+        const end = Math.min(f1, s1);
+        // Find an org address for the data that matches its alignment.
+        // Any space from skipping bytes for alignment remain free so we can use it later.
+        const start = alignUp(f0 - segment.delta, align) + segment.delta;
+        if (start + size > end) continue;
+        const df = end - f0;
         if (df < smallest) {
-          found = f0;
+          found = start;
           smallest = df;
         }
       }
@@ -1192,8 +1181,14 @@ class Link {
     }
     if (DEBUG) console.log(`Initial:\n${this.initialReport}`);
     const name = chunk.name ? `${chunk.name} ` : '';
-    throw new Error(`Could not find space for ${size}-byte chunk ${name} in ${
-                     chunk.segments.join(', ')}`);
+    const where = segments.length ? segments.join(', ') : '(no segment)';
+    const aligned = align > 1 ? `${align}-byte aligned ` : '';
+    throw new Error(`Could not find space for ${aligned}${size}-byte chunk ${name}in ${where}`);
+  }
+
+  segment(name: string): LinkSegment {
+    return this.segments.get(name) ??
+        fail(`Segment not found with name: ${name}`);
   }
 
   resolveSymbols(expr: Expr): Expr {

--- a/src/linkerconfig.ts
+++ b/src/linkerconfig.ts
@@ -536,20 +536,24 @@ export function lowerLinkerConfig(
     if (area.define) seg.define = true;
     const segdef = originalSegments.get(area.name);
     if (segdef) {
-      // if we have a memory item and segment item with the same name,
-      // try to merge them if its compatible. otherwise throw an error.
-      // this is different from ld65 behavior but i'm fine with that for now.
-      const start = segdef.start ?? (segdef.offset != null ? memory + segdef.offset
-                                                     : undefined);
-      if (start != null && start !== memory) {
-        fail(`Segment '${segdef.name}' starts at $${start.toString(16)} but ${
-             ''}shares its name with a MEMORY area at $${memory.toString(16)}`);
+      // A MEMORY area and a SEGMENTS entry of the same name are separate
+      // things in ld65 but one segment here, so merge them. The segment may
+      // start partway into its area or ask for an alignment the area's start
+      // doesn't have. Either way, the merged segment covers from there to the
+      // end of the area.
+      const start = segdef.start ??
+          (segdef.offset != null ? memory + segdef.offset : undefined);
+      let from = start ?? memory;
+      if (segdef.align != null) {
+        from = Math.ceil(from / segdef.align) * segdef.align;
       }
-      if (segdef.align != null && memory % segdef.align) {
-        fail(`Segment '${segdef.name}' wants $${segdef.align.toString(16)
-             }-byte alignment but shares its name with a MEMORY area at $${
-             memory.toString(16)}`);
+      if (from < memory || from >= memory + size) {
+        fail(`Segment '${segdef.name}' starts at $${from.toString(16)}, which ${
+             ''}is outside the MEMORY area of the same name ($${
+             memory.toString(16)}..$${(memory + size).toString(16)})`);
       }
+      seg.memory = from;
+      seg.size = size - (from - memory);
       applySegmentType(seg, segdef);
       if (area.fill && segdef.fillval != null) seg.fill = segdef.fillval;
       if (segdef.define) seg.define = true;

--- a/src/linkerconfig.ts
+++ b/src/linkerconfig.ts
@@ -22,6 +22,11 @@ export type SegmentType = AreaType | 'bss' | 'zp' | 'overwrite';
 const AREA_TYPES: readonly string[] = ['ro', 'rw'];
 const SEGMENT_TYPES: readonly string[] = ['ro', 'rw', 'bss', 'zp', 'overwrite'];
 
+const RE_CFG_COMMENT = /(#|\/\/).*/y;
+const RE_CFG_NUMBER = /\$?[0-9a-z_]+/iy;
+const RE_CFG_OPERATOR = /([;,=:]|\++|-+|&&?|\|\|?|[*/~^]|<[<=]?|>[>=]?)/y;
+const RE_CFG_PERCENT = /%[a-z0-9_]*/iy;
+
 export type CfgSymbols = Map<string, number>;
 
 export interface MemoryArea {
@@ -97,22 +102,22 @@ export class CfgTokenizer extends Tokenizer {
 
   protected override skipIgnored(): void {
     while (this.buffer.space() || this.buffer.newline() ||
-           this.buffer.token(/^(#|\/\/).*/)) {
+           this.buffer.token(RE_CFG_COMMENT)) {
              // intentionally empty
            }
   }
 
   /** change the default meaning of `%` since here its for `%O`/`%S` filename placeholders */
-  protected override numberRegex(): RegExp { return /^\$?[0-9a-z_]+/i; }
+  protected override numberRegex(): RegExp { return RE_CFG_NUMBER; }
 
   /** added a new `;` token for line ending so we need to add it to the operator list */
   protected override operatorRegex(): RegExp {
-    return /^([;,=:]|\++|-+|&&?|\|\|?|[*/~^]|<[<=]?|>[>=]?)/;
+    return RE_CFG_OPERATOR;
   }
 
   /** Handle the %o / %s tokens as well */
   protected override tokenInternal(): Token {
-    if (this.buffer.token(/^%[a-z0-9_]*/i)) {
+    if (this.buffer.token(RE_CFG_PERCENT)) {
       if (this.buffer.group() === '%S' && this.startAddr != null) {
         return {token: 'num', num: this.startAddr};
       }

--- a/src/linkerconfig.ts
+++ b/src/linkerconfig.ts
@@ -10,6 +10,7 @@
 
 import {type Expr} from './expr.ts';
 import * as Exprs from './expr.ts';
+import {type Segment} from './module.ts';
 import {type Token} from './token.ts';
 import * as Tokens from './token.ts';
 import {Tokenizer} from './tokenizer.ts';
@@ -330,12 +331,17 @@ function splitAttrs(stmt: Token[], start: number): Token[][] {
   return out;
 }
 
-function statementName(stmt: Token[]): string {
+function statementName(stmt: Token[], block: string,
+                       seen: {name: string}[]): string {
   const tok = stmt[0];
   if (tok.token !== 'ident' && tok.token !== 'str') {
     Tokens.fail(`Expected a name: ${Tokens.nameOf(tok)}`, tok);
   }
   Tokens.expect(Tokens.COLON, stmt[1], tok);
+  // Names have to be unique within a block
+  if (seen.some(s => s.name === tok.str)) {
+    Tokens.fail(`Duplicate ${block} entry: ${tok.str}`, tok);
+  }
   return tok.str;
 }
 
@@ -349,7 +355,7 @@ const SEGMENT_ATTRS = [
 
 function parseMemory(grp: Token[], at: Token, out: MemoryArea[]): void {
   for (const stmt of statements(grp, at)) {
-    const name = statementName(stmt);
+    const name = statementName(stmt, 'MEMORY', out);
     const attrs = new Attrs(splitAttrs(stmt, 2), stmt[0]);
     attrs.checkKnown(MEMORY_ATTRS, 'MEMORY');
     // file = "" means "do not write" so put it as undefined to mark that
@@ -372,7 +378,7 @@ function parseMemory(grp: Token[], at: Token, out: MemoryArea[]): void {
 
 function parseSegments(grp: Token[], at: Token, out: RawSegmentDef[]): void {
   for (const stmt of statements(grp, at)) {
-    const name = statementName(stmt);
+    const name = statementName(stmt, 'SEGMENTS', out);
     const attrs = new Attrs(splitAttrs(stmt, 2), stmt[0]);
     attrs.checkKnown(SEGMENT_ATTRS, 'SEGMENTS');
     const load = attrs.name('load');
@@ -407,7 +413,7 @@ interface RawSegmentDef extends Omit<SegmentDef, 'type'> {
 
 function parseFiles(grp: Token[], at: Token, out: FileDef[]): void {
   for (const stmt of statements(grp, at)) {
-    const name = statementName(stmt);
+    const name = statementName(stmt, 'FILES', out);
     const attrs = new Attrs(splitAttrs(stmt, 2), stmt[0]);
     attrs.checkKnown(['format'], 'FILES');
     // we don't support some of these, but we accept them as input. Probably should issue
@@ -419,7 +425,7 @@ function parseFiles(grp: Token[], at: Token, out: FileDef[]): void {
 
 function parseSymbols(grp: Token[], at: Token, out: SymbolDef[]): void {
   for (const stmt of statements(grp, at)) {
-    const name = statementName(stmt);
+    const name = statementName(stmt, 'SYMBOLS', out);
     const attrs = new Attrs(splitAttrs(stmt, 2), stmt[0]);
     attrs.checkKnown(['type', 'value', 'addrsize'], 'SYMBOLS');
     const type = (attrs.keyword('type', ['export', 'import', 'weak']) ??
@@ -484,9 +490,99 @@ export function parseLinkerConfig(text: string, file = 'linker.cfg',
             }, which is not a MEMORY area`, at);
       }
     }
+    // ld65 namespaces the memory and segments so they don't overlap, but I don't
+    // want to deal with that since we have just segments. Reject any segements
+    // with the same name that don't load+run into the other. If it does load+run
+    // into the other one, then merge them.
+    if (areas.has(rest.name) &&
+        (rest.load !== rest.name || rest.run !== rest.name)) {
+      Tokens.fail(`Segment '${rest.name}' shares its name with a MEMORY area ${
+          ''}but does not load and run there. Rename one of them or use the MEMORY segment directly`, at);
+    }
     // ld65 defaults a segment's type to that of the area it loads into.
     return {...rest, type: rest.type ?? areas.get(rest.load)!.type} as SegmentDef;
   });
 
   return {memory, segments, files, symbols};
+}
+
+/**
+ * Converts the ld65 linker config into the js65 linker types.
+ * 
+ * the `objectExports` param is all the symbols the object files export,
+ * used for checking if a weak symbol was replaced.
+ */
+export function lowerLinkerConfig(
+    cfg: LinkerConfig,
+    objectExports: ReadonlySet<string> = new Set()): Segment[] {
+  const symbols = configSymbols(cfg, objectExports);
+  const out: Segment[] = [];
+  const areas = new Map<string, Segment>();
+  const originalSegments = new Map(cfg.segments.map(s => [s.name, s]));
+
+  // Convert all of the memory items into segments.
+  for (const area of cfg.memory) {
+    const what = `MEMORY area '${area.name}'`;
+    const memory = resolveCfgExpr(area.start, symbols, `${what} start`);
+    const size = resolveCfgExpr(area.size, symbols, `${what} size`);
+    const seg: Segment = {name: area.name, memory, size};
+    if (area.bank != null) {
+      seg.bank = resolveCfgExpr(area.bank, symbols, `${what} bank`);
+    }
+    // An area with no file holds no bytes, which is how the linker recognizes
+    // RAM, so leave `out` unset rather than empty.
+    if (area.file != null) seg.out = area.file;
+    if (area.fill) seg.fill = area.fillval;
+    if (area.define) seg.define = true;
+    const segdef = originalSegments.get(area.name);
+    if (segdef) {
+      // if we have a memory item and segment item with the same name,
+      // try to merge them if its compatible. otherwise throw an error.
+      // this is different from ld65 behavior but i'm fine with that for now.
+      const start = segdef.start ?? (segdef.offset != null ? memory + segdef.offset
+                                                     : undefined);
+      if (start != null && start !== memory) {
+        fail(`Segment '${segdef.name}' starts at $${start.toString(16)} but ${
+             ''}shares its name with a MEMORY area at $${memory.toString(16)}`);
+      }
+      if (segdef.align != null && memory % segdef.align) {
+        fail(`Segment '${segdef.name}' wants $${segdef.align.toString(16)
+             }-byte alignment but shares its name with a MEMORY area at $${
+             memory.toString(16)}`);
+      }
+      applySegmentType(seg, segdef);
+      if (area.fill && segdef.fillval != null) seg.fill = segdef.fillval;
+      if (segdef.define) seg.define = true;
+    }
+    areas.set(area.name, seg);
+    out.push(seg);
+  }
+
+  // And also all of the segment items into segments.
+  for (const def of cfg.segments) {
+    if (areas.has(def.name)) continue; // already merged into its area
+    const seg: Segment = {name: def.name, load: def.load, run: def.run};
+    // `start` is an absolute address. `offset` is relative to the run area.
+    const memory = def.start ??
+        (def.offset != null ? areas.get(def.run)!.memory! + def.offset
+                            : undefined);
+    if (memory != null) seg.memory = memory;
+    if (def.align != null) seg.align = def.align;
+    if (def.alignLoad != null) seg.alignLoad = def.alignLoad;
+    if (def.fillval != null) seg.fill = def.fillval;
+    applySegmentType(seg, def);
+    if (def.define) seg.define = true;
+    if (def.optional) seg.optional = true;
+    out.push(seg);
+  }
+  return out;
+}
+
+function applySegmentType(seg: Segment, def: SegmentDef): void {
+  if (def.type === 'bss' || def.type === 'zp') seg.bss = true;
+  if (def.type === 'zp') seg.addressing = 1;
+}
+
+function fail(message: string): never {
+  throw new Tokens.SourceError(message);
 }

--- a/src/linkerconfig.ts
+++ b/src/linkerconfig.ts
@@ -1,0 +1,492 @@
+
+// SPDX-License-Identifier: MPL-2.0
+
+/**
+ * Parser for ld65 linker configuration files compatibility.
+ *
+ * Parses the ld65 scripts into the existing segment definition
+ * that we use for linking in js65.
+ */
+
+import {type Expr} from './expr.ts';
+import * as Exprs from './expr.ts';
+import {type Token} from './token.ts';
+import * as Tokens from './token.ts';
+import {Tokenizer} from './tokenizer.ts';
+import {ErrorCollector} from './assembler.ts';
+
+export type AreaType = 'ro' | 'rw';
+export type SegmentType = AreaType | 'bss' | 'zp' | 'overwrite';
+
+const AREA_TYPES: readonly string[] = ['ro', 'rw'];
+const SEGMENT_TYPES: readonly string[] = ['ro', 'rw', 'bss', 'zp', 'overwrite'];
+
+export type CfgSymbols = Map<string, number>;
+
+export interface MemoryArea {
+  name: string;
+  start: Expr;
+  size: Expr;
+  type: AreaType;
+  /** `file =`; undefined means the area's bytes are not written anywhere. */
+  file?: string;
+  fill: boolean;
+  fillval: number;
+  bank?: Expr;
+  /** Creates the symbols START/SIZE/LAST/FILEOFFS */
+  define: boolean;
+  /** ld65 orders output by the order its declared so we need to track that. */
+  index: number;
+}
+
+export interface SegmentDef {
+  name: string;
+  load: string;
+  run: string;
+  /** Optional in the config. Defaults to the *load* area's type. */
+  type: SegmentType;
+  // Unlike the MEMORY section, every numeric SEGMENTS attribute is a plain number
+  align?: number;
+  alignLoad?: number;
+  start?: number;
+  offset?: number;
+  fillval?: number;
+  /** Creates the symbols LOAD/RUN/SIZE */
+  define: boolean;
+  optional: boolean;
+  /** ld65 orders output by the order its declared so we need to track that. */
+  index: number;
+}
+
+export interface FileDef {
+  name: string;
+  format: string;
+}
+
+/**
+ * `export` defines the symbol outright
+ * `weak` defines it only if no object file already exported it
+ * `import` requires that some object file define it, and must not have a value set.
+ */
+export interface SymbolDef {
+  name: string;
+  type: 'export' | 'import' | 'weak';
+  value?: Expr;
+}
+
+export interface LinkerConfig {
+  memory: MemoryArea[];
+  segments: SegmentDef[];
+  files: FileDef[];
+  symbols: SymbolDef[];
+}
+
+/**
+ * Custom tokenizer using our existing tokenizer but with specific overrides
+ * to adapt it for the ld65 file differences. So things like `;` meaning terminator
+ * instead of comment. This does mean putting weird stuff in the ld65 script that
+ * errors out could cause some strange error messages if they overlap with js65
+ * tokens, but that should be rare enough to not matter.
+ */
+export class CfgTokenizer extends Tokenizer {
+  /**
+   * Value substituted for `%S`, passed into the cli as ld65's `-S` or FEATURES STARTADDRESS.
+   */
+  startAddr?: number;
+
+  protected override skipIgnored(): void {
+    while (this.buffer.space() || this.buffer.newline() ||
+           this.buffer.token(/^(#|\/\/).*/)) {
+             // intentionally empty
+           }
+  }
+
+  /** change the default meaning of `%` since here its for `%O`/`%S` filename placeholders */
+  protected override numberRegex(): RegExp { return /^\$?[0-9a-z_]+/i; }
+
+  /** added a new `;` token for line ending so we need to add it to the operator list */
+  protected override operatorRegex(): RegExp {
+    return /^([;,=:]|\++|-+|&&?|\|\|?|[*/~^]|<[<=]?|>[>=]?)/;
+  }
+
+  /** Handle the %o / %s tokens as well */
+  protected override tokenInternal(): Token {
+    if (this.buffer.token(/^%[a-z0-9_]*/i)) {
+      if (this.buffer.group() === '%S' && this.startAddr != null) {
+        return {token: 'num', num: this.startAddr};
+      }
+      return this.strTok('str');
+    }
+    return super.tokenInternal();
+  }
+
+  /** Reads in the entire file */
+  tokens(): Token[] {
+    return this.nextSync() ?? [];
+  }
+}
+
+/**
+ * Attributes of a single `name: key = value, ...;` statement.  The value tokens
+ * are kept so every diagnostic can point at the offending value.
+ */
+class Attrs {
+  private readonly values = new Map<string, Token[]>();
+  private readonly keys = new Map<string, Token>();
+
+  constructor(args: Token[][], private readonly at: Token) {
+    for (const arg of args) {
+      const keyTok = arg[0];
+      const key = Tokens.expectIdentifier(keyTok, at).toLowerCase();
+      Tokens.expect(Tokens.ASSIGN, arg[1], keyTok);
+      const value = arg.slice(2);
+      if (!value.length) Tokens.fail(`Missing value for '${key}'`, arg[1]);
+      if (this.values.has(key)) Tokens.fail(`Duplicate attribute: ${key}`, keyTok);
+      this.values.set(key, value);
+      this.keys.set(key, keyTok);
+    }
+  }
+
+  checkKnown(known: readonly string[], block: string): void {
+    for (const key of this.values.keys()) {
+      if (known.includes(key)) continue;
+      Tokens.fail(`Unknown ${block} attribute '${key}', expected one of: ${
+          known.join(', ')}`, this.keys.get(key));
+    }
+  }
+
+  expr(key: string): Expr|undefined {
+    const value = this.values.get(key);
+    if (!value) return undefined;
+    try {
+      return Exprs.traversePost(Exprs.parseOnly(value), Exprs.evaluate);
+    } catch (err) {
+      throw Tokens.SourceError.locate(err, value[0].source);
+    }
+  }
+
+  reqExpr(key: string): Expr {
+    const expr = this.expr(key);
+    if (!expr) Tokens.fail(`Missing required attribute '${key}'`, this.at);
+    return expr;
+  }
+
+  num(key: string): number|undefined {
+    const expr = this.expr(key);
+    if (!expr) return undefined;
+    if (expr.op !== 'num' || expr.num == null) {
+      Tokens.fail(`Value of '${key}' must be a constant${
+          describeUnresolved(expr)}`, this.values.get(key)![0]);
+    }
+    return expr.num;
+  }
+
+  reqNum(key: string): number {
+    const value = this.num(key);
+    if (value == null) Tokens.fail(`Missing required attribute '${key}'`, this.at);
+    return value;
+  }
+
+  keyword(key: string, allowed: readonly string[]): string|undefined {
+    const value = this.values.get(key);
+    if (!value) return undefined;
+    if (value.length !== 1 || value[0].token !== 'ident' ||
+        !allowed.includes(value[0].str.toLowerCase())) {
+      Tokens.fail(`Value of '${key}' must be one of: ${allowed.join(', ')}`,
+                  value[0]);
+    }
+    return value[0].str.toLowerCase();
+  }
+
+  bool(key: string, dflt: boolean): boolean {
+    const value = this.keyword(key, ['yes', 'no', 'true', 'false']);
+    if (value == null) return dflt;
+    return value === 'yes' || value === 'true';
+  }
+
+  /**
+   * 
+   */
+  name(key: string): string|undefined {
+    const value = this.values.get(key);
+    if (!value) return undefined;
+    const tok = value[0];
+    if (value.length !== 1 || (tok.token !== 'ident' && tok.token !== 'str')) {
+      Tokens.fail(`Value of '${key}' must be a name`, tok);
+    }
+    return tok.str;
+  }
+
+  reqName(key: string): string {
+    const value = this.name(key);
+    if (value == null) Tokens.fail(`Missing required attribute '${key}'`, this.at);
+    return value;
+  }
+}
+
+function unresolvedNames(expr: Expr): string[] {
+  const out = new Set<string>();
+  Exprs.traverse(expr, (e, rec) => {
+    if (e.sym) out.add(e.sym);
+    if (e.str) out.add(e.str);
+    return rec(e);
+  });
+  return [...out];
+}
+
+/** ` (FOO is not defined)` -- appended to a "not constant" diagnostic. */
+function describeUnresolved(expr: Expr): string {
+  const names = unresolvedNames(expr);
+  if (!names.length) return '';
+  return ` (${names.join(', ')} ${names.length > 1 ? 'are' : 'is'} not defined)`;
+}
+
+/**
+ * Resolves a deferred config expression against the symbols known so far.
+ * All sections have specific order that they are processed, and theres no
+ * loops for things that haven't been discovered. So no "real" forward
+ * references, but sections are parsed in the following order to kinda fake it.
+ *
+ * -> SYMBOLS 
+ * -> MEMORY resolves `start`
+ * -> MEMORY if `define`ed, creates __START__
+ * -> MEMORY resolves `size`
+ * -> Resolve all SEGMENTs that on the MEMORY to define RUN/LOAD/SIZE
+ * -> and finally the rest of the MEMORY defines SIZE/LAST/FILEOFFS
+ * 
+ * So a later MEMORYs `start` can reference an earlier MEMORYs SEGMENT defines
+ *
+ * what param is the original description of the value used for the error message.
+ */
+export function resolveCfgExpr(expr: Expr, symbols: CfgSymbols,
+                               what: string): number {
+  const resolved = Exprs.traverse(expr, (e, rec) => {
+    if (e.op === 'sym' && e.sym != null) {
+      const value = symbols.get(e.sym);
+      if (value != null) return {op: 'num', num: value};
+    }
+    return Exprs.evaluate(rec(e));
+  });
+  if (resolved.op !== 'num' || resolved.num == null) {
+    Tokens.fail(`${what} is not constant${describeUnresolved(resolved)}`, expr);
+  }
+  return resolved.num;
+}
+
+export function configSymbols(cfg: LinkerConfig,
+                              objectExports: ReadonlySet<string> = new Set()): CfgSymbols {
+  const out: CfgSymbols = new Map();
+  for (const sym of cfg.symbols) {
+    if (sym.value == null) continue;
+    if (sym.type === 'weak' && objectExports.has(sym.name)) continue;
+    try {
+      out.set(sym.name, resolveCfgExpr(sym.value, out, `Value of '${sym.name}'`));
+    } catch {
+      // Not constant, but don't create an error here.
+      // We can make a better error message later with more context than we could here.
+    }
+  }
+  return out;
+}
+
+function statements(grp: Token[], at: Token): Token[][] {
+  const out: Token[][] = [];
+  let start = 0;
+  for (;;) {
+    const semi = Tokens.find(grp, Tokens.SEMI, start);
+    if (semi < 0) break;
+    if (semi > start) out.push(grp.slice(start, semi));
+    start = semi + 1;
+  }
+  if (start < grp.length) {
+    Tokens.fail(`Expected ';' after statement`, grp[grp.length - 1] ?? at);
+  }
+  return out;
+}
+
+/**
+ * Splits the attributes into name = value pairs where the `,` can be optionally
+ * excluded because why does ld65 that have that?
+ */
+function splitAttrs(stmt: Token[], start: number): Token[][] {
+  const out: Token[][] = [];
+  let cur: Token[]|undefined;
+  let depth = 0;
+  for (let i = start; i < stmt.length; i++) {
+    const tok = stmt[i];
+    if (!depth && tok.token === 'ident' &&
+        Tokens.eq(stmt[i + 1], Tokens.ASSIGN)) {
+      out.push(cur = [tok]);
+      continue;
+    }
+    if (Tokens.eq(tok, Tokens.LP)) depth++;
+    else if (Tokens.eq(tok, Tokens.RP)) depth--;
+    else if (!depth && Tokens.eq(tok, Tokens.COMMA)) continue;
+    if (!cur) {
+      Tokens.fail(`Expected an attribute name: ${Tokens.nameOf(tok)}`, tok);
+    }
+    cur.push(tok);
+  }
+  return out;
+}
+
+function statementName(stmt: Token[]): string {
+  const tok = stmt[0];
+  if (tok.token !== 'ident' && tok.token !== 'str') {
+    Tokens.fail(`Expected a name: ${Tokens.nameOf(tok)}`, tok);
+  }
+  Tokens.expect(Tokens.COLON, stmt[1], tok);
+  return tok.str;
+}
+
+const MEMORY_ATTRS = [
+  'bank', 'define', 'file', 'fill', 'fillval', 'size', 'start', 'type',
+];
+const SEGMENT_ATTRS = [
+  'align', 'align_load', 'define', 'fillval', 'load', 'offset', 'optional',
+  'run', 'start', 'type',
+];
+
+function parseMemory(grp: Token[], at: Token, out: MemoryArea[]): void {
+  for (const stmt of statements(grp, at)) {
+    const name = statementName(stmt);
+    const attrs = new Attrs(splitAttrs(stmt, 2), stmt[0]);
+    attrs.checkKnown(MEMORY_ATTRS, 'MEMORY');
+    // file = "" means "do not write" so put it as undefined to mark that
+    const file = attrs.name('file') || undefined;
+    const bank = attrs.expr('bank');
+    out.push({
+      name,
+      start: attrs.reqExpr('start'),
+      size: attrs.reqExpr('size'),
+      type: (attrs.keyword('type', AREA_TYPES) ?? 'rw') as AreaType,
+      ...(file != null ? {file} : {}),
+      fill: attrs.bool('fill', false),
+      fillval: attrs.num('fillval') ?? 0,
+      ...(bank != null ? {bank} : {}),
+      define: attrs.bool('define', false),
+      index: out.length,
+    });
+  }
+}
+
+function parseSegments(grp: Token[], at: Token, out: RawSegmentDef[]): void {
+  for (const stmt of statements(grp, at)) {
+    const name = statementName(stmt);
+    const attrs = new Attrs(splitAttrs(stmt, 2), stmt[0]);
+    attrs.checkKnown(SEGMENT_ATTRS, 'SEGMENTS');
+    const load = attrs.name('load');
+    const run = attrs.name('run');
+    if (load == null && run == null) {
+      Tokens.fail(`Segment '${name}' needs at least one of 'load' or 'run'`,
+                  stmt[0]);
+    }
+    out.push({
+      name,
+      load: (load ?? run)!,
+      run: (run ?? load)!,
+      type: attrs.keyword('type', SEGMENT_TYPES) as SegmentType|undefined,
+      align: attrs.num('align'),
+      alignLoad: attrs.num('align_load'),
+      start: attrs.num('start'),
+      offset: attrs.num('offset'),
+      fillval: attrs.num('fillval'),
+      define: attrs.bool('define', false),
+      optional: attrs.bool('optional', false),
+      index: out.length,
+      at: stmt[0],
+    });
+  }
+}
+
+/** A SegmentDef before its `type` default has been resolved from its load area. */
+interface RawSegmentDef extends Omit<SegmentDef, 'type'> {
+  type?: SegmentType;
+  at: Token;
+}
+
+function parseFiles(grp: Token[], at: Token, out: FileDef[]): void {
+  for (const stmt of statements(grp, at)) {
+    const name = statementName(stmt);
+    const attrs = new Attrs(splitAttrs(stmt, 2), stmt[0]);
+    attrs.checkKnown(['format'], 'FILES');
+    // we don't support some of these, but we accept them as input. Probably should issue
+    // a warning but its too much effort for now.
+    const format = attrs.keyword('format', ['bin', 'binary', 'o65', 'atari']);
+    out.push({name, format: format === 'binary' ? 'bin' : (format ?? 'bin')});
+  }
+}
+
+function parseSymbols(grp: Token[], at: Token, out: SymbolDef[]): void {
+  for (const stmt of statements(grp, at)) {
+    const name = statementName(stmt);
+    const attrs = new Attrs(splitAttrs(stmt, 2), stmt[0]);
+    attrs.checkKnown(['type', 'value', 'addrsize'], 'SYMBOLS');
+    const type = (attrs.keyword('type', ['export', 'import', 'weak']) ??
+                  Tokens.fail(`Symbol '${name}' needs a 'type'`,
+                              stmt[0])) as SymbolDef['type'];
+    const value = attrs.expr('value');
+    if (type === 'import') {
+      if (value != null) {
+        Tokens.fail(`Imported symbol '${name}' must not have a value`, stmt[0]);
+      }
+    } else if (value == null) {
+      Tokens.fail(`Symbol '${name}' of type '${type}' needs a 'value'`, stmt[0]);
+    }
+    out.push({name, type, ...(value != null ? {value} : {})});
+  }
+}
+
+// TODO: allow passing in startAddr from CLI / libasm
+export interface ParseOptions {
+  startAddr?: number;
+}
+
+export function parseLinkerConfig(text: string, file = 'linker.cfg',
+                                  opts: ParseOptions = {}): LinkerConfig {
+  const errors = new ErrorCollector();
+  const tokenizer = new CfgTokenizer(text, file, {generateDebugInfo: true},
+                                     undefined, errors);
+  tokenizer.startAddr = opts.startAddr;
+  const toks = tokenizer.tokens();
+  const firstError = errors.getMessages().find(m => m.level === 'error');
+  if (firstError) throw new Tokens.SourceError(firstError.message, firstError.source);
+
+  const memory: MemoryArea[] = [];
+  const rawSegments: RawSegmentDef[] = [];
+  const files: FileDef[] = [];
+  const symbols: SymbolDef[] = [];
+
+  for (let i = 0; i < toks.length; i += 2) {
+    const nameTok = toks[i];
+    const name = Tokens.expectIdentifier(nameTok, toks[i - 1]).toUpperCase();
+    const grp = toks[i + 1];
+    if (!grp || grp.token !== 'grp') {
+      Tokens.fail(`Expected '{' after ${name}`, grp ?? nameTok);
+    }
+    switch (name) {
+      case 'MEMORY': parseMemory(grp.inner, nameTok, memory); break;
+      case 'SEGMENTS': parseSegments(grp.inner, nameTok, rawSegments); break;
+      case 'FILES': parseFiles(grp.inner, nameTok, files); break;
+      case 'SYMBOLS': parseSymbols(grp.inner, nameTok, symbols); break;
+      // TODO implement these cfg features
+      case 'FEATURES': case 'FORMATS': break;
+      default: Tokens.fail(`Unknown linker config block: ${name}`, nameTok);
+    }
+  }
+
+  const areas = new Map(memory.map(a => [a.name, a]));
+  const segments = rawSegments.map(raw => {
+    const {at, ...rest} = raw;
+    for (const key of ['load', 'run'] as const) {
+      if (!areas.has(rest[key])) {
+        Tokens.fail(`Segment '${rest.name}' has ${key} = ${rest[key]
+            }, which is not a MEMORY area`, at);
+      }
+    }
+    // ld65 defaults a segment's type to that of the area it loads into.
+    return {...rest, type: rest.type ?? areas.get(rest.load)!.type} as SegmentDef;
+  });
+
+  return {memory, segments, files, symbols};
+}

--- a/src/module.ts
+++ b/src/module.ts
@@ -105,8 +105,22 @@ export interface Segment {
   fill?: number;
   /** Output file for the segment. Use "%O" for the main output file, or a filename. Empty/undefined means no output. */
   out?: string;
-  /** Name of the segment that this should be placed inside. */
-  overlay?: string;
+  /** Segment name where the output data foes. Lets you imitate the MEMORY/SEGMENT split from ca65 */
+  load?: string;
+  /** Similar to load but for the `org` address to write to. */
+  run?: string;
+  /** Alignment (a power of two) the segment start must satisfy. */
+  align?: number;
+  /** Alignment of the load position, when load != run. */
+  alignLoad?: number;
+  /** Occupies address space but emits no bytes (ld65 `type = bss`/`zp`). */
+  bss?: boolean;
+  /** Emit START/SIZE/LAST/LOAD/RUN/FILEOFFS symbols */
+  define?: boolean;
+  /** Drop the segment entirely if no chunks land in it. */
+  optional?: boolean;
+  /** Opt in to byte-pattern sharing during placement (js65 extension). */
+  dedupe?: boolean;
   /** True if this segment is the "default" segment to use if no segment is defined */
   default?: boolean;
   /** Unallocated ranges (org), half-open [a, b). */

--- a/src/token.ts
+++ b/src/token.ts
@@ -116,6 +116,8 @@ export const WORD: Token = {token: 'cs', str: '.word'};
 export const COLON: Token = {token: 'op', str: ':'};
 //export const DCOLON: Token = {token: 'op', str: '::'};
 export const COMMA: Token = {token: 'op', str: ','};
+/** Statement terminator in an ld65 linker config. We don't use this for asm */
+export const SEMI: Token = {token: 'op', str: ';'};
 export const STAR: Token = {token: 'op', str: '*'};
 export const IMMEDIATE: Token = {token: 'op', str: '#'};
 export const ASSIGN: Token = {token: 'op', str: '='};

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -22,56 +22,73 @@ export class Tokenizer implements Tokens.Source {
   }
 
   async next(): Promise<Token[]|undefined> {
-    return await new Promise( (resolve) => {
-      let tok = this.token();
-      while (Tokens.eq(tok, Tokens.EOL)) {
-        // Skip EOLs at beginning of line.
-        tok = this.token();
-      }
-      // Group curly brace groups into a single effective Tokens.
-      const stack: Token[][] = [[]];
-      let depth = 0;
-      while (!Tokens.eq(tok, Tokens.EOL) && !Tokens.eq(tok, Tokens.EOF)) {
-        if (Tokens.eq(tok, Tokens.LC)) {
-          stack[depth++].push(tok);
-          stack.push([]);
-        } else if (Tokens.eq(tok, Tokens.RC)) {
-          if (!depth) {
-            // Missing open curly - record error and skip the close brace
-            this.errorCollector?.add('error', `Missing open curly`, tok.source);
-          } else {
-            const inner = stack.pop()!;
-            const source = stack[--depth].pop()!.source;
-            const token: Token = {token: 'grp', inner};
-            if (source) token.source = source;
-            stack[depth].push(token);
-          }
-        } else {
-          stack[depth].push(tok);
-        }
-        tok = this.token();
-      }
-      // Auto-close any unclosed braces at EOL
-      while (depth > 0) {
-        const open = stack[depth - 1].pop()!;
-        this.errorCollector?.add('error', `Missing close curly`, open.source);
-        const inner = stack.pop()!;
-        const source = open.source;
-        const token: Token = {token: 'grp', inner};
-        if (source) token.source = source;
-        stack[--depth].push(token);
-      }
-      resolve(stack[0].length ? stack[0] : undefined);
-    });
+    return this.nextSync();
   }
 
-  private token(): Token {
-    // skip whitespace
+  protected nextSync(): Token[]|undefined {
+    let tok = this.token();
+    while (Tokens.eq(tok, Tokens.EOL)) {
+      // Skip EOLs at beginning of line.
+      tok = this.token();
+    }
+    // Group curly brace groups into a single effective Tokens.
+    const stack: Token[][] = [[]];
+    let depth = 0;
+    while (!Tokens.eq(tok, Tokens.EOL) && !Tokens.eq(tok, Tokens.EOF)) {
+      if (Tokens.eq(tok, Tokens.LC)) {
+        stack[depth++].push(tok);
+        stack.push([]);
+      } else if (Tokens.eq(tok, Tokens.RC)) {
+        if (!depth) {
+          // Missing open curly - record error and skip the close brace
+          this.errorCollector?.add('error', `Missing open curly`, tok.source);
+        } else {
+          const inner = stack.pop()!;
+          const source = stack[--depth].pop()!.source;
+          const token: Token = {token: 'grp', inner};
+          if (source) token.source = source;
+          stack[depth].push(token);
+        }
+      } else {
+        stack[depth].push(tok);
+      }
+      tok = this.token();
+    }
+    // Auto-close any unclosed braces at EOL
+    while (depth > 0) {
+      const open = stack[depth - 1].pop()!;
+      this.errorCollector?.add('error', `Missing close curly`, open.source);
+      const inner = stack.pop()!;
+      const source = open.source;
+      const token: Token = {token: 'grp', inner};
+      if (source) token.source = source;
+      stack[--depth].push(token);
+    }
+    return stack[0].length ? stack[0] : undefined;
+  }
+
+  /**
+   * Overridable because a linker config uses `;` as a line terminator, so
+   * what gets ignored is different between the two.
+   */
+  protected skipIgnored(): void {
     while (this.buffer.space() ||
            this.buffer.token(/^;.*/) ||
            (this.opts.lineContinuations && this.buffer.token(/^\\(\r\n|\n|\r)/))) {
             // intentionally empty
            }
+  }
+
+  /** `%` is a binary literal prefix in ca65, but used for special `%O` and `%S` flags in linkercfg. */
+  protected numberRegex(): RegExp { return /^[$%]?[0-9a-z_]+/i; }
+
+  protected operatorRegex(): RegExp {
+    return /^(:=|:|\++|-+|&&?|\|\|?|[#*/,=~!^]|<[<>=]?|>[>=]?)/;
+  }
+
+  protected token(): Token {
+    // skip whitespace
+    this.skipIgnored();
     if (this.buffer.eof()) return Tokens.EOF;
 
     // remember position of non-whitespace
@@ -96,7 +113,7 @@ export class Tokenizer implements Tokens.Source {
     }
   }
 
-  private tokenInternal(): Token {
+  protected tokenInternal(): Token {
     if (this.buffer.newline()) return {token: 'eol'};
     if (this.buffer.token(/^@+[a-z0-9_]*/i) ||
         this.buffer.token(/^((::)?[a-z_][a-z0-9_]*)+/i)) {
@@ -104,7 +121,7 @@ export class Tokenizer implements Tokens.Source {
     }
     if (this.buffer.token(/^\.[a-z][a-z0-9]*/i)) return this.csTok();
     if (this.buffer.token(/^:([+-]\d+|[-+]+|<+rts|>*rts)/)) return this.strTok('ident');
-    if (this.buffer.token(/^(:=|:|\++|-+|&&?|\|\|?|[#*/,=~!^]|<[<>=]?|>[>=]?)/)) {
+    if (this.buffer.token(this.operatorRegex())) {
       const op = this.strTok('op');
       // the := is just like = but it marks it as a label in the dbg file.
       // which we don't support so just treat it as = for now.
@@ -118,7 +135,7 @@ export class Tokenizer implements Tokens.Source {
     if (this.buffer.token('}')) return {token: 'rc'};
     if (this.buffer.token(')')) return {token: 'rp'};
     if (this.buffer.token(/^["']/)) return this.tokenizeStr();
-    if (this.buffer.token(/^[$%]?[0-9a-z_]+/i)) return this.tokenizeNum();
+    if (this.buffer.token(this.numberRegex())) return this.tokenizeNum();
     throw new Error(`Syntax error`);
   }
 
@@ -167,7 +184,7 @@ export class Tokenizer implements Tokens.Source {
     this.errorCollector.add('error', message, source);
   }
 
-  private strTok(token: Tokens.StringToken['token']): Token {
+  protected strTok(token: Tokens.StringToken['token']): Token {
     return {token, str: this.buffer.group()!};
   }
 
@@ -180,11 +197,10 @@ export class Tokenizer implements Tokens.Source {
     };
   }
 
-  private tokenizeNum(str: string = this.buffer.group()!): Token {
+  protected tokenizeNum(str: string = this.buffer.group()!): Token {
     if (this.opts.numberSeparators) str = str.replace(/_/g, '');
     if (str[0] === '$') return parseHex(str.substring(1));
     if (str[0] === '%') return parseBin(str.substring(1));
-    if (str[0] === '0') return parseOct(str);
     return parseDec(str);
   }
 }
@@ -197,11 +213,6 @@ function parseHex(str: string): Token {
 function parseDec(str: string): Token {
   if (!/^[0-9]+$/.test(str)) throw new Error(`Bad decimal number: ${str}`);
   return {token: 'num', num: Number.parseInt(str, 10)};
-}
-
-function parseOct(str: string): Token {
-  if (!/^[0-7]+$/.test(str)) throw new Error(`Bad octal number: ${str}`);
-  return {token: 'num', num: Number.parseInt(str, 8)};
 }
 
 function parseBin(str: string): Token {

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -7,7 +7,26 @@ import * as Tokens from './token.ts';
 import { SourceContents } from './tokenstream.ts';
 import { ErrorCollector } from './assembler.ts';
 
-const NEWLINE = /^(\r\n|\n|\r)/;
+const NEWLINE = /(\r\n|\n|\r)/y;
+
+// Each of these regexes use the `y` flag to mark the regex as sticky.
+// This means if you run the regex with the same input multiple times,
+// it will start scanning from the last found index. This saves SO much
+// time as it will not need to start from the beginning of the string,
+// nor do we need to reallocate the string with a slice.
+const RE_COMMENT = /;.*/y;
+const RE_LINE_CONT = /\\(\r\n|\n|\r)/y;
+const RE_AT_IDENT = /@+[a-z0-9_]*/iy;
+const RE_IDENT = /((::)?[a-z_][a-z0-9_]*)+/iy;
+const RE_CS = /\.[a-z][a-z0-9]*/iy;
+const RE_LOCAL_LABEL = /:([+-]\d+|[-+]+|<+rts|>*rts)/y;
+const RE_NUMBER = /[$%]?[0-9a-z_]+/iy;
+const RE_OPERATOR = /(:=|:|\++|-+|&&?|\|\|?|[#*/,=~!^]|<[<>=]?|>[>=]?)/y;
+const RE_STRING_START = /["']/y;
+const RE_UNICODE_ESC = /\\u([0-9a-f]{4})/iy;
+const RE_HEX_ESC = /\\x([0-9a-f]{2})/iy;
+const RE_CHAR_ESC = /\\(.)/y;
+const RE_ANY = /./y;
 
 export class Tokenizer implements Tokens.Source {
   readonly buffer: Buffer;
@@ -73,17 +92,17 @@ export class Tokenizer implements Tokens.Source {
    */
   protected skipIgnored(): void {
     while (this.buffer.space() ||
-           this.buffer.token(/^;.*/) ||
-           (this.opts.lineContinuations && this.buffer.token(/^\\(\r\n|\n|\r)/))) {
+           this.buffer.token(RE_COMMENT) ||
+           (this.opts.lineContinuations && this.buffer.token(RE_LINE_CONT))) {
             // intentionally empty
            }
   }
 
   /** `%` is a binary literal prefix in ca65, but used for special `%O` and `%S` flags in linkercfg. */
-  protected numberRegex(): RegExp { return /^[$%]?[0-9a-z_]+/i; }
+  protected numberRegex(): RegExp { return RE_NUMBER; }
 
   protected operatorRegex(): RegExp {
-    return /^(:=|:|\++|-+|&&?|\|\|?|[#*/,=~!^]|<[<>=]?|>[>=]?)/;
+    return RE_OPERATOR;
   }
 
   protected token(): Token {
@@ -115,12 +134,12 @@ export class Tokenizer implements Tokens.Source {
 
   protected tokenInternal(): Token {
     if (this.buffer.newline()) return {token: 'eol'};
-    if (this.buffer.token(/^@+[a-z0-9_]*/i) ||
-        this.buffer.token(/^((::)?[a-z_][a-z0-9_]*)+/i)) {
+    if (this.buffer.token(RE_AT_IDENT) ||
+        this.buffer.token(RE_IDENT)) {
       return this.strTok('ident');
     }
-    if (this.buffer.token(/^\.[a-z][a-z0-9]*/i)) return this.csTok();
-    if (this.buffer.token(/^:([+-]\d+|[-+]+|<+rts|>*rts)/)) return this.strTok('ident');
+    if (this.buffer.token(RE_CS)) return this.csTok();
+    if (this.buffer.token(RE_LOCAL_LABEL)) return this.strTok('ident');
     if (this.buffer.token(this.operatorRegex())) {
       const op = this.strTok('op');
       // the := is just like = but it marks it as a label in the dbg file.
@@ -128,13 +147,13 @@ export class Tokenizer implements Tokens.Source {
       if ((op as Tokens.StringToken).str === ':=') return {token: 'op', str: '='};
       return op;
     }
-    if (this.buffer.token('[')) return {token: 'lb'};
-    if (this.buffer.token('{')) return {token: 'lc'};
-    if (this.buffer.token('(')) return {token: 'lp'};
-    if (this.buffer.token(']')) return {token: 'rb'};
-    if (this.buffer.token('}')) return {token: 'rc'};
-    if (this.buffer.token(')')) return {token: 'rp'};
-    if (this.buffer.token(/^["']/)) return this.tokenizeStr();
+    if (this.buffer.tokenStr('[')) return {token: 'lb'};
+    if (this.buffer.tokenStr('{')) return {token: 'lc'};
+    if (this.buffer.tokenStr('(')) return {token: 'lp'};
+    if (this.buffer.tokenStr(']')) return {token: 'rb'};
+    if (this.buffer.tokenStr('}')) return {token: 'rc'};
+    if (this.buffer.tokenStr(')')) return {token: 'rp'};
+    if (this.buffer.token(RE_STRING_START)) return this.tokenizeStr();
     if (this.buffer.token(this.numberRegex())) return this.tokenizeNum();
     throw new Error(`Syntax error`);
   }
@@ -154,18 +173,18 @@ export class Tokenizer implements Tokens.Source {
                           {file: this.file, line: m.line, column: m.column});
         return this.makeStrToken(end, str);
       }
-      if (b.token(/^\\u([0-9a-f]{4})/i)) {
+      if (b.token(RE_UNICODE_ESC)) {
         str += String.fromCodePoint(parseInt(b.group(1)!, 16));
-      } else if (b.token(/^\\x([0-9a-f]{2})/i)) {
+      } else if (b.token(RE_HEX_ESC)) {
         str += String.fromCharCode(parseInt(b.group(1)!, 16));
-      } else if (b.token(/^\\(.)/)) {
+      } else if (b.token(RE_CHAR_ESC)) {
         str += b.group(1)!;
       } else {
-        b.token(/^./);
+        b.token(RE_ANY);
         str += b.group(0)!;
       }
     }
-    b.token(end);
+    b.tokenStr(end);
     return this.makeStrToken(end, str);
   }
 

--- a/src/validate_modules.ts
+++ b/src/validate_modules.ts
@@ -421,6 +421,10 @@ function validateOptions(v: unknown, path: string): Js65Options {
   if (target !== undefined) out.target = target;
   const baseRomOffset = optNumber(v.baseRomOffset, `${path}.baseRomOffset`);
   if (baseRomOffset !== undefined) out.baseRomOffset = baseRomOffset;
+  const linkerConfig = optString(v.linkerConfig, `${path}.linkerConfig`);
+  if (linkerConfig !== undefined) out.linkerConfig = linkerConfig;
+  const linkerConfigName = optString(v.linkerConfigName, `${path}.linkerConfigName`);
+  if (linkerConfigName !== undefined) out.linkerConfigName = linkerConfigName;
   if (v.outputFormat !== undefined) {
     const fmt = reqString(v.outputFormat, `${path}.outputFormat`);
     if (!OUTPUT_FORMATS.has(fmt)) fail(`${path}.outputFormat`, 'expected one of binary|ips|object');

--- a/src/validate_modules.ts
+++ b/src/validate_modules.ts
@@ -161,6 +161,8 @@ function validateChunk(v: unknown, path: string): Chunk {
   if (name !== undefined) out.name = name;
   const org = optNumber(v.org, `${path}.org`);
   if (org !== undefined) out.org = org;
+  const align = optNumber(v.align, `${path}.align`);
+  if (align !== undefined) out.align = align;
   if (v.subs !== undefined) {
     out.subs = reqArray(v.subs, `${path}.subs`)
       .map((s, i) => validateSubstitution(s, `${path}.subs[${i}]`));
@@ -208,8 +210,22 @@ function validateSegment(v: unknown, path: string): Segment {
   if (fill !== undefined) out.fill = fill;
   const o = optString(v.out, `${path}.out`);
   if (o !== undefined) out.out = o;
-  const overlay = optString(v.overlay, `${path}.overlay`);
-  if (overlay !== undefined) out.overlay = overlay;
+  const load = optString(v.load, `${path}.load`);
+  if (load !== undefined) out.load = load;
+  const run = optString(v.run, `${path}.run`);
+  if (run !== undefined) out.run = run;
+  const align = optNumber(v.align, `${path}.align`);
+  if (align !== undefined) out.align = align;
+  const alignLoad = optNumber(v.alignLoad, `${path}.alignLoad`);
+  if (alignLoad !== undefined) out.alignLoad = alignLoad;
+  const bss = optBoolean(v.bss, `${path}.bss`);
+  if (bss !== undefined) out.bss = bss;
+  const define = optBoolean(v.define, `${path}.define`);
+  if (define !== undefined) out.define = define;
+  const optional = optBoolean(v.optional, `${path}.optional`);
+  if (optional !== undefined) out.optional = optional;
+  const dedupe = optBoolean(v.dedupe, `${path}.dedupe`);
+  if (dedupe !== undefined) out.dedupe = dedupe;
   const def = optBoolean(v.default, `${path}.default`);
   if (def !== undefined) out.default = def;
   if (v.free !== undefined) {

--- a/test/assembler_test.ts
+++ b/test/assembler_test.ts
@@ -1091,6 +1091,33 @@ describe('Assembler', function() {
     });
   });
 
+  describe('.faraddr', function() {
+    it('should emit three little-endian bytes', function() {
+      const a = new Assembler(Cpu.P02);
+      a.directive([cs('.faraddr'), num(1), COMMA, num(0x123456)]);
+      expect(strip(a.module())).toEqual({
+        chunks: [{
+          overwrite: 'allow',
+          segments: [],
+          data: Uint8Array.of(1, 0, 0, 0x56, 0x34, 0x12),
+        }],
+        symbols: [], segments: []});
+    });
+
+    it('should support expressions with backward refs', function() {
+      const a = new Assembler(Cpu.P02);
+      a.assign('q', 0x30507);
+      a.directive([cs('.faraddr'), ident('q')]);
+      expect(strip(a.module())).toEqual({
+        chunks: [{
+          overwrite: 'allow',
+          segments: [],
+          data: Uint8Array.of(7, 5, 3),
+        }],
+        symbols: [], segments: []});
+    });
+  });
+
   describe('.dword', function() {
     it('should support numbers', function() {
       const a = new Assembler(Cpu.P02);

--- a/test/assembler_test.ts
+++ b/test/assembler_test.ts
@@ -1363,11 +1363,6 @@ Foo: .res 1
     });
   });
 
-  // Marking the chunk zeropage isn't enough on its own: the operand sizing in
-  // `instruction` only looks at `expr.meta.size` and the importzp/globalzp set,
-  // so a label whose only zeropage evidence is its chunk still assembles as
-  // absolute. Operands are relocated at link time, so what lands in the chunk is
-  // an $ff placeholder per byte -- one for zeropage, two for absolute.
   describe('zeropage operand sizing', function() {
     function codeOf(m: Module) {
       const chunk = (m.chunks ?? []).find(c => c.segments.includes('CODE'));
@@ -1400,7 +1395,6 @@ Foo: .res 1
 
     it('should size a label reached through a `.define`d segment name as zeropage',
        async function() {
-         // How bhop names the segment: `.define BHOP_ZP_SEGMENT "ZEROPAGE"`.
          const m = await assembleModule(`
 .define ZP_SEGMENT "ZEROPAGE"
 .segment ZP_SEGMENT
@@ -1586,6 +1580,129 @@ Ptr: .res 2
 .endscope
 `);
          expect(codeOf(m)).toEqual([0x85, 0xff]);
+       });
+
+    // A constant defined outside a `.proc` is a value, not an address, so there
+    // is no address size to carry - the value itself has to make it in. ca65
+    // binds the name to the enclosing definition at the point of use, which
+    // means the number is already in hand when the operand gets sized.
+    it('should size a constant from an enclosing scope by its value',
+       async function() {
+         const m = await assembleModule(`
+BLANK_TILE = $af
+.segment "CODE"
+.proc p
+  lda BLANK_TILE
+.endproc
+`);
+         expect(codeOf(m)).toEqual([0xa5, 0xaf]);
+       });
+
+    it('should size a constant from an enclosing scope through nested scopes',
+       async function() {
+         const m = await assembleModule(`
+BLANK_TILE = $af
+.segment "CODE"
+.scope outer
+.proc inner
+  lda BLANK_TILE
+.endproc
+.endscope
+`);
+         expect(codeOf(m)).toEqual([0xa5, 0xaf]);
+       });
+
+    it('should fold an offset from an enclosing scope\'s constant', async function() {
+      // Only worth anything if the value comes in rather than a reference: the
+      // `+` has to fold to a number before the operand can be sized from it.
+      const m = await assembleModule(`
+BLANK_TILE = $af
+.segment "CODE"
+.proc p
+  lda BLANK_TILE+1
+.endproc
+`);
+      expect(codeOf(m)).toEqual([0xa5, 0xb0]);
+    });
+
+    it('should go absolute when an offset carries the value out of the zeropage',
+       async function() {
+         // Both halves fit in a byte and the sum does not, so the address size
+         // cannot come from the operands alone.
+         const m = await assembleModule(`
+.segment "CODE"
+  lda $ff+$ff
+  lda $80+$80
+`);
+         expect(codeOf(m)).toEqual([0xad, 0xfe, 0x01, 0xad, 0x00, 0x01]);
+       });
+
+    it('should keep an offset absolute when an operand needs two bytes',
+       async function() {
+         const m = await assembleModule(`
+BIG = $1234
+.segment "CODE"
+.proc p
+  lda BIG-$1200
+.endproc
+`);
+         expect(codeOf(m)).toEqual([0xad, 0x34, 0x00]);
+       });
+
+    it('should size an explicitly scoped constant by its value', async function() {
+      const m = await assembleModule(`
+.scope consts
+BLANK_TILE = $af
+.endscope
+.segment "CODE"
+.proc p
+  lda consts::BLANK_TILE
+.endproc
+`);
+      expect(codeOf(m)).toEqual([0xa5, 0xaf]);
+    });
+
+    it('should stay absolute for a constant from an enclosing scope that does not fit',
+       async function() {
+         const m = await assembleModule(`
+BIG = $1234
+.segment "CODE"
+.proc p
+  lda BIG
+.endproc
+`);
+         expect(codeOf(m)).toEqual([0xad, 0x34, 0x12]);
+       });
+
+    it('should still size a constant defined after the reference as absolute',
+       async function() {
+         // Same rule as a forward-referenced label: nothing knows the value yet,
+         // so the operand has to assume the worst. Guards against widening the
+         // lookup into a second pass.
+         const m = await assembleModule(`
+.segment "CODE"
+.proc p
+  lda BLANK_TILE
+.endproc
+BLANK_TILE = $af
+`);
+         expect(codeOf(m)).toEqual([0xad, 0xff, 0xff]);
+       });
+
+    it('should bind to the enclosing constant when the local one comes later',
+       async function() {
+         // The first reference has only the outer `$af` to go on; the second is
+         // after the local definition and takes that instead.
+         const m = await assembleModule(`
+BLANK_TILE = $af
+.segment "CODE"
+.proc p
+  lda BLANK_TILE
+BLANK_TILE = $12
+  lda BLANK_TILE
+.endproc
+`);
+         expect(codeOf(m)).toEqual([0xa5, 0xaf, 0xa5, 0x12]);
        });
   });
 
@@ -2168,30 +2285,24 @@ Ptr: .res 2
     //     expect(err.message).toEqual("5000 doesn't fit in one byte");
     //   }
     // });
-    it('should use an abs value because foo is sized to 2 and the following foo value fits that size', async function() {
+    it('should use the outer foo when the inner one is not assigned until later', async function() {
       const a = new Assembler(Cpu.P02);
       a.assign('foo', 5000);
       a.scope();
       await a.instruction([ident('lda'), ident('foo')]);
       a.assign('foo', 5);
       a.endScope();
-      // We make a sized substitution for this and set that we'll sub in 5 later, which is good enough (TM)
+      // The reference binds to whatever `foo` names at the point of use, and at
+      // that point the only `foo` is the outer one. The inner assignment starts
+      // a new symbol that this instruction never sees.
       expect(strip(a.module())).toEqual({
         segments: [],
         chunks: [{
           overwrite: 'allow',
           segments: [],
-          data: Uint8Array.of(0xad, 0xff, 0xff),
-          subs: [{
-            expr: { num: 0, op: "sym", },
-            offset: 1, size: 2,
-          }],
+          data: Uint8Array.of(0xad, 5000 & 0xff, 5000 >> 8),
         }],
-        symbols: [{
-          expr: {
-            meta: { size: 1 },
-            num: 5, op: "num"},
-        }],
+        symbols: [],
       });
     });
     it('should use an abs value because the symbol is undefined, so it is sized to 2 until the symbol is defined', async function() {

--- a/test/assembler_test.ts
+++ b/test/assembler_test.ts
@@ -1306,7 +1306,390 @@ describe('Assembler', function() {
           data: Uint8Array.of(0x4a),
         }],
         segments: [], symbols: [],
-      });          
+      });
+    });
+  });
+
+  describe('predeclared ZEROPAGE segment', function() {
+    function chunkIn(m: Module, segment: string) {
+      const chunk = (m.chunks ?? []).find(c => c.segments.includes(segment));
+      if (!chunk) throw new Error(`No chunk in segment ${segment}`);
+      return chunk;
+    }
+
+    it('should give `.segment "ZEROPAGE"` zeropage address size', async function() {
+      const m = await assembleModule(`.segment "ZEROPAGE"\nFoo: .res 1\n`);
+      expect(m.segments).toEqual([{name: 'ZEROPAGE', addressing: 1}]);
+    });
+
+    it('should mark a chunk in `.segment "ZEROPAGE"` as zeropage', async function() {
+      const m = await assembleModule(`.segment "ZEROPAGE"\nFoo: .res 1\n`);
+      expect(chunkIn(m, 'ZEROPAGE').zeropage).toBe(true);
+    });
+
+    it('should keep zeropage address size when the segment also carries ld65 attributes',
+       async function() {
+         // The memory placement usually comes from the linker config, but a source
+         // file is free to spell it out. Do not clear the address size in this case.
+         const m = await assembleModule(`.segment "ZEROPAGE" :mem $10 :size $80\nFoo: .res 1\n`);
+         expect(m.segments).toEqual([
+           {name: 'ZEROPAGE', addressing: 1, memory: 0x10, size: 0x80}]);
+         expect(chunkIn(m, 'ZEROPAGE').zeropage).toBe(true);
+       });
+
+    it('should report 1 from `.addrsize` for a label in `.segment "ZEROPAGE"`',
+       async function() {
+         const m = await assembleModule(`
+.segment "ZEROPAGE"
+Foo: .res 1
+.segment "CODE"
+  .byte .addrsize(Foo)
+`);
+         const code = chunkIn(m, 'CODE');
+         expect(Array.from(code.data)).toEqual([1]);
+       });
+
+    it('should leave other named segments absolute', async function() {
+      // Only ZEROPAGE is zeropage-addressed. The rest of ca65's predeclared
+      // segments must stay absolute.
+      const m = await assembleModule(`
+.segment "BSS"
+Foo: .res 1
+.segment "CODE"
+  sta Foo
+`);
+      const code = chunkIn(m, 'CODE');
+      expect(Array.from(code.data)).toEqual([0x8d, 0xff, 0xff]);
+    });
+  });
+
+  // Marking the chunk zeropage isn't enough on its own: the operand sizing in
+  // `instruction` only looks at `expr.meta.size` and the importzp/globalzp set,
+  // so a label whose only zeropage evidence is its chunk still assembles as
+  // absolute. Operands are relocated at link time, so what lands in the chunk is
+  // an $ff placeholder per byte -- one for zeropage, two for absolute.
+  describe('zeropage operand sizing', function() {
+    function codeOf(m: Module) {
+      const chunk = (m.chunks ?? []).find(c => c.segments.includes('CODE'));
+      if (!chunk) throw new Error('No chunk in segment CODE');
+      return Array.from(chunk.data);
+    }
+
+    it('should size a label in the `.zeropage` shorthand segment as zeropage',
+       async function() {
+         const m = await assembleModule(`
+.zeropage
+Foo: .res 1
+.segment "CODE"
+  sta Foo
+  lda Foo
+`);
+         expect(codeOf(m)).toEqual([0x85, 0xff, 0xa5, 0xff]);
+       });
+
+    it('should size a label in `.segment "ZEROPAGE"` as zeropage', async function() {
+      const m = await assembleModule(`
+.segment "ZEROPAGE"
+Foo: .res 1
+.segment "CODE"
+  sta Foo
+  lda Foo
+`);
+      expect(codeOf(m)).toEqual([0x85, 0xff, 0xa5, 0xff]);
+    });
+
+    it('should size a label reached through a `.define`d segment name as zeropage',
+       async function() {
+         // How bhop names the segment: `.define BHOP_ZP_SEGMENT "ZEROPAGE"`.
+         const m = await assembleModule(`
+.define ZP_SEGMENT "ZEROPAGE"
+.segment ZP_SEGMENT
+Foo: .res 1
+.segment "CODE"
+  sta Foo
+`);
+         expect(codeOf(m)).toEqual([0x85, 0xff]);
+       });
+
+    it('should size indexed operands on a zeropage label as zeropage', async function() {
+      const m = await assembleModule(`
+.segment "ZEROPAGE"
+Foo: .res 1
+.segment "CODE"
+  lda Foo,x
+  ldx Foo,y
+`);
+      expect(codeOf(m)).toEqual([0xb5, 0xff, 0xb6, 0xff]);
+    });
+
+    it('should still size a forward reference as absolute', async function() {
+      // ca65 does the same here -- it can't know the address size yet, so it
+      // picks absolute and warns. This guards against "fixing" it too eagerly.
+      const m = await assembleModule(`
+.segment "CODE"
+  sta Foo
+.segment "ZEROPAGE"
+Foo: .res 1
+`);
+      expect(codeOf(m)).toEqual([0x8d, 0xff, 0xff]);
+    });
+
+    it('should still size a label in a non-zeropage segment as absolute',
+       async function() {
+         const m = await assembleModule(`
+.segment "BSS"
+Foo: .res 1
+.segment "CODE"
+  sta Foo
+`);
+         expect(codeOf(m)).toEqual([0x8d, 0xff, 0xff]);
+       });
+
+    it('should size an outer zeropage label referenced from a `.proc` as zeropage',
+       async function() {
+         // The reference resolves in the proc's scope, which doesn't have the
+         // symbol, so the address size has to come from walking out to where it
+         // is defined.
+         const m = await assembleModule(`
+.segment "ZEROPAGE"
+Foo: .res 1
+.segment "CODE"
+.proc p
+  sta Foo
+.endproc
+`);
+         expect(codeOf(m)).toEqual([0x85, 0xff]);
+       });
+
+    it('should size an outer zeropage label referenced from a nested `.scope` as zeropage',
+       async function() {
+         const m = await assembleModule(`
+.segment "ZEROPAGE"
+Foo: .res 1
+.segment "CODE"
+.scope outer
+.scope inner
+  sta Foo
+.endscope
+.endscope
+`);
+         expect(codeOf(m)).toEqual([0x85, 0xff]);
+       });
+
+    it('should keep zeropage address size across an offset', async function() {
+      // ca65 propagates address size through +/-, so `Ptr+1` is still zeropage.
+      const m = await assembleModule(`
+.segment "ZEROPAGE"
+Ptr: .res 2
+.segment "CODE"
+  sta Ptr+1
+  sta Ptr+0
+`);
+      expect(codeOf(m)).toEqual([0x85, 0xff, 0x85, 0xff]);
+    });
+
+    it('should keep zeropage address size across an offset from a `.proc`',
+       async function() {
+         const m = await assembleModule(`
+.segment "ZEROPAGE"
+Ptr: .res 2
+.segment "CODE"
+.proc p
+  sta Ptr+1
+.endproc
+`);
+         expect(codeOf(m)).toEqual([0x85, 0xff]);
+       });
+
+    it('should keep zeropage address size through an alias', async function() {
+      const m = await assembleModule(`
+.segment "ZEROPAGE"
+Ptr: .res 2
+.segment "CODE"
+Alias := Ptr
+  sta Alias
+  sta Alias+1
+`);
+      expect(codeOf(m)).toEqual([0x85, 0xff, 0x85, 0xff]);
+    });
+
+    it('should size an `.importzp` symbol offset as zeropage', async function() {
+      const m = await assembleModule(`
+.importzp Foo
+.segment "CODE"
+  sta Foo
+  sta Foo+1
+`);
+      expect(codeOf(m)).toEqual([0x85, 0xff, 0x85, 0xff]);
+    });
+
+    it('should stay absolute when an absolute label is offset by a zeropage one',
+       async function() {
+         // Nonsense arithmetic, but it must not silently become zeropage.
+         const m = await assembleModule(`
+.segment "ZEROPAGE"
+Zp: .res 1
+.segment "BSS"
+Abs: .res 1
+.segment "CODE"
+  sta Abs+Zp
+`);
+         expect(codeOf(m)).toEqual([0x8d, 0xff, 0xff]);
+       });
+
+    it('should keep zeropage address size through an alias made inside a scope',
+       async function() {
+         // `:=` is handled as the preprocessor reads the line, so the alias is
+         // built while the scope is open and `Zp` is only reachable through a
+         // forward reference. That reference has to carry the address size, or
+         // everything downstream of the alias goes absolute.
+         const m = await assembleModule(`
+.segment "ZEROPAGE"
+Zp: .res 1
+.segment "CODE"
+.proc p
+Alias := Zp
+  sta Alias
+.endproc
+`);
+         expect(codeOf(m)).toEqual([0x85, 0xff]);
+       });
+
+    it('should keep zeropage address size when the offset gets folded away',
+       async function() {
+         // With an `.org` the label is no longer chunk-relative, so `Ptr+1`
+         // folds to a plain number during `:=` and has to keep the address size
+         // through the fold rather than riding along on the relative meta.
+         const m = await assembleModule(`
+.segment "ZEROPAGE"
+.org $20
+Ptr: .res 2
+.segment "CODE"
+Alias := Ptr+1
+  sta Alias
+`);
+         expect(codeOf(m)).toEqual([0x85, 0x21]);
+       });
+
+    it('should keep zeropage address size for an offset from a nested scope',
+       async function() {
+         // Both halves at once: the reference has to find the outer definition
+         // to get an address size, and the `+` has to carry it up.
+         const m = await assembleModule(`
+.segment "ZEROPAGE"
+Ptr: .res 2
+.segment "CODE"
+.scope outer
+.scope inner
+  sta Ptr+1
+.endscope
+.endscope
+`);
+         expect(codeOf(m)).toEqual([0x85, 0xff]);
+       });
+  });
+
+  // `.align` in relocatable mode defers to the linker by starting a new chunk
+  // with an alignment constraint. If the segment ends before any data follows,
+  // that constraint has to stay with the segment it was written in - ca65 pads
+  // at the point of the directive - instead of leaking onto the next segment.
+  describe('trailing .align', function() {
+    function chunksIn(m: Module, segment: string) {
+      return (m.chunks ?? []).filter(c => c.segments.includes(segment));
+    }
+
+    it('should pad the segment it appeared in', async function() {
+      const m = await assembleModule(`
+.segment "BBB"
+  .byte 4
+  .align 64
+.segment "AAA"
+  .byte 6,7,8
+`);
+      const [bbb] = chunksIn(m, 'BBB');
+      expect(Array.from(bbb.data)).toEqual([4, ...new Array(63).fill(0)]);
+      expect(bbb.align).toBe(64);
+    });
+
+    it('should not leak the alignment onto the next segment', async function() {
+      const m = await assembleModule(`
+.segment "BBB"
+  .byte 4
+  .align 64
+.segment "AAA"
+  .byte 6,7,8
+`);
+      const [aaa] = chunksIn(m, 'AAA');
+      expect(Array.from(aaa.data)).toEqual([6, 7, 8]);
+      expect(aaa.align).toBeUndefined();
+    });
+
+    it('should use the fill value it was given', async function() {
+      const m = await assembleModule(`
+.segment "BBB"
+  .byte 4
+  .align 8, $ff
+.segment "AAA"
+  .byte 6
+`);
+      const [bbb] = chunksIn(m, 'BBB');
+      expect(Array.from(bbb.data)).toEqual([4, ...new Array(7).fill(0xff)]);
+    });
+
+    it('should pad a segment left aligned at the end of the source', async function() {
+      const m = await assembleModule(`
+.segment "BBB"
+  .byte 4
+  .align 8
+`);
+      const [bbb] = chunksIn(m, 'BBB');
+      expect(Array.from(bbb.data)).toEqual([4, ...new Array(7).fill(0)]);
+      expect(bbb.align).toBe(8);
+    });
+
+    it('should keep deferring the alignment when data follows it', async function() {
+      // The normal case is unchanged: the alignment belongs to the new chunk,
+      // and the linker gets to place it wherever it fits.
+      const m = await assembleModule(`
+.segment "BBB"
+  .byte 4
+  .align 64
+  .byte 5
+`);
+      const chunks = chunksIn(m, 'BBB');
+      expect(chunks.map(c => Array.from(c.data))).toEqual([[4], [5]]);
+      expect(chunks.map(c => c.align)).toEqual([undefined, 64]);
+    });
+
+    it('should take the widest of several trailing alignments', async function() {
+      const m = await assembleModule(`
+.segment "BBB"
+  .byte 4
+  .align 8
+  .align 64
+  .align 2
+.segment "AAA"
+  .byte 6
+`);
+      const [bbb] = chunksIn(m, 'BBB');
+      expect(bbb.align).toBe(64);
+      expect(bbb.data.length).toBe(64);
+    });
+
+    it('should pad the pushed segment when `.popseg` ends it', async function() {
+      const m = await assembleModule(`
+.segment "AAA"
+  .byte 6
+.pushseg "BBB"
+  .byte 4
+  .align 8
+.popseg
+  .byte 7
+`);
+      const [bbb] = chunksIn(m, 'BBB');
+      expect(Array.from(bbb.data)).toEqual([4, ...new Array(7).fill(0)]);
+      expect(bbb.align).toBe(8);
+      expect(chunksIn(m, 'AAA').map(c => Array.from(c.data))).toEqual([[6, 7]]);
     });
   });
 

--- a/test/assembler_test.ts
+++ b/test/assembler_test.ts
@@ -1219,6 +1219,54 @@ describe('Assembler', function() {
         }]});
     });
 
+    it('should parse the ld65-compatible attributes', async function() {
+      const m = await assembleModule(`
+.segment "ROM" :mem $8000 :size $2000 :out "rom.bin" :fill $ff :define
+.segment "CODE" :load "ROM" :run "RAM" :align $100 :alignload $10 :optional
+.segment "VARS" :mem $300 :size $100 :bss :dedupe
+.segment "ZP" :mem $10 :size $80 :zeropage
+`);
+      expect(m.segments).toEqual([{
+        name: 'ROM',
+        memory: 0x8000, size: 0x2000, offset: 0,
+        out: 'rom.bin', fill: 0xff, define: true,
+        free: [[0x8000, 0xa000]],
+      }, {
+        name: 'CODE',
+        load: 'ROM', run: 'RAM',
+        align: 0x100, alignLoad: 0x10, optional: true,
+      }, {
+        name: 'VARS',
+        memory: 0x300, size: 0x100, bss: true, dedupe: true,
+      }, {
+        name: 'ZP',
+        memory: 0x10, size: 0x80, addressing: 1, bss: true,
+      }]);
+    });
+
+    it('should default :fill to zero', async function() {
+      const m = await assembleModule(`.segment "ROM" :mem $8000 :size $10 :fill\n`);
+      expect(m.segments).toEqual([{
+        name: 'ROM', memory: 0x8000, size: 0x10, fill: 0,
+        free: [[0x8000, 0x8010]],
+      }]);
+    });
+
+    it('should ignore ld65 read-only attributes', async function() {
+      const m = await assembleModule(`.segment "ROM" :mem $8000 :size $10 :ro\n`);
+      expect(m.segments).toEqual([{name: 'ROM', memory: 0x8000, size: 0x10}]);
+    });
+
+    it('should reject a non-power-of-two alignment', async function() {
+      await expect(assembleModule(`.segment "CODE" :align 3\n`))
+          .rejects.toThrow(/align must be a power of two: 3/);
+    });
+
+    it('should reject an unknown segment attribute', async function() {
+      await expect(assembleModule(`.segment "CODE" :overlay "ROM"\n`))
+          .rejects.toThrow(/Unknown segment attr: overlay/);
+    });
+
     it('should allow setting a prefix', async function() {
       const a = new Assembler(Cpu.P02);
       a.segmentPrefix('cr:');

--- a/test/cli_test.ts
+++ b/test/cli_test.ts
@@ -46,6 +46,98 @@ describe('CLI', function() {
     });
   });
 
+  describe('linker config', function() {
+    const cli = new Cli({
+      fsReadString: async () => '',
+      fsReadBytes: async () => new Uint8Array(0),
+      fsWriteString: async () => {},
+      fsWriteBytes: async () => {},
+      fsWalk: async () => {},
+      exit: () => {},
+    });
+
+    it('accepts every -C spelling', function() {
+      expect(cli.parseArgs(['-C', 'nes.cfg']).cfgfile).toBe('nes.cfg');
+      expect(cli.parseArgs(['--config', 'nes.cfg']).cfgfile).toBe('nes.cfg');
+      expect(cli.parseArgs(['--config=nes.cfg']).cfgfile).toBe('nes.cfg');
+    });
+
+    it('does not confuse -C with -c', function() {
+      const args = cli.parseArgs(['-c', 'main.s']);
+      expect(args.compileonly).toBe(true);
+      expect(args.cfgfile).toBe('');
+    });
+
+    it('rejects -C combined with --compileonly', async function() {
+      const files = {'main.s': 'lda #3\n', 'nes.cfg': 'MEMORY {}\n'};
+      await expect(build(files, ['-c', '-C', 'nes.cfg', 'main.s']))
+          .rejects.toThrow();
+    });
+
+    it('links with the config and writes its extra output files',
+       async function() {
+      const files = {
+        'main.s': '.segment "HEADER"\n.byte 1,2,3,4\n.segment "CODE"\nlda #3\n',
+        'nes.cfg': `
+          MEMORY {
+            HDR: start = $0000, size = $4, file = "%O_header";
+            PRG: start = $8000, size = $4, file = %O, fill = yes, fillval = $ff;
+          }
+          SEGMENTS {
+            HEADER: load = HDR;
+            CODE:   load = PRG;
+          }`,
+      };
+      const written = await build(files, ['-C', 'nes.cfg', '-o', 'rom.nes',
+                                          'main.s']);
+      expect([...written.get('rom.nes')!]).toEqual([0xa9, 3, 0xff, 0xff]);
+      // `%O` in the config's file name is the output file's name.
+      expect([...written.get('rom.nes_header')!]).toEqual([1, 2, 3, 4]);
+    });
+
+    it('reports a config parse error against the config file',
+       async function() {
+      const files = {
+        'main.s': '.segment "CODE"\nlda #3\n',
+        'nes.cfg': 'MEMORY {\n  PRG: start = $8000, size = $2\n}\n',
+      };
+      const lines: string[] = [];
+      const log = console.log;
+      console.log = (...args: unknown[]) => { lines.push(args.join(' ')); };
+      try {
+        await expect(build(files, ['-C', 'nes.cfg', 'main.s'])).rejects.toThrow();
+      } finally {
+        console.log = log;
+      }
+      // Loading the config through readSource is what buys the source snippet.
+      expect(lines.join('\n')).toContain("nes.cfg:2:30: error: Expected ';'");
+      expect(lines.join('\n')).toContain('PRG: start = $8000, size = $2');
+    });
+
+    /** Runs the CLI over a literal file tree, returning everything it wrote. */
+    async function build(files: Record<string, string>, args: string[]) {
+      const written = new Map<string, Uint8Array>();
+      let exitCode = 0;
+      const read = (path: string, filename: string) => {
+        const key = joinDir(path, filename);
+        if (!(key in files)) throw new Error(`ENOENT ${key}`);
+        return files[key];
+      };
+      const cli = new Cli({
+        fsReadString: async (path, filename) => read(path, filename),
+        fsReadBytes: async (path, filename) =>
+            new TextEncoder().encode(read(path, filename)),
+        fsWriteString: async () => {},
+        fsWriteBytes: async (_path, filename, data) => { written.set(filename, data); },
+        fsWalk: async () => {},
+        exit: (code: number) => { exitCode = code; },
+      });
+      await cli.run(args);
+      if (exitCode !== 0) throw new Error(`cli exited with code ${exitCode}`);
+      return written;
+    }
+  });
+
   describe('include directories', function() {
     const cli = new Cli({
       fsReadString: async () => '',

--- a/test/integration_test.ts
+++ b/test/integration_test.ts
@@ -796,6 +796,25 @@ ValidLabel:
       expect(result[16]).toBe(0xff);
     });
 
+    it('.align constrains where the linker puts a relocatable chunk', async function() {
+      const source = `
+.segment "CODE" :bank $00 :size $40 :mem $8000 :off $0000 :fill $ff
+.reloc
+  .byte $01, $01, $01
+.reloc
+  .align $10
+  .byte $02, $02
+.reloc
+  .byte $03, $03, $03, $03, $03, $03, $03, $03
+`;
+      const result = await compileSource(source);
+      // Biggest chunk first, then the 3-byte one, and the aligned chunk skips
+      // to $8010 - leaving the bytes in between to the segment's fill.
+      expect(Array.from(result.slice(0, 18))).toEqual([
+        3, 3, 3, 3, 3, 3, 3, 3, 1, 1, 1, 0xff, 0xff, 0xff, 0xff, 0xff, 2, 2,
+      ]);
+    });
+
     it('.struct members yield byte offsets and .sizeof reports the total', async function() {
       const source = `
 .segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000

--- a/test/linker_test.ts
+++ b/test/linker_test.ts
@@ -177,7 +177,9 @@ describe('Linker', function() {
         .toEqual([[0x0210, [2, 4, 0x00, 0xc2, 1, 3, 0x02, 0xc2]]]);
   });
 
-  it('should fail to relocate chunks with no free allocations', function() {
+  it('should fail to relocate chunks that do not fit', function() {
+    // A segment with no free ranges of its own is free in its entirety, so
+    // running out of space means declaring a segment too small to hold them.
     const m = {
       chunks: [{
         segments: ['code'],
@@ -190,10 +192,25 @@ describe('Linker', function() {
       }],
       segments: [{
         name: 'code',
-        size: 0x400, offset: 0x0010, memory: 0xc000,
+        size: 4, offset: 0x0010, memory: 0xc000,
       }],
     };
     expect(() => link(m)).toThrow(/Could not find space/);
+  });
+
+  it('should fill a segment with no free ranges of its own', function() {
+    const m = {
+      chunks: [{
+        segments: ['code'],
+        data: Uint8Array.of(2, 4, 0xff, 0xff),
+        subs: [{offset: 2, size: 2, expr: off(0, 0)}],
+      }],
+      segments: [{
+        name: 'code',
+        size: 0x400, offset: 0x0010, memory: 0xc000,
+      }],
+    };
+    expect([...link(m).chunks()]).toEqual([[0x10, [2, 4, 0x00, 0xc0]]]);
   });
 
   it('should honor a chunk alignment and leave the skipped bytes free',
@@ -286,6 +303,218 @@ describe('Linker', function() {
     // fits two of them, so the 4-byte chunk that loses the race moves to 'b'.
     expect([...link(m).chunks()])
         .toEqual([[0, [1, 2, 3, 4, 9, 5, 6, 7, 8]]]);
+  });
+
+  it('should measure a hosted segment and pack it into its host', function() {
+    const m = {
+      chunks: [{
+        segments: ['CODE'],
+        data: Uint8Array.of(1, 1, 1, 1),
+      }, {
+        segments: ['DATA'],
+        data: Uint8Array.of(2, 2, 2),
+      }],
+      segments: [
+        {name: 'PRG', size: 0x100, offset: 0x10, memory: 0x8000, out: '%O'},
+        {name: 'CODE', load: 'PRG'},
+        {name: 'DATA', load: 'PRG'},
+      ],
+    };
+    // Neither hosted segment declares a size, so each one is measured from its
+    // contents and they pack tight against each other in the host.
+    expect([...link(m).chunks()]).toEqual([[0x10, [1, 1, 1, 1, 2, 2, 2]]]);
+  });
+
+  it('should measure a hosted segment independently of its host', function() {
+    const m = (memory: number) => ({
+      chunks: [{
+        segments: ['CODE'],
+        data: Uint8Array.of(1, 1, 1, 1),
+      }, {
+        segments: ['DATA'],
+        data: Uint8Array.of(2, 2, 2),
+      }],
+      segments: [
+        {name: 'PRG', size: 0x100, offset: 0x10, memory, out: '%O'},
+        {name: 'CODE', load: 'PRG'},
+        {name: 'DATA', load: 'PRG'},
+      ],
+    });
+    // Sizing is segment-relative, so moving the host does not change it.
+    expect([...link(m(0x8000)).chunks()]).toEqual([...link(m(0x9000)).chunks()]);
+  });
+
+  it('should align a hosted segment within its host', function() {
+    const m = {
+      chunks: [{
+        segments: ['CODE'],
+        data: Uint8Array.of(1, 1, 1),
+      }, {
+        segments: ['DATA'],
+        data: Uint8Array.of(2, 2),
+      }],
+      segments: [
+        {name: 'PRG', size: 0x100, offset: 0x10, memory: 0x8000, out: '%O'},
+        {name: 'CODE', load: 'PRG'},
+        {name: 'DATA', load: 'PRG', align: 16},
+      ],
+    };
+    // DATA's alignment bumps the host cursor from $8003 to $8010.
+    expect([...link(m).chunks()])
+        .toEqual([[0x10, [1, 1, 1]], [0x20, [2, 2]]]);
+  });
+
+  it('should run a hosted segment somewhere it does not load', function() {
+    const m = {
+      chunks: [{
+        segments: ['BOOT'],
+        data: Uint8Array.of(0xaa, 0xbb, 0xff, 0xff),
+        subs: [{offset: 2, size: 2, expr: off(0, 0)}],
+      }, {
+        segments: ['CODE'],
+        data: Uint8Array.of(1, 2),
+      }],
+      segments: [
+        {name: 'PRG', size: 0x100, offset: 0x10, memory: 0x8000, out: '%O'},
+        {name: 'RAM', size: 0x100, memory: 0x300},
+        {name: 'BOOT', load: 'PRG', run: 'RAM'},
+        {name: 'CODE', load: 'PRG'},
+      ],
+    };
+    // BOOT's labels resolve against its run address in RAM ($300), but its
+    // bytes are written into the file space PRG gave it - and PRG is charged
+    // for them, so CODE starts after BOOT rather than on top of it.
+    expect([...link(m).chunks()])
+        .toEqual([[0x10, [0xaa, 0xbb, 0x00, 0x03, 1, 2]]]);
+  });
+
+  it('should align a hosted segment\'s load without moving its run address',
+     function() {
+    const m = {
+      chunks: [{
+        segments: ['A'],
+        data: Uint8Array.of(0xff, 0xff, 7),
+        subs: [{offset: 0, size: 2, expr: off(1, 0)}],
+      }, {
+        segments: ['B'],
+        data: Uint8Array.of(2, 2),
+      }],
+      segments: [
+        {name: 'PRG', size: 0x100, offset: 0x10, memory: 0x8000, out: '%O'},
+        {name: 'RAM', size: 0x100, memory: 0x300},
+        {name: 'A', load: 'PRG', run: 'RAM'},
+        {name: 'B', load: 'PRG', run: 'RAM', alignLoad: 16},
+      ],
+    };
+    // B still runs tight against A at $303, but loads at the next multiple of
+    // 16 in the file.
+    expect([...link(m).chunks()])
+        .toEqual([[0x10, [0x03, 0x03, 7]], [0x20, [2, 2]]]);
+  });
+
+  it('should give a bss segment address space but no output', function() {
+    const m = {
+      chunks: [{
+        segments: ['CODE'],
+        data: Uint8Array.of(0xa5, 0xff, 0xa5, 0xff),
+        subs: [
+          {offset: 1, size: 1, expr: off(1, 0)},
+          {offset: 3, size: 1, expr: off(2, 0)},
+        ],
+      }, {
+        segments: ['VARS'],
+        data: new Uint8Array(4),
+      }, {
+        segments: ['MORE'],
+        data: new Uint8Array(2),
+      }],
+      segments: [
+        {name: 'PRG', size: 0x100, offset: 0x10, memory: 0x8000, out: '%O'},
+        {name: 'ZP', size: 0x100, memory: 0x00},
+        {name: 'CODE', load: 'PRG'},
+        {name: 'VARS', run: 'ZP'},
+        {name: 'MORE', run: 'ZP'},
+      ],
+    };
+    // The two zero page segments stack up in address space and emit nothing.
+    expect([...link(m).chunks()]).toEqual([[0x10, [0xa5, 0x00, 0xa5, 0x04]]]);
+  });
+
+  it('should throw when a hosted segment overflows its host', function() {
+    const m = {
+      chunks: [{
+        segments: ['CODE'],
+        data: Uint8Array.of(1, 1, 1, 1),
+      }, {
+        segments: ['DATA'],
+        data: Uint8Array.of(2, 2),
+      }],
+      segments: [
+        {name: 'PRG', size: 4, offset: 0x10, memory: 0x8000, out: '%O'},
+        {name: 'CODE', load: 'PRG'},
+        {name: 'DATA', load: 'PRG'},
+      ],
+    };
+    expect(() => link(m)).toThrow(/Segment DATA .* does not fit in PRG/);
+  });
+
+  it('should throw when a hosted segment holds a .org chunk with no address',
+     function() {
+    const m = {
+      chunks: [{
+        segments: ['CODE'],
+        org: 0x8000,
+        data: Uint8Array.of(1, 1),
+      }],
+      segments: [
+        {name: 'PRG', size: 0x100, offset: 0x10, memory: 0x8000, out: '%O'},
+        {name: 'CODE', load: 'PRG'},
+      ],
+    };
+    expect(() => link(m)).toThrow(/no address of its own/);
+  });
+
+  it('should size a hosted segment around a .org chunk', function() {
+    const m = {
+      chunks: [{
+        segments: ['CODE'],
+        org: 0x8004,
+        data: Uint8Array.of(1, 1),
+      }, {
+        segments: ['DATA'],
+        data: Uint8Array.of(2, 2),
+      }],
+      segments: [
+        {name: 'PRG', size: 0x100, offset: 0x10, memory: 0x8000, out: '%O'},
+        {name: 'CODE', load: 'PRG', memory: 0x8000},
+        {name: 'DATA', load: 'PRG'},
+      ],
+    };
+    // CODE is measured out to the end of its .org chunk, so DATA starts after
+    // it rather than on top of it.
+    expect([...link(m).chunks()]).toEqual([[0x14, [1, 1, 2, 2]]]);
+  });
+
+  it('should hand out file offsets in declaration order', function() {
+    const m = {
+      chunks: [{
+        segments: ['CODE'],
+        data: Uint8Array.of(1, 1, 1, 1),
+      }, {
+        segments: ['FTR'],
+        data: Uint8Array.of(9, 9),
+      }],
+      segments: [
+        {name: 'HDR', size: 0x10, offset: 0, memory: 0, out: '%O'},
+        {name: 'PRG', size: 0x100, memory: 0x8000, out: '%O'},
+        {name: 'FTR', size: 0x20, memory: 0, out: '%O'},
+        {name: 'CODE', load: 'PRG'},
+      ],
+    };
+    // PRG takes the cursor left by the header, and since it has no fill it
+    // only advances the cursor by the four bytes CODE actually needed - so
+    // FTR starts at $14 rather than at the end of PRG's declared size.
+    expect([...link(m).chunks()]).toEqual([[0x10, [1, 1, 1, 1, 9, 9]]]);
   });
 
   it('should choose an eligible segment for .reloc chunks', function() {

--- a/test/linker_test.ts
+++ b/test/linker_test.ts
@@ -196,6 +196,98 @@ describe('Linker', function() {
     expect(() => link(m)).toThrow(/Could not find space/);
   });
 
+  it('should honor a chunk alignment and leave the skipped bytes free',
+     function() {
+    const m = {
+      chunks: [{
+        segments: ['a'],
+        data: new Uint8Array(13).fill(1),
+      }, {
+        segments: ['a'],
+        align: 16,
+        data: Uint8Array.of(2, 2, 2, 2),
+      }, {
+        segments: ['a'],
+        data: Uint8Array.of(3, 3, 3),
+      }],
+      segments: [{
+        name: 'a', size: 128, offset: 0, memory: 0,
+        free: [[0, 128]],
+      }],
+    };
+    // Chunks are packed largest-first, so the 13-byte chunk lands at 0 and the
+    // aligned one skips to 16 rather than 13 - and the three bytes it skipped
+    // stay free for the 3-byte chunk that comes after it.
+    expect([...link(m).chunks()])
+        .toEqual([[0, [...new Array(13).fill(1), 3, 3, 3, 2, 2, 2, 2]]]);
+  });
+
+  it('should align a chunk on its org, not its offset', function() {
+    const m = {
+      chunks: [{
+        segments: ['a'],
+        align: 0x100,
+        data: Uint8Array.of(2, 4, 6, 8),
+      }],
+      segments: [{
+        name: 'a', size: 0x400, offset: 0x10, memory: 0xc000,
+        free: [[0xc001, 0xc400]],
+      }],
+    };
+    // $c100, i.e. file offset $110 - the offset itself is not a multiple of
+    // $100, so aligning in offset space would land somewhere else entirely.
+    expect([...link(m).chunks()]).toEqual([[0x110, [2, 4, 6, 8]]]);
+  });
+
+  it('should pack the biggest chunks in a segment first', function() {
+    const m = {
+      chunks: [{
+        segments: ['a'],
+        data: Uint8Array.of(1, 1),
+      }, {
+        segments: ['a'],
+        data: Uint8Array.of(2, 2, 2, 2),
+      }, {
+        segments: ['a'],
+        data: Uint8Array.of(3, 3, 3),
+      }],
+      segments: [{
+        name: 'a', size: 10, offset: 0, memory: 0,
+        free: [[0, 10]],
+      }],
+    };
+    // Size order, not the order the chunks were read.
+    expect([...link(m).chunks()])
+        .toEqual([[0, [2, 2, 2, 2, 3, 3, 3, 1, 1]]]);
+  });
+
+  it('should defer to a later segment when the first one is full', function() {
+    const m = {
+      chunks: [{
+        segments: ['a', 'b'],
+        data: Uint8Array.of(1, 2, 3, 4),
+      }, {
+        segments: ['b', 'a'],
+        data: Uint8Array.of(5, 6, 7, 8),
+      }, {
+        segments: ['b', 'a'],
+        data: Uint8Array.of(9),
+      }],
+      segments: [{
+        name: 'a', size: 5, offset: 0, memory: 0,
+        free: [[0, 5]],
+      }, {
+        name: 'b', size: 5, offset: 5, memory: 5,
+        free: [[5, 10]],
+      }],
+    };
+    // All three prefer 'a', since eligibility is ordered by segment
+    // declaration rather than by the order the chunk lists them.  'a' only
+    // fits two of them, so the 4-byte chunk that loses the race moves to 'b'.
+    expect([...link(m).chunks()])
+        .toEqual([[0, [1, 2, 3, 4, 9, 5, 6, 7, 8]]]);
+  });
+
   it('should choose an eligible segment for .reloc chunks', function() {
     const m = {
       chunks: [{
@@ -220,6 +312,9 @@ describe('Linker', function() {
   });
 
   it('should overlap segments with common bytes', function() {
+    // Sharing bytes only sees data that is already placed, and segments are
+    // filled in declaration order, so 'b' has to be declared before 'a' for
+    // the shared chunk to find the copy inside the 5-byte chunk.
     const m = {
       chunks: [{
         segments: ['a', 'b'],
@@ -233,15 +328,43 @@ describe('Linker', function() {
         subs: [{offset: 0, size: 2, expr: off(0, 0)}],
       }],
       segments: [{
-        name: 'a', size: 100, offset: 0, memory: 0,
-        free: [[0, 100]],
-      }, {
         name: 'b', size: 100, offset: 100, memory: 100,
-        free: [[100, 200]],
+        free: [[100, 200]], dedupe: true,
+      }, {
+        name: 'a', size: 100, offset: 0, memory: 0,
+        free: [[0, 100]], dedupe: true,
       }],
     };
     expect([...link(m).chunks()])
         .toEqual([[0, [101, 0]], [100, [1, 3, 5, 7, 9]]]);
+  });
+
+  it('should only share bytes in segments that opt in', function() {
+    const m = () => ({
+      chunks: [{
+        segments: ['a'],
+        data: Uint8Array.of(1, 3, 5, 7, 9),
+      }, {
+        segments: ['a'],
+        data: Uint8Array.of(3, 5, 7),
+      }, {
+        segments: ['a'],
+        data: Uint8Array.of(0xff, 0xff),
+        subs: [{offset: 0, size: 2, expr: off(1, 0)}],
+      }],
+      segments: [{
+        name: 'a', size: 100, offset: 0, memory: 0,
+        free: [[0, 100]], dedupe: false,
+      }],
+    });
+    // Without :dedupe the 3-byte chunk gets its own space after the 5-byte one.
+    expect([...link(m()).chunks()])
+        .toEqual([[0, [1, 3, 5, 7, 9, 3, 5, 7, 5, 0]]]);
+    // With it, it aliases onto the copy inside the 5-byte chunk at $01.
+    const shared = m();
+    shared.segments[0].dedupe = true;
+    expect([...link(shared).chunks()])
+        .toEqual([[0, [1, 3, 5, 7, 9, 1, 0]]]);
   });
 
   it('should share with existing data', function() {
@@ -262,10 +385,10 @@ describe('Linker', function() {
       }],
       segments: [{
         name: 'a', size: 100, offset: 0, memory: 0x8000,
-        free: [[0x8005, 0x800a]],
+        free: [[0x8005, 0x800a]], dedupe: true,
       }],
     };
-    const patch = new Linker().base(base, 10).read(m).link();      
+    const patch = new Linker().base(base, 10).read(m).link();
     expect([...patch.chunks()]).toEqual([[5, [21, 0x80]]]);
   });
 
@@ -347,8 +470,10 @@ describe('Linker', function() {
         free: [[0x8000, 0x8064]],
       }],
     };
+    // Chunks are placed segment by segment, largest first, so the 6-byte chunk
+    // takes the front of segment 'a' and the 2-byte one follows it at $8006.
     expect([...link(m).chunks()]).toEqual([
-      [0, [2, 4, 9, 0, 0x80, 8, 0, 0x80]],
+      [0, [9, 0, 0x80, 8, 6, 0x80, 2, 4]],
       [100, [1, 3, 5, 7, 9]],
     ]);
   });
@@ -422,8 +547,11 @@ describe('Linker', function() {
         free: [[0x8000, 0xa000]],
       }],
     };
+    // Placement order is fixed (largest first) rather than following the
+    // dependency graph, so the cycle is broken by placing the 6-byte chunk
+    // first and letting the 4-byte one resolve against it afterwards.
     expect([...link(m).chunks()])
-        .toEqual([[0, [2, 0x04, 0x80, 4, 3, 5, 0x00, 0x80, 7, 9]]]);
+        .toEqual([[0, [3, 5, 0x06, 0x80, 7, 9, 2, 0x00, 0x80, 4]]]);
   });
 
   // RAM segment tests

--- a/test/linker_test.ts
+++ b/test/linker_test.ts
@@ -4,6 +4,8 @@
 import {describe, it, expect} from 'bun:test';
 import {type Expr} from '../src/expr.ts';
 import {Linker} from '../src/linker.ts';
+import {type Module} from '../src/module.ts';
+import {SourceError} from '../src/token.ts';
 import * as util from '../src/util.ts';
 
 const [_] = [util];
@@ -305,7 +307,7 @@ describe('Linker', function() {
         .toEqual([[0, [1, 2, 3, 4, 9, 5, 6, 7, 8]]]);
   });
 
-  it('should measure a hosted segment and pack it into its host', function() {
+  it('should measure an unmapped segment and pack it into the mapped one', function() {
     const m = {
       chunks: [{
         segments: ['CODE'],
@@ -320,12 +322,12 @@ describe('Linker', function() {
         {name: 'DATA', load: 'PRG'},
       ],
     };
-    // Neither hosted segment declares a size, so each one is measured from its
-    // contents and they pack tight against each other in the host.
+    // Neither unmapped segment declares a size, so each one is measured from its
+    // contents and they pack tight against each other in the mapped one.
     expect([...link(m).chunks()]).toEqual([[0x10, [1, 1, 1, 1, 2, 2, 2]]]);
   });
 
-  it('should measure a hosted segment independently of its host', function() {
+  it('should measure an unmapped segment independently of the mapped one', function() {
     const m = (memory: number) => ({
       chunks: [{
         segments: ['CODE'],
@@ -340,11 +342,11 @@ describe('Linker', function() {
         {name: 'DATA', load: 'PRG'},
       ],
     });
-    // Sizing is segment-relative, so moving the host does not change it.
+    // Sizing is segment-relative, so moving the mapped one does not change it.
     expect([...link(m(0x8000)).chunks()]).toEqual([...link(m(0x9000)).chunks()]);
   });
 
-  it('should align a hosted segment within its host', function() {
+  it('should align an unmapped segment within the mapped one', function() {
     const m = {
       chunks: [{
         segments: ['CODE'],
@@ -359,12 +361,12 @@ describe('Linker', function() {
         {name: 'DATA', load: 'PRG', align: 16},
       ],
     };
-    // DATA's alignment bumps the host cursor from $8003 to $8010.
+    // DATA's alignment bumps PRG's cursor from $8003 to $8010.
     expect([...link(m).chunks()])
         .toEqual([[0x10, [1, 1, 1]], [0x20, [2, 2]]]);
   });
 
-  it('should run a hosted segment somewhere it does not load', function() {
+  it('should run an unmapped segment somewhere it does not load', function() {
     const m = {
       chunks: [{
         segments: ['BOOT'],
@@ -388,7 +390,7 @@ describe('Linker', function() {
         .toEqual([[0x10, [0xaa, 0xbb, 0x00, 0x03, 1, 2]]]);
   });
 
-  it('should align a hosted segment\'s load without moving its run address',
+  it('should align an unmapped segment\'s load without moving its run address',
      function() {
     const m = {
       chunks: [{
@@ -440,7 +442,7 @@ describe('Linker', function() {
     expect([...link(m).chunks()]).toEqual([[0x10, [0xa5, 0x00, 0xa5, 0x04]]]);
   });
 
-  it('should throw when a hosted segment overflows its host', function() {
+  it('should throw when an unmapped segment overflows the mapped one', function() {
     const m = {
       chunks: [{
         segments: ['CODE'],
@@ -458,7 +460,7 @@ describe('Linker', function() {
     expect(() => link(m)).toThrow(/Segment DATA .* does not fit in PRG/);
   });
 
-  it('should throw when a hosted segment holds a .org chunk with no address',
+  it('should throw when an unmapped segment holds a .org chunk with no address',
      function() {
     const m = {
       chunks: [{
@@ -474,7 +476,7 @@ describe('Linker', function() {
     expect(() => link(m)).toThrow(/no address of its own/);
   });
 
-  it('should size a hosted segment around a .org chunk', function() {
+  it('should size an unmapped segment around a .org chunk', function() {
     const m = {
       chunks: [{
         segments: ['CODE'],
@@ -890,5 +892,268 @@ describe('Linker', function() {
     // The addresses should be different (allocated sequentially)
     const [_offset, data] = result[0];
     expect(data[1]).not.toBe(data[3]);  // Different addresses
+  });
+});
+
+describe('Linker with an ld65 config', function() {
+
+  function linkCfg(cfg: string, ...modules: Module[]) {
+    const linker = new Linker({linkerConfig: cfg, linkerConfigName: 'test.cfg'});
+    for (const m of modules) linker.read(m);
+    return linker.link();
+  }
+
+  it('should lay out its areas in declaration order', function() {
+    const cfg = `
+      MEMORY {
+        ZP:  start = $00,   size = $100;
+        RAM: start = $200,  size = $100;
+        HDR: start = $0000, size = $4,  file = %O, fill = yes;
+        PRG: start = $8000, size = $20, file = %O, fill = yes, fillval = $ff;
+      }
+      SEGMENTS {
+        ZEROPAGE: load = ZP,  type = zp;
+        BSS:      load = RAM, type = bss;
+        HEADER:   load = HDR;
+        CODE:     load = PRG;
+        DATA:     load = PRG;
+      }`;
+    const m = {
+      chunks: [
+        {segments: ['HEADER'], data: Uint8Array.of(1, 2, 3)},
+        {segments: ['CODE'], data: Uint8Array.of(10, 11)},
+        {segments: ['DATA'], data: Uint8Array.of(20)},
+        {segments: ['BSS'], data: Uint8Array.of(0, 0)},
+      ],
+    };
+    // HDR takes the front of the file because it is declared first, and PRG
+    // follows it at $4.  Both areas fill their whole declared size; the RAM
+    // areas take no file space at all and the BSS chunk emits nothing.
+    expect([...linkCfg(cfg, m).chunks()]).toEqual([
+      [0, [1, 2, 3, 0, 10, 11, 20, ...new Array(29).fill(0xff)]],
+    ]);
+  });
+
+  it('should collapse a segment into its same-named area', function() {
+    const cfg = `
+      MEMORY {
+        ZEROPAGE: start = $00,   size = $100;
+        PRG:      start = $8000, size = $8, file = %O;
+      }
+      SEGMENTS {
+        ZEROPAGE: load = ZEROPAGE, type = zp;
+        CODE:     load = PRG;
+      }`;
+    const m = {
+      chunks: [{
+        segments: ['ZEROPAGE'],
+        data: Uint8Array.of(0, 0),
+      }, {
+        segments: ['CODE'],
+        data: Uint8Array.of(0xa5, 0xff),  // lda $xx
+        subs: [{offset: 1, size: 1, expr: off(0, 0)}],
+      }],
+    };
+    // The two namespaces are separate in ld65, and nrom.cfg really does reuse
+    // ZEROPAGE for both.  js65 has one namespace, so the segment is the area.
+    expect([...linkCfg(cfg, m).chunks()]).toEqual([[0, [0xa5, 0x00]]]);
+  });
+
+  it('should fill a merged area around the segments lowered into it', function() {
+    const cfg = `
+      MEMORY {
+        RAM: start = $10,   size = $20;
+        PRG: start = $8000, size = $8, file = %O;
+      }
+      SEGMENTS {
+        BSS:  load = RAM, type = bss;
+        RAM:  load = RAM, type = bss;
+        CODE: load = PRG;
+      }`;
+    const m = {
+      chunks: [{
+        segments: ['BSS'],
+        data: Uint8Array.of(0, 0, 0, 0),
+      }, {
+        segments: ['RAM'],
+        data: Uint8Array.of(0, 0),
+      }, {
+        segments: ['CODE'],
+        data: Uint8Array.of(0xa5, 0xff, 0xa5, 0xff),
+        subs: [
+          {offset: 1, size: 1, expr: off(0, 0)},
+          {offset: 3, size: 1, expr: off(1, 0)},
+        ],
+      }],
+    };
+    // RAM is both the area BSS lives in and a segment of its own, so its own
+    // chunks go after the $4 bytes it handed to BSS rather than on top of them.
+    expect([...linkCfg(cfg, m).chunks()])
+        .toEqual([[0, [0xa5, 0x10, 0xa5, 0x14]]]);
+  });
+
+  it('should reserve a merged area\'s whole file space', function() {
+    const cfg = `
+      MEMORY {
+        A: start = $8000, size = $8, file = %O;
+        B: start = $9000, size = $4, file = %O;
+      }
+      SEGMENTS {
+        CODE: load = A;
+        A:    load = A;
+        DATA: load = B;
+      }`;
+    const m = {
+      chunks: [
+        {segments: ['CODE'], data: Uint8Array.of(1, 1)},
+        {segments: ['A'], data: Uint8Array.of(2, 2)},
+        {segments: ['DATA'], data: Uint8Array.of(3, 3)},
+      ],
+    };
+    // A's own chunks can land anywhere it has left, so B has to start past all
+    // of A rather than just past the segments lowered into it.
+    expect([...linkCfg(cfg, m).chunks()])
+        .toEqual([[0, [1, 1, 2, 2]], [8, [3, 3]]]);
+  });
+
+  it('should allocate segments in the order the config declares them',
+     function() {
+    const cfg = `
+      MEMORY { PRG: start = $8000, size = $10, file = %O; }
+      SEGMENTS {
+        DATA: load = PRG;
+        CODE: load = PRG;
+      }`;
+    const m = {
+      chunks: [
+        {segments: ['CODE'], data: Uint8Array.of(1, 2, 3, 4)},
+        {segments: ['DATA'], data: Uint8Array.of(9)},
+      ],
+    };
+    // DATA is declared first, so it goes first even though CODE is bigger.
+    expect([...linkCfg(cfg, m).chunks()]).toEqual([[0, [9, 1, 2, 3, 4]]]);
+  });
+
+  it('should pin a segment with an explicit start', function() {
+    const cfg = `
+      MEMORY { PRG: start = $8000, size = $10, file = %O, fill = yes,
+                    fillval = $ff; }
+      SEGMENTS {
+        CODE:    load = PRG;
+        VECTORS: load = PRG, start = $800e;
+      }`;
+    const m = {
+      chunks: [
+        {segments: ['CODE'], data: Uint8Array.of(1, 2)},
+        {segments: ['VECTORS'], data: Uint8Array.of(0xaa, 0xbb)},
+      ],
+    };
+    expect([...linkCfg(cfg, m).chunks()])
+        .toEqual([[0, [1, 2, ...new Array(12).fill(0xff), 0xaa, 0xbb]]]);
+  });
+
+  it('should align a segment within its area', function() {
+    const cfg = `
+      MEMORY { PRG: start = $8000, size = $20, file = %O; }
+      SEGMENTS {
+        CODE: load = PRG;
+        DATA: load = PRG, align = $10;
+      }`;
+    const m = {
+      chunks: [
+        {segments: ['CODE'], data: Uint8Array.of(1, 1, 1)},
+        {segments: ['DATA'], data: Uint8Array.of(2, 2)},
+      ],
+    };
+    expect([...linkCfg(cfg, m).chunks()])
+        .toEqual([[0, [1, 1, 1]], [0x10, [2, 2]]]);
+  });
+
+  it('should run a segment somewhere it does not load', function() {
+    const cfg = `
+      MEMORY {
+        RAM: start = $300,  size = $100;
+        PRG: start = $8000, size = $8, file = %O;
+      }
+      SEGMENTS {
+        BOOT: load = PRG, run = RAM;
+        CODE: load = PRG;
+      }`;
+    const m = {
+      chunks: [{
+        segments: ['BOOT'],
+        data: Uint8Array.of(0xaa, 0xbb, 0xff, 0xff),
+        subs: [{offset: 2, size: 2, expr: off(0, 0)}],
+      }, {
+        segments: ['CODE'],
+        data: Uint8Array.of(1, 2),
+      }],
+    };
+    // BOOT's label resolves against $300 where it runs, but its bytes are
+    // written into - and charged to - the file space PRG handed it.
+    expect([...linkCfg(cfg, m).chunks()])
+        .toEqual([[0, [0xaa, 0xbb, 0x00, 0x03, 1, 2]]]);
+  });
+
+  it('should give a segment its area\'s bank', function() {
+    const cfg = `
+      MEMORY {
+        PRG0: start = $8000, size = $4, file = %O, bank = 8;
+        PRG1: start = $8000, size = $4, file = %O, bank = 9;
+      }
+      SEGMENTS {
+        CODE: load = PRG0;
+        DATA: load = PRG1;
+      }`;
+    const m = {
+      chunks: [{
+        segments: ['CODE'],
+        data: Uint8Array.of(0xff, 0xff),
+        subs: [
+          {offset: 0, size: 1, expr: op('^', off(0, 0))},
+          {offset: 1, size: 1, expr: op('^', off(1, 0))},
+        ],
+      }, {
+        segments: ['DATA'],
+        data: Uint8Array.of(7),
+      }],
+    };
+    expect([...linkCfg(cfg, m).chunks()]).toEqual([[0, [8, 9, 7]]]);
+  });
+
+  it('should resolve a config symbol in an area expression', function() {
+    const cfg = `
+      SYMBOLS { __PRGSTART__: type = weak, value = $8000; }
+      MEMORY { PRG: start = __PRGSTART__, size = $4, file = %O; }
+      SEGMENTS { CODE: load = PRG; }`;
+    const m = {
+      chunks: [{
+        segments: ['CODE'],
+        data: Uint8Array.of(0xff, 0xff),
+        subs: [{offset: 0, size: 2, expr: off(0, 0)}],
+      }],
+    };
+    expect([...linkCfg(cfg, m).chunks()]).toEqual([[0, [0x00, 0x80]]]);
+  });
+
+  it('should throw when a segment overflows its area', function() {
+    const cfg = `
+      MEMORY { PRG: start = $8000, size = $2, file = %O; }
+      SEGMENTS { CODE: load = PRG; }`;
+    const m = {chunks: [{segments: ['CODE'], data: Uint8Array.of(1, 2, 3, 4)}]};
+    expect(() => linkCfg(cfg, m))
+        .toThrow(/Segment CODE .* does not fit in PRG/);
+  });
+
+  it('should report a config parse error against the config file', function() {
+    const cfg = `MEMORY {\n  PRG: start = $8000, size = $2\n}`;
+    let err: unknown;
+    try {
+      linkCfg(cfg, {chunks: []});
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(SourceError);
+    expect((err as SourceError).source).toMatchObject({file: 'test.cfg'});
   });
 });

--- a/test/linker_test.ts
+++ b/test/linker_test.ts
@@ -21,6 +21,9 @@ function op(op: string, ...args: Expr[]): Expr {
 function num(num: number): Expr {
   return {op: 'num', num};
 }
+function imp(sym: string): Expr {
+  return {op: 'im', sym};
+}
 
 describe('Linker', function() {
   it('should link a simple .org chunk', function() {
@@ -897,10 +900,14 @@ describe('Linker', function() {
 
 describe('Linker with an ld65 config', function() {
 
-  function linkCfg(cfg: string, ...modules: Module[]) {
+  function linkerCfg(cfg: string, ...modules: Module[]) {
     const linker = new Linker({linkerConfig: cfg, linkerConfigName: 'test.cfg'});
     for (const m of modules) linker.read(m);
-    return linker.link();
+    return linker;
+  }
+
+  function linkCfg(cfg: string, ...modules: Module[]) {
+    return linkerCfg(cfg, ...modules).link();
   }
 
   it('should lay out its areas in declaration order', function() {
@@ -1143,6 +1150,241 @@ describe('Linker with an ld65 config', function() {
     const m = {chunks: [{segments: ['CODE'], data: Uint8Array.of(1, 2, 3, 4)}]};
     expect(() => linkCfg(cfg, m))
         .toThrow(/Segment CODE .* does not fit in PRG/);
+  });
+
+  it('should give an area\'s own chunks their turn among the segments',
+     function() {
+    // The FDS disk header is written to the front of the same area the files
+    // that follow it are lowered into, so it cannot be left the leftovers.
+    const cfg = `
+      MEMORY { SIDE1: start = $0000, size = $20, file = %O; }
+      SEGMENTS {
+        SIDE1:     load = SIDE1;
+        FILE0_HDR: load = SIDE1;
+        FILE0_DAT: load = SIDE1;
+      }`;
+    const m = {
+      chunks: [
+        {segments: ['FILE0_DAT'], data: Uint8Array.of(3, 3, 3, 3)},
+        {segments: ['SIDE1'], data: Uint8Array.of(1, 1)},
+        {segments: ['FILE0_HDR'], data: Uint8Array.of(2, 2, 2)},
+      ],
+    };
+    expect([...linkCfg(cfg, m).chunks()])
+        .toEqual([[0, [1, 1, 2, 2, 2, 3, 3, 3, 3]]]);
+  });
+
+  it('should fill an area from the SEGMENTS order, not the MEMORY order',
+     function() {
+    // The merged segment holds the area's place in the file, but takes its
+    // turn to be filled where the SEGMENTS block puts it.
+    const cfg = `
+      MEMORY {
+        RAM: start = $10,   size = $20;
+        PRG: start = $8000, size = $8, file = %O;
+      }
+      SEGMENTS {
+        BSS:  load = RAM;
+        RAM:  load = RAM;
+        CODE: load = PRG;
+      }`;
+    const m = {
+      chunks: [{
+        segments: ['BSS'],
+        data: Uint8Array.of(0, 0, 0, 0),
+      }, {
+        segments: ['RAM'],
+        data: Uint8Array.of(0, 0),
+      }, {
+        segments: ['CODE'],
+        data: Uint8Array.of(0xa5, 0xff, 0xa5, 0xff),
+        subs: [
+          {offset: 1, size: 1, expr: off(0, 0)},
+          {offset: 3, size: 1, expr: off(1, 0)},
+        ],
+      }],
+    };
+    expect([...linkCfg(cfg, m).chunks()])
+        .toEqual([[0, [0xa5, 0x10, 0xa5, 0x14]]]);
+  });
+
+  it('should write segments to more than one output file', function() {
+    const cfg = `
+      MEMORY {
+        HDR: start = $0000, size = $4, file = "%O_header";
+        PRG: start = $8000, size = $6, file = %O, fill = yes, fillval = $ff;
+      }
+      SEGMENTS {
+        HEADER: load = HDR, define = yes;
+        CODE:   load = PRG, define = yes;
+      }`;
+    const m = {
+      chunks: [{
+        segments: ['HEADER'],
+        data: Uint8Array.of(1, 2, 3, 0xff),
+        // Both files start their offsets at zero, so both segments are at 0.
+        subs: [{offset: 3, size: 1, expr: imp('__CODE_FILEOFFS__')}],
+      }, {
+        segments: ['CODE'],
+        data: Uint8Array.of(10, 11),
+      }],
+    };
+    const linker = linkerCfg(cfg, m);
+    const main = linker.link();
+    expect([...main.chunks()])
+        .toEqual([[0, [10, 11, 0xff, 0xff, 0xff, 0xff]]]);
+    const extra = linker.outputFiles();
+    expect(extra.length).toBe(1);
+    expect(extra[0].name).toBe('%O_header');
+    expect([...extra[0].data]).toEqual([1, 2, 3, 0]);
+  });
+
+  it('should define the geometry of a segment', function() {
+    const cfg = `
+      MEMORY { PRG: start = $8000, size = $20, file = %O; }
+      SEGMENTS {
+        CODE: load = PRG, define = yes;
+        DATA: load = PRG, define = yes;
+      }`;
+    const m = {
+      chunks: [{
+        segments: ['CODE'],
+        data: Uint8Array.of(...new Array(10).fill(0xff)),
+        subs: [
+          {offset: 0, size: 2, expr: imp('__CODE_START__')},
+          {offset: 2, size: 2, expr: imp('__CODE_SIZE__')},
+          {offset: 4, size: 2, expr: imp('__CODE_LAST__')},
+          {offset: 6, size: 2, expr: imp('__CODE_FILEOFFS__')},
+          // A forward reference into a segment declared later, which is the
+          // shape of the FDS `.word __FILE0_DAT_RUN__` header pattern.
+          {offset: 8, size: 2, expr: imp('__DATA_RUN__')},
+        ],
+      }, {
+        segments: ['DATA'],
+        data: Uint8Array.of(1, 2),
+      }],
+    };
+    expect([...linkCfg(cfg, m).chunks()]).toEqual([
+      [0, [0x00, 0x80, 0x0a, 0x00, 0x0a, 0x80, 0x00, 0x00, 0x0a, 0x80, 1, 2]],
+    ]);
+  });
+
+  it('should define separate load and run addresses', function() {
+    const cfg = `
+      MEMORY {
+        RAM: start = $300,  size = $100;
+        PRG: start = $8000, size = $10, file = %O;
+      }
+      SEGMENTS {
+        BOOT: load = PRG, run = RAM, define = yes;
+        CODE: load = PRG;
+      }`;
+    const m = {
+      chunks: [{
+        segments: ['BOOT'],
+        data: Uint8Array.of(0xff, 0xff, 0xff, 0xff, 0xff, 0xff),
+        subs: [
+          // _LOAD__ is an address in PRG, not the file offset that _FILEOFFS__
+          // gives, and _RUN__ is the address in RAM the bytes get copied to.
+          {offset: 0, size: 2, expr: imp('__BOOT_LOAD__')},
+          {offset: 2, size: 2, expr: imp('__BOOT_RUN__')},
+          {offset: 4, size: 2, expr: imp('__BOOT_FILEOFFS__')},
+        ],
+      }, {
+        segments: ['CODE'],
+        data: Uint8Array.of(7),
+      }],
+    };
+    expect([...linkCfg(cfg, m).chunks()])
+        .toEqual([[0, [0x00, 0x80, 0x00, 0x03, 0x00, 0x00, 7]]]);
+  });
+
+  it('should define an area\'s used extent as its _LAST__', function() {
+    const cfg = `
+      MEMORY { RAM: start = $200, size = $100, define = yes; }
+      SEGMENTS { BSS: load = RAM, type = bss; }`;
+    const m = {
+      chunks: [{
+        segments: ['BSS'],
+        data: Uint8Array.of(0, 0, 0, 0),
+      }, {
+        // The chunk that reads the defines has to live somewhere that emits.
+        segments: ['CODE'],
+        data: Uint8Array.of(0xff, 0xff, 0xff, 0xff, 0xff, 0xff),
+        subs: [
+          {offset: 0, size: 2, expr: imp('__RAM_START__')},
+          {offset: 2, size: 2, expr: imp('__RAM_SIZE__')},
+          {offset: 4, size: 2, expr: imp('__RAM_LAST__')},
+        ],
+      }],
+      segments: [{name: 'CODE', size: 8, offset: 0, memory: 0x9000}],
+    };
+    expect([...linkCfg(cfg, m).chunks()])
+        .toEqual([[0, [0x00, 0x02, 0x00, 0x01, 0x04, 0x02]]]);
+  });
+
+  it('should export a config symbol', function() {
+    const cfg = `
+      SYMBOLS { __STACKSIZE__: type = export, value = $200; }
+      MEMORY { PRG: start = $8000, size = $4, file = %O; }
+      SEGMENTS { CODE: load = PRG; }`;
+    const m = {
+      chunks: [{
+        segments: ['CODE'],
+        data: Uint8Array.of(0xff, 0xff),
+        subs: [{offset: 0, size: 2, expr: imp('__STACKSIZE__')}],
+      }],
+    };
+    expect([...linkCfg(cfg, m).chunks()]).toEqual([[0, [0x00, 0x02]]]);
+  });
+
+  it('should let an object file override a weak config symbol', function() {
+    const cfg = `
+      SYMBOLS { __STACKSIZE__: type = weak, value = $200; }
+      MEMORY { PRG: start = $8000, size = $4, file = %O; }
+      SEGMENTS { CODE: load = PRG; }`;
+    const m = {
+      chunks: [{
+        segments: ['CODE'],
+        data: Uint8Array.of(0xff, 0xff),
+        subs: [{offset: 0, size: 2, expr: imp('__STACKSIZE__')}],
+      }],
+      symbols: [{export: '__STACKSIZE__', expr: num(0x30)}],
+    };
+    expect([...linkCfg(cfg, m).chunks()]).toEqual([[0, [0x30, 0x00]]]);
+  });
+
+  it('should resolve a config symbol against a segment define', function() {
+    const cfg = `
+      MEMORY {
+        RAM: start = $200, size = $100, define = yes;
+        PRG: start = $8000, size = $4, file = %O;
+      }
+      SEGMENTS {
+        BSS:  load = RAM, type = bss;
+        CODE: load = PRG;
+      }
+      SYMBOLS { __HEAP__: type = export, value = __RAM_LAST__; }`;
+    const m = {
+      chunks: [{
+        segments: ['BSS'],
+        data: Uint8Array.of(0, 0, 0),
+      }, {
+        segments: ['CODE'],
+        data: Uint8Array.of(0xff, 0xff),
+        subs: [{offset: 0, size: 2, expr: imp('__HEAP__')}],
+      }],
+    };
+    expect([...linkCfg(cfg, m).chunks()]).toEqual([[0, [0x03, 0x02]]]);
+  });
+
+  it('should require an imported config symbol to be exported', function() {
+    const cfg = `
+      SYMBOLS { __MAIN__: type = import; }
+      MEMORY { PRG: start = $8000, size = $4, file = %O; }
+      SEGMENTS { CODE: load = PRG; }`;
+    const m = {chunks: [{segments: ['CODE'], data: Uint8Array.of(1)}]};
+    expect(() => linkCfg(cfg, m)).toThrow(/__MAIN__ is imported .* never exported/);
   });
 
   it('should report a config parse error against the config file', function() {

--- a/test/linkerconfig_test.ts
+++ b/test/linkerconfig_test.ts
@@ -1,0 +1,521 @@
+﻿
+// SPDX-License-Identifier: MPL-2.0
+
+import {describe, it, expect} from 'bun:test';
+import {type Expr} from '../src/expr.ts';
+import {type CfgSymbols, configSymbols, parseLinkerConfig, resolveCfgExpr}
+    from '../src/linkerconfig.ts';
+import {SourceError} from '../src/token.ts';
+
+describe('parseLinkerConfig', function() {
+
+  // Helper function to resolve deferred symbols for testing.
+  function areaGeometry(area: {start: Expr, size: Expr}, symbols?: CfgSymbols) {
+    return [resolveCfgExpr(area.start, symbols ?? new Map(), 'start'),
+            resolveCfgExpr(area.size, symbols ?? new Map(), 'size')];
+  }
+  function value(expr: Expr|undefined, symbols?: CfgSymbols) {
+    return expr == null
+        ? undefined
+        : resolveCfgExpr(expr, symbols ?? new Map(), 'value');
+  }
+
+  function expectSourceError(cfg: string, message: RegExp, line?: number) {
+    let err: unknown;
+    try {
+      parseLinkerConfig(cfg, 'test.cfg');
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(SourceError);
+    expect((err as Error).message).toMatch(message);
+    if (line != null) {
+      expect((err as SourceError).source).toMatchObject({file: 'test.cfg', line});
+    }
+  }
+
+  // Sample cfg pulled from a project
+  const NROM_CFG = `MEMORY {
+    ZEROPAGE:        start = $00,   size = $100,  type = rw;
+    SHADOW_OAM:       start = $0200, size = $100,  type = rw;
+    RAM:       start = $0300, size = $500,  type = rw;
+    PRGRAM:    start = $6000, size = $2000,  type = rw;
+    HDR:       start = $0000, size = $10,   type = ro, file = %O, fill = yes;
+    PRG_8000:  start = $8000, size = $4000, type = ro, file = %O, fill = yes, fillval = $FF, bank = 0;
+    PRG_C000:  start = $C000, size = $4000, type = ro, file = %O, fill = yes, fillval = $FF;
+    CHR0:      start = $0000, size = $1000, type = ro, file = %O, fill = yes, fillval = $00;
+    CHR1:      start = $0000, size = $1000, type = ro, file = %O, fill = yes, fillval = $00;
+}
+
+SEGMENTS {
+   ZEROPAGE:  load = ZEROPAGE,  type = zp;
+   BSS:        load = RAM,        type = bss, align = $100, define = yes;
+   RAM:        load = RAM,        type = bss, start = $0300;
+   HEADER:     load = HDR,        type = ro,  align = $10;
+   CODE:       load = PRG_C000,   type = ro,  align = $100;
+   PRG0_8000:  load = PRG_8000,   type = ro;
+   PRG1_C000:  load = PRG_C000,   type = ro,  align = $100;
+   VECTORS:    load = PRG_C000,   type = ro,  start = $FFFA;
+   CHR0:       load = CHR0,       type = ro,  align = $1000, define = no;
+   CHR1:       load = CHR1,       type = ro,  align = $1000, define = no;
+}
+
+FILES {
+   %O:   format = bin;
+}`;
+
+  it('should parse a real nrom config', function() {
+    const cfg = parseLinkerConfig(NROM_CFG);
+    expect(cfg.memory.length).toBe(9);
+    expect(cfg.segments.length).toBe(10);
+    expect(cfg.files).toEqual([{name: '%O', format: 'bin'}]);
+    const prg8000 = cfg.memory.find(a => a.name === 'PRG_8000')!;
+    expect(areaGeometry(prg8000)).toEqual([0x8000, 0x4000]);
+    expect(value(prg8000.bank)).toBe(0);
+    expect(prg8000).toMatchObject({
+      type: 'ro', file: '%O', fill: true, fillval: 0xff, define: false,
+    });
+    // No `file` attribute at all -- distinct from `file = ""`.
+    expect(cfg.memory.find(a => a.name === 'RAM')!.file).toBeUndefined();
+    expect(cfg.segments.find(s => s.name === 'VECTORS')).toMatchObject({
+      load: 'PRG_C000', run: 'PRG_C000', type: 'ro', start: 0xfffa,
+      define: false, optional: false,
+    });
+    expect(cfg.segments.find(s => s.name === 'BSS')).toMatchObject({
+      load: 'RAM', type: 'bss', align: 0x100, define: true,
+    });
+  });
+
+  it('should preserve declaration order', function() {
+    // Areas fix output-file ordering, segments fix within-area placement order.
+    const cfg = parseLinkerConfig(NROM_CFG);
+    expect(cfg.memory.map(a => a.index)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8]);
+    expect(cfg.segments.map(s => s.index)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    expect(cfg.memory.map(a => a.name)).toEqual([
+      'ZEROPAGE', 'SHADOW_OAM', 'RAM', 'PRGRAM', 'HDR',
+      'PRG_8000', 'PRG_C000', 'CHR0', 'CHR1',
+    ]);
+    expect(cfg.segments.map(s => s.name)).toEqual([
+      'ZEROPAGE', 'BSS', 'RAM', 'HEADER', 'CODE',
+      'PRG0_8000', 'PRG1_C000', 'VECTORS', 'CHR0', 'CHR1',
+    ]);
+  });
+
+  describe('numbers', function() {
+    it('should read every number form a real config uses', function() {
+      const cfg = parseLinkerConfig(`
+        MEMORY {
+          A: start = $00, size = 63, fillval = $FF;
+          B: start = 00,  size = 65500;
+        }
+        SEGMENTS {
+          S1: load = A, align = 64;
+          S2: load = A, align = $100;
+        }
+      `);
+      expect(cfg.memory.map(a => areaGeometry(a)))
+          .toEqual([[0, 63], [0, 65500]]);
+      expect(cfg.memory[0].fillval).toBe(0xff);
+      expect(cfg.segments.map(s => s.align)).toEqual([64, 256]);
+    });
+
+    it('should read a leading-zero number as decimal', function() {
+      const cfg = parseLinkerConfig(`
+        MEMORY {
+          A: start = $0, size = $10, bank = 00;
+          B: start = $0, size = $10, bank = 08;
+          C: start = $0, size = $10, bank = 09;
+          D: start = $0, size = $10, bank = $02;
+        }
+      `);
+      expect(cfg.memory.map(a => value(a.bank))).toEqual([0, 8, 9, 2]);
+    });
+
+    it('should fold a constant expression', function() {
+      const cfg = parseLinkerConfig(`
+        MEMORY { A: start = $8000 + 16, size = $2000 * 2; }
+      `);
+      expect(areaGeometry(cfg.memory[0])).toEqual([0x8010, 0x4000]);
+    });
+
+    it('should require a SEGMENTS align to be constant at parse time', function() {
+      expectSourceError(
+          `MEMORY { A: start = $0, size = $10; }\n` +
+          `SEGMENTS { S: load = A, align = FOO; }`,
+          /Value of 'align' must be a constant \(FOO is not defined\)/, 2);
+    });
+
+    it('should require MEMORY fillval to be constant at parse time', function() {
+      expectSourceError(`MEMORY { A: start = $0, size = $10, fillval = FOO; }`,
+                        /Value of 'fillval' must be a constant/, 1);
+    });
+  });
+
+  // See `resolveCfgExpr` for why these only have to be constant at the moment
+  // they are consumed.
+  describe('deferred expressions', function() {
+    it('should keep a symbolic MEMORY start as a tree rather than failing', function() {
+      const cfg = parseLinkerConfig(`MEMORY { A: start = __ONCE_RUN__, size = $10; }`);
+      expect(cfg.memory[0].start.op).not.toBe('num');
+      expect(() => areaGeometry(cfg.memory[0]))
+          .toThrow(/start is not constant \(__ONCE_RUN__ is not defined\)/);
+    });
+
+    it('should resolve a MEMORY expression against a SYMBOLS entry', function() {
+      // Example found in ca65 linker script for apple2/atari2600 target
+      const cfg = parseLinkerConfig(`
+        SYMBOLS { __STACKSIZE__: type = weak, value = $0010; }
+        MEMORY {
+          RAM: file = "", start = $0080, size = $0080 - __STACKSIZE__, define = yes;
+          ROM: file = %O, start = $F000, size = $1000, fill = yes, fillval = $FF;
+        }
+      `);
+      const syms = configSymbols(cfg);
+      expect(syms.get('__STACKSIZE__')).toBe(0x10);
+      expect(areaGeometry(cfg.memory[0], syms)).toEqual([0x80, 0x70]);
+      expect(areaGeometry(cfg.memory[1], syms)).toEqual([0xf000, 0x1000]);
+    });
+
+    it('should let a SYMBOLS entry reference an earlier one', function() {
+      const cfg = parseLinkerConfig(`
+        SYMBOLS {
+          __BASE__: type = export, value = $0200;
+          __TOP__:  type = export, value = __BASE__ + $100;
+        }
+      `);
+      expect([...configSymbols(cfg)]).toEqual([
+        ['__BASE__', 0x200], ['__TOP__', 0x300],
+      ]);
+    });
+
+    it('should let an object export beat a weak symbol but not an export', function() {
+      const cfg = parseLinkerConfig(`
+        SYMBOLS {
+          __WEAK__:   type = weak,   value = $1111;
+          __STRONG__: type = export, value = $2222;
+        }
+      `);
+      const syms = configSymbols(cfg, new Set(['__WEAK__', '__STRONG__']));
+      expect(syms.has('__WEAK__')).toBe(false);
+      expect(syms.get('__STRONG__')).toBe(0x2222);
+    });
+
+    it('should contribute no value for an import', function() {
+      const cfg = parseLinkerConfig(`SYMBOLS { __EXEHDR__: type = import; }`);
+      expect(cfg.symbols).toEqual([{name: '__EXEHDR__', type: 'import'}]);
+      expect([...configSymbols(cfg)]).toEqual([]);
+    });
+
+    it('should reject a valueless export and a valued import', function() {
+      expectSourceError(`SYMBOLS { A: type = export; }`,
+                        /Symbol 'A' of type 'export' needs a 'value'/, 1);
+      expectSourceError(`SYMBOLS { A: type = import, value = 1; }`,
+                        /Imported symbol 'A' must not have a value/, 1);
+      expectSourceError(`SYMBOLS { A: value = 1; }`,
+                        /Symbol 'A' needs a 'type'/, 1);
+    });
+
+    it('should let an area size reference that area own start define', function() {
+      // ld65 defines `__NAME_START__` between resolving `start` and `size`
+      // precisely so that the size expression may reference it.
+      const cfg = parseLinkerConfig(`
+        MEMORY {
+          A: start = $8000, size = $C000 - __A_START__, define = yes;
+        }
+      `);
+      const syms = configSymbols(cfg);
+      const start = resolveCfgExpr(cfg.memory[0].start, syms, 'start');
+      expect(start).toBe(0x8000);
+      expect(() => resolveCfgExpr(cfg.memory[0].size, syms, 'size'))
+          .toThrow(/__A_START__ is not defined/);
+      syms.set('__A_START__', start);
+      expect(resolveCfgExpr(cfg.memory[0].size, syms, 'size')).toBe(0x4000);
+    });
+
+    it('should defer a layout-derived reference to lowering', function() {
+      // Example from apple2.cfg
+      // `__ONCE_RUN__` is only known after placing MAIN's segments, and
+      // MAIN is declared before BSS, so no extra pass is needed.
+      const cfg = parseLinkerConfig(`
+        MEMORY {
+          MAIN: start = $0803, size = $8DFD;
+          BSS:  start = __ONCE_RUN__, size = $9600 - __ONCE_RUN__;
+        }
+        SEGMENTS {
+          ONCE: load = MAIN, type = ro, define = yes;
+          BSS:  load = BSS,  type = bss;
+        }
+      `);
+      const syms = configSymbols(cfg);
+      expect(resolveCfgExpr(cfg.memory[0].start, syms, 'start')).toBe(0x803);
+      syms.set('__ONCE_RUN__', 0x9000);
+      expect(areaGeometry(cfg.memory[1], syms)).toEqual([0x9000, 0x600]);
+    });
+
+    it('should substitute %S when a start address is supplied', function() {
+      const src = `MEMORY { HEADER: start = %S - $003A, size = $003A; }`;
+      expect(areaGeometry(parseLinkerConfig(src, 'x.cfg',
+                                           {startAddr: 0x0803}).memory[0]))
+          .toEqual([0x0803 - 0x3a, 0x3a]);
+      const cfg = parseLinkerConfig(src);
+      expect(() => areaGeometry(cfg.memory[0]))
+          .toThrow(/start is not constant \(%S is not defined\)/);
+    });
+
+    it('should reject a malformed number', function() {
+      expectSourceError(`MEMORY { A: start = 0x10, size = $10; }`,
+                        /Bad decimal number/, 1);
+    });
+  });
+
+  describe('lexical inversions vs. ca65', function() {
+    it('should treat ; as a statement terminator, not a comment', function() {
+      // In ca65 everything after the first `;` here would be a comment.
+      const cfg = parseLinkerConfig(
+          `MEMORY { A: start = $0, size = $10; B: start = $10, size = $10; }`);
+      expect(cfg.memory.map(a => a.name)).toEqual(['A', 'B']);
+    });
+
+    it('should skip # comments and blank lines', function() {
+      // The shape of nsf.cfg's MEMORY block, including its bare `#arrmem`.
+      const cfg = parseLinkerConfig(`
+        MEMORY {
+          # bank configuration:
+          # $8000-$9FFF: 8K fixed bank
+
+          A: start = $8000, size = $2000;   # trailing comment
+
+          # automatically allocate music data's memory areas
+          #arrmem
+
+          B: start = $A000, size = $2000;
+        }
+      `);
+      expect(cfg.memory.map(a => a.name)).toEqual(['A', 'B']);
+    });
+
+    it('should skip // comments', function() {
+      const cfg = parseLinkerConfig(`
+        // leading comment
+        MEMORY {
+          A: start = $8000, size = $2000;   // trailing comment
+        }
+      `);
+      expect(cfg.memory.map(a => a.name)).toEqual(['A']);
+    });
+
+    it('should lex tab-indented statements', function() {
+      const cfg = parseLinkerConfig(
+          'MEMORY {\n\tA:\tstart = $0,\tsize = $10;\n}\n');
+      expect(cfg.memory.map(a => a.name)).toEqual(['A']);
+    });
+
+    it('should treat the comma between attributes as optional', function() {
+      // The atari5200.cfg and apple2-hgr.cfg spellings; see `splitAttrs`.
+      const cfg = parseLinkerConfig(`
+        MEMORY {
+          A: start = $0, size = $0014   fill = yes, fillval = $40;
+        }
+        SEGMENTS {
+          S: load = A,   type = ro   start = $4000;
+        }
+      `);
+      expect(cfg.memory[0]).toMatchObject({fill: true, fillval: 0x40});
+      expect(cfg.segments[0]).toMatchObject({type: 'ro', start: 0x4000});
+    });
+
+    it('should reject a value where an attribute name belongs', function() {
+      expectSourceError(`MEMORY {\n  A: $0, size = $10;\n}`,
+                        /Expected an attribute name/, 2);
+    });
+
+    it('should accept %O bare and quoted, as a key and as a value', function() {
+      const cfg = parseLinkerConfig(`
+        FILES {
+          %O: format = bin;
+          "%O_header": format = bin;
+        }
+        MEMORY {
+          A: start = $0, size = $10, file = %O;
+          B: start = $0, size = $80, file = "%O_header";
+        }
+      `);
+      expect(cfg.files.map(f => f.name)).toEqual(['%O', '%O_header']);
+      expect(cfg.memory.map(a => a.file)).toEqual(['%O', '%O_header']);
+    });
+  });
+
+  describe('blocks', function() {
+    it('should parse SYMBOLS', function() {
+      const cfg = parseLinkerConfig(`
+        SYMBOLS {
+          __STACKSIZE__: type = weak, value = $0800;
+          _exported:     type = export, value = 1;
+          _imported:     type = import;
+        }
+      `);
+      expect(cfg.symbols.map(s => [s.name, s.type, value(s.value)])).toEqual([
+        ['__STACKSIZE__', 'weak', 0x800],
+        ['_exported', 'export', 1],
+        ['_imported', 'import', undefined],
+      ]);
+    });
+
+    it('should ignore FEATURES and FORMATS without throwing', function() {
+      const cfg = parseLinkerConfig(`
+        FEATURES {
+          CONDES: segment = RODATA,
+                  type = constructor,
+                  label = __CONSTRUCTOR_TABLE__;
+        }
+        FORMATS { o65: export = _main; }
+        MEMORY { A: start = $0, size = $10; }
+      `);
+      expect(cfg.memory.map(a => a.name)).toEqual(['A']);
+    });
+
+    it('should reject an unknown block', function() {
+      expectSourceError(`NONSENSE { A: start = $0; }`,
+                        /Unknown linker config block: NONSENSE/, 1);
+    });
+
+    it('should reject a block with no braces', function() {
+      expectSourceError(`MEMORY`, /Expected '\{' after MEMORY/, 1);
+    });
+  });
+
+  describe('malformed configs', function() {
+    const cases: Array<[string, string, RegExp]> = [
+      ['a missing statement terminator',
+       `MEMORY {\n  A: start = $0, size = $10\n}`, /Expected ';'/],
+      ['an unterminated block',
+       `MEMORY {\n  A: start = $0, size = $10;`, /Missing close curly/],
+      ['an absent size',
+       `MEMORY {\n  A: start = $0;\n}`, /Missing required attribute 'size'/],
+      ['a bad area type',
+       `MEMORY {\n  A: start = $0, size = $10, type = weird;\n}`,
+       /'type' must be one of: ro, rw$/],
+      ['a segment type used on an area',
+       `MEMORY {\n  A: start = $0, size = $10, type = bss;\n}`,
+       /'type' must be one of: ro, rw$/],
+      ['a bad segment type',
+       `MEMORY {\n  A: start = $0, size = $10;\n}\n` +
+       `SEGMENTS {\n  S: load = A, type = weird;\n}`,
+       /'type' must be one of: ro, rw, bss, zp, overwrite/],
+      ['a bad boolean',
+       `MEMORY {\n  A: start = $0, size = $10, fill = maybe;\n}`,
+       /'fill' must be one of/],
+      ['an unknown attribute',
+       `MEMORY {\n  A: start = $0, size = $10, frobnicate = yes;\n}`,
+       /Unknown MEMORY attribute 'frobnicate'/],
+      ['a duplicated attribute',
+       `MEMORY {\n  A: start = $0, size = $10, size = $20;\n}`,
+       /Duplicate attribute: size/],
+      ['a missing value',
+       `MEMORY {\n  A: start = $0, size = ;\n}`, /Missing value for 'size'/],
+      ['a missing colon',
+       `MEMORY {\n  A start = $0, size = $10;\n}`, /Expected :/],
+      ['a segment loading from an undeclared area',
+       `MEMORY {\n  A: start = $0, size = $10;\n}\nSEGMENTS {\n  S: load = NOPE;\n}`,
+       /load = NOPE, which is not a MEMORY area/],
+      ['a segment with neither load nor run',
+       `MEMORY {\n  A: start = $0, size = $10;\n}\nSEGMENTS {\n  S: type = ro;\n}`,
+       /needs at least one of 'load' or 'run'/],
+    ];
+    for (const [name, cfg, message] of cases) {
+      it(`should reject ${name}`, function() {
+        expectSourceError(cfg, message);
+      });
+    }
+
+    it('should report the line the error is actually on', function() {
+      expectSourceError(
+          `MEMORY {\n  A: start = $0, size = $10;\n  B: start = $0;\n}`,
+          /Missing required attribute 'size'/, 3);
+    });
+  });
+
+  describe('run != load', function() {
+    // The shape of TakuikaNinja/FDS-Mirroring-Test's fds.cfg: every byte lives
+    // in one SIDE1A area, but the BIOS file loader copies each file to a
+    // different runtime address.
+    const FDS_CFG = `MEMORY {
+    SIDE1A:   start = $0000, size = 65500, type = ro, file = %O, fill = yes, fillval = 0;
+    PRG0:     start = $6000, size = $7FF6, type = rw, file = "";
+    VEC1:     start = $DFF6, size = $000A, type = rw, file = "";
+}
+SEGMENTS {
+    FILE0_HDR: load = SIDE1A, type = ro;
+    FILE0_DAT: load = SIDE1A, run = PRG0, define = yes;
+    FILE1_HDR: load = SIDE1A, type = ro;
+    FILE1_DAT: load = SIDE1A, run = VEC1, define = yes;
+}`;
+
+    it('should parse an fds-shaped config in full', function() {
+      const cfg = parseLinkerConfig(FDS_CFG);
+      expect(cfg.memory.map(a => a.name)).toEqual(['SIDE1A', 'PRG0', 'VEC1']);
+      expect(areaGeometry(cfg.memory[0])).toEqual([0, 65500]);
+      expect(cfg.memory[0]).toMatchObject({
+        type: 'ro', file: '%O', fill: true, fillval: 0,
+      });
+      // `file = ""` must become undefined, not a bucket named ''.
+      expect(cfg.memory[1].file).toBeUndefined();
+      expect(cfg.memory[2].file).toBeUndefined();
+      expect(cfg.segments.map(s => [s.name, s.load, s.run])).toEqual([
+        ['FILE0_HDR', 'SIDE1A', 'SIDE1A'],
+        ['FILE0_DAT', 'SIDE1A', 'PRG0'],
+        ['FILE1_HDR', 'SIDE1A', 'SIDE1A'],
+        ['FILE1_DAT', 'SIDE1A', 'VEC1'],
+      ]);
+      // FILE0_DAT declares no type; it inherits SIDE1A's `ro`, not PRG0's `rw`.
+      expect(cfg.segments[1]).toMatchObject({type: 'ro', define: true});
+    });
+
+    it('should default run to load and load to run', function() {
+      const cfg = parseLinkerConfig(`
+        MEMORY {
+          A: start = $0000, size = $1000;
+          B: start = $6000, size = $1000;
+        }
+        SEGMENTS {
+          LOAD_ONLY: load = A;
+          RUN_ONLY:  run  = B;
+          BOTH:      load = A, run = B;
+        }
+      `);
+      expect(cfg.segments.map(s => [s.load, s.run])).toEqual([
+        ['A', 'A'], ['B', 'B'], ['A', 'B'],
+      ]);
+    });
+
+    it('should parse the remaining ld65 segment attributes', function() {
+      const cfg = parseLinkerConfig(`
+        MEMORY { A: start = $0200, size = $1000; }
+        SEGMENTS {
+          DATA: load = A, type = rw, define = yes, offset = $0200;
+          OVER: load = A, type = overwrite, start = $0400, fillval = $EA;
+        }
+      `);
+      expect(cfg.segments[0]).toMatchObject({offset: 0x200, type: 'rw'});
+      expect(cfg.segments[1])
+          .toMatchObject({type: 'overwrite', start: 0x400, fillval: 0xea});
+    });
+
+    it('should accept BINARY as an alias for BIN', function() {
+      const cfg = parseLinkerConfig(`FILES { %O: format = binary; }`);
+      expect(cfg.files).toEqual([{name: '%O', format: 'bin'}]);
+    });
+
+    it('should parse align_load separately from align', function() {
+      const cfg = parseLinkerConfig(`
+        MEMORY {
+          A: start = $0000, size = $1000;
+          B: start = $6000, size = $1000;
+        }
+        SEGMENTS { S: load = A, run = B, align = 64, align_load = 16; }
+      `);
+      expect(cfg.segments[0]).toMatchObject({align: 64, alignLoad: 16});
+    });
+  });
+});
+

--- a/test/linkerconfig_test.ts
+++ b/test/linkerconfig_test.ts
@@ -3,8 +3,8 @@
 
 import {describe, it, expect} from 'bun:test';
 import {type Expr} from '../src/expr.ts';
-import {type CfgSymbols, configSymbols, parseLinkerConfig, resolveCfgExpr}
-    from '../src/linkerconfig.ts';
+import {type CfgSymbols, configSymbols, lowerLinkerConfig, parseLinkerConfig,
+        resolveCfgExpr} from '../src/linkerconfig.ts';
 import {SourceError} from '../src/token.ts';
 
 describe('parseLinkerConfig', function() {
@@ -421,6 +421,13 @@ FILES {
       ['a segment with neither load nor run',
        `MEMORY {\n  A: start = $0, size = $10;\n}\nSEGMENTS {\n  S: type = ro;\n}`,
        /needs at least one of 'load' or 'run'/],
+      ['a duplicated area',
+       `MEMORY {\n  A: start = $0, size = $10;\n  A: start = $20, size = $10;\n}`,
+       /Duplicate MEMORY entry: A/],
+      ['a duplicated segment',
+       `MEMORY {\n  A: start = $0, size = $10;\n}\n` +
+       `SEGMENTS {\n  S: load = A;\n  S: load = A;\n}`,
+       /Duplicate SEGMENTS entry: S/],
     ];
     for (const [name, cfg, message] of cases) {
       it(`should reject ${name}`, function() {
@@ -516,6 +523,152 @@ SEGMENTS {
       `);
       expect(cfg.segments[0]).toMatchObject({align: 64, alignLoad: 16});
     });
+  });
+});
+
+describe('lowerLinkerConfig', function() {
+
+  function lower(cfg: string) {
+    return lowerLinkerConfig(parseLinkerConfig(cfg, 'test.cfg'));
+  }
+
+  it('should lower an area into a free-standing segment', function() {
+    expect(lower(`MEMORY {
+      RAM: start = $0300, size = $0500;
+      PRG: start = $8000, size = $4000, file = %O, fill = yes, fillval = $FF,
+           bank = 1, define = yes;
+      CHR: start = $0000, size = $2000, file = "chr.bin";
+    }`)).toEqual([
+      {name: 'RAM', memory: 0x300, size: 0x500},
+      {name: 'PRG', memory: 0x8000, size: 0x4000, bank: 1, out: '%O',
+       fill: 0xff, define: true},
+      {name: 'CHR', memory: 0, size: 0x2000, out: 'chr.bin'},
+    ]);
+  });
+
+  it('should lower a segment into an unmapped segment', function() {
+    expect(lower(`
+      MEMORY {
+        PRG: start = $8000, size = $4000, file = %O;
+        RAM: start = $0300, size = $0500;
+      }
+      SEGMENTS {
+        CODE:     load = PRG, align = $100;
+        BOOT:     load = PRG, run = RAM, align_load = 16, fillval = $EA;
+        ZEROPAGE: load = RAM, type = zp;
+        BSS:      load = RAM, type = bss, optional = yes, define = yes;
+        VECTORS:  load = PRG, start = $BFFA;
+        TABLE:    load = PRG, offset = $200;
+      }`).slice(2)).toEqual([
+      {name: 'CODE', load: 'PRG', run: 'PRG', align: 0x100},
+      {name: 'BOOT', load: 'PRG', run: 'RAM', alignLoad: 16, fill: 0xea},
+      {name: 'ZEROPAGE', load: 'RAM', run: 'RAM', bss: true, addressing: 1},
+      {name: 'BSS', load: 'RAM', run: 'RAM', bss: true, define: true,
+       optional: true},
+      {name: 'VECTORS', load: 'PRG', run: 'PRG', memory: 0xbffa},
+      // `offset` is relative to the run area, unlike `start`.
+      {name: 'TABLE', load: 'PRG', run: 'PRG', memory: 0x8200},
+    ]);
+  });
+
+  describe('a segment sharing its area\'s name', function() {
+
+    function expectRejected(cfg: string, message: RegExp) {
+      let err: unknown;
+      try {
+        lower(cfg);
+      } catch (e) {
+        err = e;
+      }
+      expect(err).toBeInstanceOf(SourceError);
+      expect((err as Error).message).toMatch(message);
+    }
+
+    it('should collapse into the area', function() {
+      // nrom.cfg declares both, and the segment is just the area's contents.
+      expect(lower(`
+        MEMORY {
+          ZEROPAGE: start = $00,   size = $100;
+          RAM:      start = $0300, size = $500;
+        }
+        SEGMENTS {
+          ZEROPAGE: load = ZEROPAGE, type = zp;
+          BSS:      load = RAM,      type = bss, align = $100;
+          RAM:      load = RAM,      type = bss, start = $0300;
+        }`)).toEqual([
+        {name: 'ZEROPAGE', memory: 0, size: 0x100, bss: true, addressing: 1},
+        {name: 'RAM', memory: 0x300, size: 0x500, bss: true},
+        {name: 'BSS', load: 'RAM', run: 'RAM', bss: true, align: 0x100},
+      ]);
+    });
+
+    it('should keep the area\'s place in the layout', function() {
+      // The area's declaration order is the order its file is written in, so
+      // the merged segment has to stay where the area was.
+      expect(lower(`
+        MEMORY {
+          HDR: start = $0000, size = $10,   file = %O;
+          PRG: start = $8000, size = $4000, file = %O;
+        }
+        SEGMENTS {
+          CODE: load = PRG;
+          HDR:  load = HDR;
+        }`).map(s => s.name)).toEqual(['HDR', 'PRG', 'CODE']);
+    });
+
+    it('should reject a segment that loads somewhere else', function() {
+      expectRejected(`
+        MEMORY {
+          A: start = $0000, size = $10;
+          B: start = $8000, size = $10;
+        }
+        SEGMENTS { A: load = B; }`,
+        /Segment 'A' shares its name with a MEMORY area but does not load/);
+    });
+
+    it('should reject a segment that runs somewhere else', function() {
+      expectRejected(`
+        MEMORY {
+          A: start = $0000, size = $10;
+          B: start = $8000, size = $10;
+        }
+        SEGMENTS { A: load = A, run = B; }`,
+        /Segment 'A' shares its name with a MEMORY area but does not load/);
+    });
+
+    it('should reject a start that contradicts the area', function() {
+      expectRejected(`
+        MEMORY { A: start = $8000, size = $100; }
+        SEGMENTS { A: load = A, start = $8010; }`,
+        /Segment 'A' starts at \$8010 but shares its name/);
+    });
+
+    it('should reject an alignment the area cannot satisfy', function() {
+      expectRejected(`
+        MEMORY { A: start = $8010, size = $100; }
+        SEGMENTS { A: load = A, align = $100; }`,
+        /Segment 'A' wants \$100-byte alignment/);
+    });
+  });
+
+  it('should resolve config symbols in area expressions', function() {
+    expect(lower(`
+      SYMBOLS { __SIZE__: type = weak, value = $2000; }
+      MEMORY { PRG: start = $10000 - __SIZE__, size = __SIZE__; }`))
+        .toEqual([{name: 'PRG', memory: 0xe000, size: 0x2000}]);
+  });
+
+  it('should let an object file override a weak config symbol', function() {
+    const cfg = parseLinkerConfig(`
+      SYMBOLS {
+        __STACK__: type = weak, value = $100;
+        __TOP__:   type = export, value = $200;
+      }
+      MEMORY { RAM: start = $200 - __STACK__, size = __TOP__; }`);
+    // The object file's own definition wins, which leaves nothing for the
+    // area's start to resolve against.
+    expect(() => lowerLinkerConfig(cfg, new Set(['__STACK__'])))
+        .toThrow(/MEMORY area 'RAM' start is not constant \(__STACK__/);
   });
 });
 

--- a/test/linkerconfig_test.ts
+++ b/test/linkerconfig_test.ts
@@ -636,18 +636,25 @@ describe('lowerLinkerConfig', function() {
         /Segment 'A' shares its name with a MEMORY area but does not load/);
     });
 
-    it('should reject a start that contradicts the area', function() {
-      expectRejected(`
+    it('should start where the segment says, inside the area', function() {
+      expect(lower(`
         MEMORY { A: start = $8000, size = $100; }
-        SEGMENTS { A: load = A, start = $8010; }`,
-        /Segment 'A' starts at \$8010 but shares its name/);
+        SEGMENTS { A: load = A, start = $8010; }`))
+          .toEqual([{name: 'A', memory: 0x8010, size: 0xf0}]);
     });
 
-    it('should reject an alignment the area cannot satisfy', function() {
-      expectRejected(`
+    it('should round the merged start up to the segment\'s alignment', function() {
+      expect(lower(`
         MEMORY { A: start = $8010, size = $100; }
-        SEGMENTS { A: load = A, align = $100; }`,
-        /Segment 'A' wants \$100-byte alignment/);
+        SEGMENTS { A: load = A, align = $100; }`))
+          .toEqual([{name: 'A', memory: 0x8100, size: 0x10}]);
+    });
+
+    it('should reject a start outside the area', function() {
+      expectRejected(`
+        MEMORY { A: start = $8000, size = $100; }
+        SEGMENTS { A: load = A, start = $9000; }`,
+        /Segment 'A' starts at \$9000, which is outside the MEMORY area/);
     });
   });
 

--- a/test/mlb_test.ts
+++ b/test/mlb_test.ts
@@ -587,6 +587,30 @@ ptr: .res 2
       expect(ptr?.address).toBe('1-2');
     });
 
+    it('should resolve an equate over a relocatable RAM label', async function() {
+      // `held = buttons+2` is resolved before the chunk is placed, so its
+      // value is still relative to the chunk it names.
+      // The segment starts at $f1, so a chunk-relative value that never
+      // learned where its chunk landed would come out as 2 rather than $f3.
+      const source = `
+.segment "BIOSZP" :size $f :mem $00f1 :zp
+.segment "BIOSZP"
+buttons: .res 4
+held = buttons+2
+.segment "PRG"
+.org $8000
+  lda held
+`;
+      const entries = await assembleAndGetDebugInfo(source);
+      const buttons = entries.find(e => e.label === 'buttons');
+      const held = entries.find(e => e.label === 'held');
+
+      expect(buttons?.type).toBe("NesInternalRam");
+      expect(buttons?.address).toBe('f1-f4');
+      expect(held?.type).toBe("NesInternalRam");
+      expect(held?.address).toBe('f3');
+    });
+
     it('should generate NesSaveRam for SRAM labels in RAM segments', async function() {
       const source = `
 .segment "SRAM" :size $2000 :mem $6000

--- a/test/tokenizer_test.ts
+++ b/test/tokenizer_test.ts
@@ -191,7 +191,7 @@ describe('Tokenizer.line', function() {
   it('should tokenize all kinds of numbers', async function() {
     expect(await tokenize('123 0123 %10110 $123d')).toEqual([
       [{token: 'num', num: 123},
-       {token: 'num', num: 0o123},
+       {token: 'num', num: 123},
        {token: 'num', num: 0b10110, width: 1},
        {token: 'num', num: 0x123d, width: 2}],
     ]);
@@ -261,8 +261,8 @@ describe('Tokenizer.line', function() {
     await expectSourceError(tokenize('  12a'), /Bad decimal.*near '12a'/s, 1, 2);
   });
 
-  it('should fail to parse a bad octal number', async function() {
-    await expectSourceError(tokenize('  018'), /Bad octal.*near '018'/s, 1, 2);
+  it('should fail to parse a bad leading-zero number', async function() {
+    await expectSourceError(tokenize('  01a'), /Bad decimal.*near '01a'/s, 1, 2);
   });
 
   it('should fail to parse a bad binary number', async function() {
@@ -305,5 +305,46 @@ describe('Tokenizer.line', function() {
 
   it('should not parse .2 as a directive', async function() {
     await expectSourceError(tokenize(' .2'), /Syntax error/s, 1, 1);
+  });
+
+  // Verify that the original js65 tokenizer uses the original behavior
+  describe('js65 token override checks', function() {
+    it('should lex % as a binary literal prefix', async function() {
+      expect(await tokenize('  .byte %0101, %11111111\n')).toEqual([[
+        {token: 'cs', str: '.byte', rawStr: '.byte'},
+        {token: 'num', num: 0b0101, width: 1},
+        {token: 'op', str: ','},
+        {token: 'num', num: 0b11111111, width: 1},
+      ]]);
+    });
+
+    it('should treat ; as a comment to end of line', async function() {
+      expect(await tokenize('  lda #1 ; sta $2\n  nop\n')).toEqual([
+        [{token: 'ident', str: 'lda'}, {token: 'op', str: '#'},
+         {token: 'num', num: 1}],
+        [{token: 'ident', str: 'nop'}],
+      ]);
+    });
+
+    it('should treat newlines as statement terminators', async function() {
+      expect(await tokenize('  nop\n  nop\n')).toEqual([
+        [{token: 'ident', str: 'nop'}],
+        [{token: 'ident', str: 'nop'}],
+      ]);
+    });
+
+    it('should read a leading-zero number as decimal', async function() {
+      expect(await tokenize('  .byte 010\n')).toEqual([[
+        {token: 'cs', str: '.byte', rawStr: '.byte'},
+        {token: 'num', num: 10},
+      ]]);
+    });
+
+    it('should lex # as an operator', async function() {
+      expect(await tokenize('  lda #$12\n')).toEqual([[
+        {token: 'ident', str: 'lda'}, {token: 'op', str: '#'},
+        {token: 'num', num: 0x12, width: 1},
+      ]]);
+    });
   });
 });


### PR DESCRIPTION
A rather large change that affects how js65 does linking.

Previously, we linked modules together by sorting all segments in a module by size, and then placing each of them. But to better match how ld65 does it (although not a perfect match) we instead link each segment completely, one at a time. We still sort the chunks in the segment from largest to smallest, for most homebrew style projects this won't matter much at all, but for romhacking "patching" projects you might find some differences. It shouldn't affect 99% of cases though. Hard to know the fall out for sure, but I believe it was the right approach to compromise and meld the ld65 linker approach with the js65 one.

After I got the linker scripts working, it let me test a few ca65 projects upstream and see compare the output. It turns out we were missing several locations where we fell back to ABS addressing for a ZP symbol, which really hurt our compilation sizes. I've tried to address several of those by using better zero page tracking, such as handling cases where +/- changed the address, we now check if the address was ZP before, and then consider it ZP after the arthimetic operation (if its still within the right size).

And last bit, a little while back, I found out about sticky regexes, which greatly sped up the tokenization, allowing us to skip slicing strings and rescanning the input files each time we move to the next token. For really large input files, this makes a huge difference. Well, what I didn't realize at that time is we only have a small fixed number of regex inputs, and if we move them to be const (instead of doing whatever that stickyregex cache was :p) then we don't need to rebuild the regex for each token, which provided another 4x speed up for basically nothing!

The bun runtime when compiling a medium size project went from 2.2 seconds to .5
The hermes runtime for the same project whet from 16 seconds to 3.4