### PR TITLE
Preprocessor upgrades and performance improvements

### DIFF
--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -8,7 +8,7 @@ import * as mod from './module.ts';
 import { type Token, type AssemblerMessage, type ErrorLevel } from './token.ts'
 import * as Tokens from './token.ts';
 import { Tokenizer } from './tokenizer.ts';
-import { IntervalSet, assertNever } from './util.ts';
+import { IntervalSet, assertNever, MaxKeySizeCacheMap } from './util.ts';
 
 type Chunk = mod.ChunkNum; //<number[]>;
 type Module = mod.Module;
@@ -299,9 +299,9 @@ export class Assembler {
   private pendingLabel?: {name: string, startPc: Expr};
 
   /** Mapping for any string to byte array  */
-  private charMapping = new Map<string, number[]>();
+  private charMapping = new MaxKeySizeCacheMap<string, number[]>();
   /** Saved charmaps for `.pushcharmap`/`.popcharmap`. */
-  private charmapStack: Array<Map<string, number[]>> = [];
+  private charmapStack: Array<MaxKeySizeCacheMap<string, number[]>> = [];
 
   /**
    * We don't have any CPUs to switch to, so this is just there to make sure the
@@ -1020,7 +1020,7 @@ export class Assembler {
         case '.hibytes': return this.byte(...this.parseDataList(tokens).map(e => Exprs.hiByte(e)));
         case '.lobytes': return this.byte(...this.parseDataList(tokens).map(e => Exprs.loByte(e)));
         case '.bytestr': return this.byteInternal(this.parseByteStr(tokens));
-        case '.literal': return this.byteInternal(this.parseDataList(tokens, true), new Map());
+        case '.literal': return this.byteInternal(this.parseDataList(tokens, true), new MaxKeySizeCacheMap());
         case '.res': return this.res(...this.parseResArgs(tokens));
         case '.word': return this.word(...this.parseDataList(tokens));
         case '.dbyt': return this.dbyte(...this.parseDataList(tokens));
@@ -1037,7 +1037,7 @@ export class Assembler {
         case '.charmap': return this.charmap(tokens);
         case '.strmap': return this.strmap(tokens);
         case '.pushcharmap': return this.parseNoArgs(tokens, 1),
-          void this.charmapStack.push(new Map(this.charMapping));
+          void this.charmapStack.push(new MaxKeySizeCacheMap(this.charMapping));
         case '.popcharmap': return this.parseNoArgs(tokens, 1),
           void (this.charMapping = this.charmapStack.pop() ?? this.charMapping);
         case '.setcpu': return this.setCpu(this.parseStr(tokens, 1));
@@ -1699,7 +1699,7 @@ export class Assembler {
   // the `charMap` parameter defaults to the current charMap, but for `.literal`
   // we pass in an empty map to disable the charMapping for this string.
   byteInternal(args: Array<Expr|string|number>,
-               charmap: Map<string, number[]> = this.charMapping) {
+               charmap: MaxKeySizeCacheMap<string, number[]> = this.charMapping) {
     const {chunk} = this;
     this.markWritten(args.length);
 
@@ -2315,12 +2315,11 @@ export class Assembler {
   }
 }
 
-function writeString(data: number[], str: string, charmap: Map<string, number[]>) {
+function writeString(data: number[], str: string, charmap: MaxKeySizeCacheMap<string, number[]>) {
   // Split into Unicode code points (not js string UTF-16 code units) so a multi-byte
   // character is one unit for both matching and the unmapped fallback.
   const chars = Array.from(str);
-  const maxKeyLen = charmap.size ?
-      Math.max(...[...charmap.keys()].map(k => Array.from(k).length)) : 0;
+  const maxKeyLen = charmap.getLargestKeySize();
   for (let i = 0; i < chars.length; ) {
     // Greedy longest-match, so a `.strmap` key beats the single-character
     // `.charmap` entries it overlaps.

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -114,6 +114,14 @@ abstract class BaseScope {
     if (tail !== name) symbol.scoped = true;
     return symbol;
   }
+
+  /** Insert a brand new symbol into the table, scoped if there is one open */
+  declare(name: string, symbol: Symbol): Symbol {
+    const [tail, scope] = this.pickScope(name);
+    scope.symbols.set(tail, symbol);
+    if (tail !== name) symbol.scoped = true;
+    return symbol;
+  }
 }
 
 class Scope extends BaseScope {
@@ -430,17 +438,34 @@ export class Assembler {
     }
   }
 
-  definedSymbol(sym: string): boolean {
-    // In this case, it's okay to traverse up the scope chain since if we
-    // were to reference the symbol, it's guaranteed to be defined somehow.
-    if (this.globals.get(sym) === 'import') return true;
+  private walkSymbolTree(sym: string): Expr|undefined {
     let scope: Scope|undefined = this.currentScope;
     const unscoped = !sym.includes('::');
     do {
       const s = scope.resolve(sym, {allowForwardRef: false});
-      if (s) return Boolean(s.expr);
+      if (s) return s.expr;
     } while (unscoped && (scope = scope.parent));
+    return undefined;
+  }
+
+  definedSymbol(sym: string): boolean {
+    // In this case, it's okay to traverse up the scope chain since if we
+    // were to reference the symbol, it's guaranteed to be defined somehow.
+    if (this.globals.get(sym) === 'import') return true;
+    const s = this.walkSymbolTree(sym);
+    if (s !== undefined) return Boolean(s);
     return false;
+  }
+
+  /**
+   * The value is needed by the preprocessor to determine if something
+   * is chunk relative. `* - Label` is a valid way to get a size of some code,
+   * but if you use the normal scope resolve, it would try to get a numeric
+   * value when we want to keep it as an expression for computing the diff.
+   */
+  definedValue(sym: string): Expr|undefined {
+    if (sym === '*') return this.pc();
+    return this.walkSymbolTree(sym);
   }
 
   constantSymbol(sym: string): boolean {
@@ -738,11 +763,18 @@ export class Assembler {
     }
     close(this.currentScope);
 
+    const globalScope = this.currentScope.global;
     for (const [name, global] of this.globals) {
       // Resolve the symbol in the scope the declaration appeared in and
       // fall back to the global scope if not found.
       const scope = this.globalScopes.get(name) ?? this.currentScope;
-      const sym = scope.symbols.get(name);
+      let sym = scope.symbols.get(name);
+      // A declaration inside a `.proc`/`.scope` can name a symbol that lives
+      // further out - the same lookup an ordinary reference from there does.
+      for (let s = scope.parent; s && !sym?.expr; s = s.parent) {
+        const outer = s.symbols.get(name);
+        if (outer?.expr) sym = outer;
+      }
       // `.global` is import-or-export depending on whether it got defined here.
       const kind = global === 'global' ? (sym?.expr ? 'export' : 'import') : global;
       if (kind === 'export') {
@@ -755,6 +787,13 @@ export class Assembler {
           this.symbols.push(sym);
         }
         sym.export = name;
+        // An `.export` inside a `.proc`/`.scope` publishes the name for the
+        // whole module, so a reference from outside that scope - which by now
+        // has been floated up to the global scope - names this symbol.
+        const outer = globalScope.symbols.get(name);
+        if (outer && outer !== sym && !outer.expr) {
+          outer.expr = {op: 'sym', num: sym.id};
+        }
       } else if (kind === 'import') {
         if (!sym) continue; // okay to import but not use.
         // TODO - record both positions?
@@ -910,7 +949,9 @@ export class Assembler {
 
   // Assemble from a list of tokens
   async line(tokens: Token[]) {
-    if (Tokens.eq(tokens[1], Tokens.ASSIGN) || Tokens.eq(tokens[1], Tokens.SET)) {
+    if (Tokens.eq(tokens[1], Tokens.ASSIGN) ||
+        Tokens.eq(tokens[1], Tokens.ASSIGN_LABEL) ||
+        Tokens.eq(tokens[1], Tokens.SET)) {
       // Skip over any assignments as these were handled in the preprocessor?
       // TODO: Should the preprocessor remove the tokens?
       return;
@@ -1205,7 +1246,7 @@ export class Assembler {
       this.fail(`Mutable set requires constant`, token);
     } else if (!sym) {
       if (!mut) throw new Error(`impossible`);
-      scope.symbols.set(ident, sym = {id: -1});
+      sym = scope.declare(ident, {id: -1});
     } else if (!mut && sym.expr) {
       const orig =
           sym.expr.source ? `\nOriginally defined${Tokens.at(sym.expr)}` : '';

--- a/src/buffer.ts
+++ b/src/buffer.ts
@@ -20,6 +20,15 @@ export class Buffer {
   constructor(readonly content: string, public line = 1, public column = 0) {}
 
   private advance(s: string) {
+    // fast path for skipping the check for newlines when advancing since
+    // almost all tokens we skip by don't have a newline in them
+    if (!s.includes('\n') && !s.includes('\r')) {
+      this.column += s.length;
+      this.pos += s.length;
+      return;
+    }
+    // slow path if the token has newlines in it, we want to split it and move
+    // to the next line/column/etc
     // s is the freshly-matched token text starting at this.pos.
     this.pos += s.length;
     s = s.replace('\n', s.includes('\r') ? '' : '\r');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -84,7 +84,7 @@ export class Cli {
     let bytes = await this.callbacks.fsReadBytes("", filename);
     if (typeof bytes === "string") bytes = new Base64().decode(bytes);
     if (isGzip(bytes)) {
-      return { type: 'module', module: deserializeObjectFile(bytes, filename) };
+      return { type: 'module', module: await deserializeObjectFile(bytes, filename) };
     }
     // Frontends also strip the BOM, but it doesn't hurt to check it in this path too.
     if (bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf) bytes = bytes.subarray(3);
@@ -281,7 +281,7 @@ export class Cli {
         await this.callbacks.fsWriteBytes("", args.mapfile, map.data);
       }
     } catch (e) {
-      this.printerrors(e);
+      this.printerrors(e as Error);
       throw e;
     }
   }

--- a/src/expr.ts
+++ b/src/expr.ts
@@ -392,10 +392,12 @@ export function parse(tokens: Token[], index = 0, symbols?: SymbolLookup,
     if (val) {
       // looking for a value: literal, balanced parens, or prefix op.
       if (front.token === 'cs' || front.token === 'op') {
-        const mapped = NAME_MAP.get(front.str);
-        const prefix = PREFIXOPS.get(mapped ?? front.str);
+        const str = collapseSigns(front.str, true);
+        if (!str) continue; // a run of signs that cancels itself out
+        const mapped = NAME_MAP.get(str);
+        const prefix = PREFIXOPS.get(mapped ?? str);
         if (prefix) {
-          ops.push([front.str, prefix]);
+          ops.push([str, prefix]);
         } else if (front.token === 'cs') {
           const op = front.str;
           if (!FUNCTIONS.has(op)) {
@@ -482,8 +484,9 @@ export function parse(tokens: Token[], index = 0, symbols?: SymbolLookup,
         break;
       }
       if (front.token === 'cs' || front.token === 'op') {
-        const mapped = NAME_MAP.get(front.str);
-        const op = BINOPS.get(mapped ?? front.str);
+        const str = collapseSigns(front.str, false);
+        const mapped = NAME_MAP.get(str);
+        const op = BINOPS.get(mapped ?? str);
         if (!op) break; // we're at the end...?  or if no op.
         // see if anything to the left is faster.
         while (ops.length) {
@@ -496,7 +499,7 @@ export function parse(tokens: Token[], index = 0, symbols?: SymbolLookup,
           }
           popOp();
         }
-        ops.push([front.str, op]);
+        ops.push([str, op]);
         val = true;
       } else {
         //throw new Error(`Garbage after expression: ${Tokens.nameAt(front)}`);
@@ -516,6 +519,20 @@ export function parse(tokens: Token[], index = 0, symbols?: SymbolLookup,
   return [exprs[0], i];
 }
 
+
+const SIGN_RUN = /^([-+])\1+$/;
+
+/**
+ * We allow an asm6 style +++ free-standing to be a label, but for a long
+ * run of a +++ b, we can collapse that into a single a + b here to simplify
+ * handling these cases. For instance a -- b turns into a - (-b) which is a + b
+ */
+function collapseSigns(str: string, unary: boolean): string {
+  if (!SIGN_RUN.test(str)) return str;
+  const negations = str[0] === '-' ? (unary ? str.length : str.length - 1) : 0;
+  if (negations % 2) return '-';
+  return unary ? '' : '+';
+}
 
 /** ca65 evaluates expressions as signed 32-bit integers, so we do too. */
 function i32(x: number): number {

--- a/src/libassembler.ts
+++ b/src/libassembler.ts
@@ -3,7 +3,6 @@
 
 // We use the browser build here since this file is intended to be used from both the cli and browser
 // environments
-import { gzipSync, gunzipSync, strToU8, strFromU8 } from 'fflate/browser';
 import { Assembler } from './assembler.ts';
 import { Base64 } from './base64.ts';
 import { Cpu } from './cpu.ts';
@@ -534,14 +533,16 @@ export function isGzip(data: Uint8Array): boolean {
  * compress the object files to save a lotta space. In my testing its around 10x just
  * from gzip + another 2.5x saved just from cutting indents outta the json file.
  */
-export function serializeObjectFile(m: Module): Uint8Array {
+export async function serializeObjectFile(m: Module): Promise<Uint8Array> {
+  const { gzipSync, strToU8 } = await import('fflate/browser');
   return gzipSync(strToU8(serializeModule(m)), { level: 9 });
 }
 
 /**
  * Decode a `.o` file produced by serializeObjectFile back into a Module.
  */
-export function deserializeObjectFile(data: Uint8Array, name = 'object file'): Module {
+export async function deserializeObjectFile(data: Uint8Array, name = 'object file'): Promise<Module> {
+  const { gunzipSync, strFromU8 } = await import('fflate/browser');
   let json: string;
   try {
     json = strFromU8(gunzipSync(data));
@@ -636,11 +637,11 @@ export async function compile(
     }
 
     if (outputFormat === 'object') {
-      const outputs: OutputFile[] = asm.modules.map(m => ({
+      const outputs: OutputFile[] = await Promise.all(asm.modules.map(async m => ({
         name: `${m.name || 'module'}.o`,
-        data: serializeObjectFile(m),
+        data: await serializeObjectFile(m),
         type: 'object',
-      }));
+      })));
       return { success: true, outputs, messages: asm.messages };
     }
 

--- a/src/linker.ts
+++ b/src/linker.ts
@@ -30,6 +30,13 @@ export interface MesenLabelFormat {
   comment: string,
 }
 
+const RE_IS_COMMENT = /^\s*(;|.*:\s*$)/;
+const RE_COLON = /:/g;
+const RE_INLINE_COMMENT = /;(.*)$/;
+const RE_LABEL_ONLY_LINE = /^\s*.*:\s*$/;
+const RE_FULL_COMMENT_LINE = /^\s*;/;
+const RE_LABEL_OR_COMMENT_LINE = /^\s*(;|.*:\s*$)/;
+
 export class Linker {
   opts: Options;
   // TODO - accept a list of [filename, contents]?
@@ -118,7 +125,7 @@ export class Linker {
       if (debugLevel === 0) {
         // Level 0: Only include comments, skip source code and labels
         // Walk backwards while we see comment lines (;) or label definitions (ending with :)
-        do { firstLine--; } while (firstLine >= 0 && /^\s*(;|.*:\s*$)/.test(sourceLines[firstLine]));
+        do { firstLine--; } while (firstLine >= 0 && RE_IS_COMMENT.test(sourceLines[firstLine]));
 
         const lines = sourceLines.slice(firstLine + 1, actualLine + 1);
         const result: string[] = [];
@@ -126,20 +133,20 @@ export class Linker {
         for (const l of lines) {
           const trimmed = l.trim();
           // Check if line is a full comment line
-          if (/^\s*;/.test(l)) {
+          if (RE_FULL_COMMENT_LINE.test(l)) {
             // Remove leading semicolon and colons from comments
-            const commentText = trimmed.substring(1).trim().replace(/:/g, '');
+            const commentText = trimmed.substring(1).trim().replace(RE_COLON, '');
             if (commentText) {
               result.push(commentText);
             }
-          } else if (/^\s*.*:\s*$/.test(l)) {
+          } else if (RE_LABEL_ONLY_LINE.test(l)) {
             // Label-only line - skip it (labels go in the label field, not comments)
           } else {
             // Check if line has an inline comment (code ; comment)
-            const inlineCommentMatch = l.match(/;(.*)$/);
+            const inlineCommentMatch = l.match(RE_INLINE_COMMENT);
             if (inlineCommentMatch) {
               // Remove colons from the comment (no leading semicolon)
-              const commentText = inlineCommentMatch[1].trim().replace(/:/g, '');
+              const commentText = inlineCommentMatch[1].trim().replace(RE_COLON, '');
               if (commentText) {
                 result.push(commentText);
               }
@@ -152,11 +159,11 @@ export class Linker {
       } else {
         // Level 1+: Include comments and code, but not labels
         // Walk backwards while we see comment lines (;) or label definitions (ending with :)
-        do { firstLine--; } while (firstLine >= 0 && /^\s*(;|.*:\s*$)/.test(sourceLines[firstLine]));
+        do { firstLine--; } while (firstLine >= 0 && RE_LABEL_OR_COMMENT_LINE.test(sourceLines[firstLine]));
         // Filter out label-only lines and remove colons from remaining lines
         comment = sourceLines.slice(firstLine + 1, actualLine + 1)
-          .filter((s) => !/^\s*\S+:\s*$/.test(s))  // Exclude label-only lines
-          .map((s) => s.trim().replace(/:/g, ''))
+          .filter((s) => !RE_LABEL_ONLY_LINE.test(s))
+          .map((s) => s.trim().replace(RE_COLON, ''))
           .join('\\n');
       }
     }

--- a/src/linkerconfig.ts
+++ b/src/linkerconfig.ts
@@ -111,9 +111,9 @@ export class CfgTokenizer extends Tokenizer {
   protected override numberRegex(): RegExp { return RE_CFG_NUMBER; }
 
   /** added a new `;` token for line ending so we need to add it to the operator list */
-  protected override operatorRegex(): RegExp {
-    return RE_CFG_OPERATOR;
-  }
+  protected override operatorRegex(): RegExp { return RE_CFG_OPERATOR; }
+  protected override addressSizeRegex(): undefined { return undefined; }
+  protected override registerRegex(): undefined { return undefined; }
 
   /** Handle the %o / %s tokens as well */
   protected override tokenInternal(): Token {

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -16,6 +16,9 @@ import { ErrorCollector, RecoverableError } from './assembler.ts';
 //    to know when to release the frame?
 const MAX_STACK_DEPTH = 100;
 
+/** Token types that finish off a value so a `::` after one qualifies it. */
+const VALUE_END: ReadonlySet<string> = new Set(['num', 'str', 'rb', 'rp', 'rc', 'grp']);
+
 /**
  * Value reported by `.version`, encoded the way ca65 does it:
  * `(major << 8) | minor`.
@@ -63,6 +66,8 @@ interface Env {
   /** Whether the name is an opcode mnemonic of the CPU being assembled for. */
   isMnemonic(name: string): boolean;
   evaluate(expr: Expr): number|undefined;
+  /** Expression a defined symbol (or `*`) stands for, without interning it. */
+  definedValue(sym: string): Expr|undefined;
   assignSym(line: Token[]): void;
   setSym(line: Token[]): void;
   /** Applies the current charmap to a character literal (`'a'`). */
@@ -152,7 +157,8 @@ export class Preprocessor implements Tokens.Source {
             this.outQueue.push(label);
             break;
           }
-          if (Tokens.eq(line[1], Tokens.ASSIGN)) {
+          if (Tokens.eq(line[1], Tokens.ASSIGN) ||
+              Tokens.eq(line[1], Tokens.ASSIGN_LABEL)) {
             this.env.assignSym(line);
           } else if (Tokens.eq(line[1], Tokens.SET)) {
             this.env.setSym(line);
@@ -218,10 +224,43 @@ export class Preprocessor implements Tokens.Source {
     return line;
   }
 
+  /** Whether a name is an instruction or a `.macro`, and so can't be a scope. */
+  private isCallable(name: string): boolean {
+    return this.macros.get(name) instanceof Macro || this.env.isMnemonic(name);
+  }
+
+  /**
+   * Differentiate between a `scope :: label` and a `.if :: global` by finding
+   * where exactly the "label" starts. In the first case it should roll
+   * up everything through the scope, but the second should stop at
+   * the `::`. This combines the scope into one big ident token to make it
+   * easier to process.
+   * In the tokenizer, we keep each part `scope :: label` separate (thats 3
+   * tokens) to match how ca65 does it, and then for later handling, we combine
+   * that into one label token.
+   */
+  private mergeScopePrefix(line: Token[], pos: number): number {
+    if (pos < 1 || !Tokens.eq(line[pos - 1], Tokens.DCOLON)) return pos;
+    const ident = line[pos];
+    if (ident.token !== 'ident') return pos;
+    const before = pos >= 2 ? line[pos - 2] : undefined;
+    if (before && before.token !== 'ident' && VALUE_END.has(before.token)) {
+      return pos;
+    }
+    const scope = before?.token === 'ident' && !this.isCallable(before.str) ?
+        before.str : '';
+    const start = scope ? pos - 2 : pos - 1;
+    line.splice(start, pos - start + 1,
+                {token: 'ident', str: `${scope}::${ident.str}`, source: ident.source});
+    return start;
+  }
+
   /** Returns the next position to expand. */
   private expandToken(line: Token[], pos: number): number {
     const front = line[pos]!;
     if (front.token === 'ident') {
+      // define replacement has to happen first in case the scope has some
+      // name that needs replaced before we turn it into a label.
       const define = this.macros.get(front.str);
       if (define instanceof Define) {
         const overflow = define.expand(line, pos);
@@ -231,8 +270,14 @@ export class Preprocessor implements Tokens.Source {
           return pos;
         }
       }
+      // Whatever it expanded to still has to be joined to the scope in front.
+      return this.mergeScopePrefix(line, pos) + 1;
     } else if (front.token === 'cs') {
       return this.expandDirective(front.str, line, pos);
+    } else if (front.token === 'grp') {
+      // Expand the { ... } lists immediately instead of passing it
+      // down to the callee
+      this.expandLine(front.inner);
     }
     return pos + 1;
   }
@@ -394,11 +439,12 @@ export class Preprocessor implements Tokens.Source {
     return [{token: 'num', num: Preprocessor.tokensEqual(a, b, true) ? 1 : 0, source: cs.source}];
   }
 
-  /** Evaluate an already-expanded token list to a constant token count. */
   private constCount(toks: Token[], cs: Token): number {
-    const e = Exprs.evaluate(Exprs.parseOnly(toks, 0));
-    if (e.num == null) Tokens.fail(`Expected a constant token count`, cs);
-    return e.num;
+    try {
+      return this.evaluateConst(parseOneExpr(toks, cs, this.env.encodeChar), cs);
+    } catch {
+      Tokens.fail(`Expected a constant token count`, cs);
+    }
   }
 
   private left(cs: Token, count: Token[], list: Token[]) : Token[] {
@@ -501,7 +547,9 @@ export class Preprocessor implements Tokens.Source {
     const expr = parseOneExpr(arg, cs, this.env.encodeChar);
     let known = true;
     try {
-      this.evaluateConst(expr, cs);
+      // `*` and labels have a value here, but it's an address rather than a
+      // constant, so `.const` says no to them the way ca65 does.
+      this.evaluateConst(expr, cs, false);
     } catch {
       known = false; // `*`, forward references and imports are not constant
     }
@@ -570,14 +618,19 @@ export class Preprocessor implements Tokens.Source {
     return true;
   }
 
-  evaluateConst(expr: Expr, source?: Token): number {
+  /**
+   * @param addresses Whether `*` and labels may stand in for their address value
+   * `.const` needs them as labels, but other callers want them as addresses.
+   */
+  evaluateConst(expr: Expr, source?: Token, addresses = true): number {
     // Attempt to look up a symbol and see if its a constant value
     const evalWrapper = (ex: Expr) => {
-      if (ex.op === 'sym' && this.env.definedSymbol(ex.sym!)) {
-        // HACK? If its defined but not set, default it to zero?
-        const num = this.env.evaluate(ex);
-        if (num === undefined) throw new Error(`Symbol ${ex.sym} is undefined`);
-        return Exprs.evaluate({op: 'num', num, meta: Exprs.size(num, undefined)});
+      if (ex.op === 'sym' && ex.sym) {
+        // Substitute the expression rather than a number.
+        // Labels and `*` are chunk-relative, and it's the surrounding
+        // arithmetic like `* - label` that makes them constant again.
+        const val = this.env.definedValue(ex.sym);
+        if (val && (addresses || !isAddress(val))) return Exprs.evaluate(val);
       }
       return Exprs.evaluate(ex);
     };
@@ -918,6 +971,10 @@ export class Preprocessor implements Tokens.Source {
 function parseOneIdent(ts: Token[], prev?: Token): string {
   const e = parseOneExpr(ts, prev);
   return Exprs.identifier(e);
+}
+
+function isAddress(expr: Expr): boolean {
+  return expr.op !== 'num' || expr.meta?.rel === true || expr.meta?.org != null;
 }
 
 function parseOneExpr(ts: Token[], prev?: Token, charEncoder?: Exprs.CharEncoder): Expr {

--- a/src/token.ts
+++ b/src/token.ts
@@ -114,13 +114,14 @@ export const WORD: Token = {token: 'cs', str: '.word'};
 
 // Important operator tokens
 export const COLON: Token = {token: 'op', str: ':'};
-//export const DCOLON: Token = {token: 'op', str: '::'};
+export const DCOLON: Token = {token: 'op', str: '::'};
 export const COMMA: Token = {token: 'op', str: ','};
 /** Statement terminator in an ld65 linker config. We don't use this for asm */
 export const SEMI: Token = {token: 'op', str: ';'};
 export const STAR: Token = {token: 'op', str: '*'};
 export const IMMEDIATE: Token = {token: 'op', str: '#'};
 export const ASSIGN: Token = {token: 'op', str: '='};
+export const ASSIGN_LABEL: Token = {token: 'op', str: ':='};
 
 // CS -> CS token alias map
 export const CS_TOKEN_ALIAS_MAP = new Map([

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -17,11 +17,17 @@ const NEWLINE = /(\r\n|\n|\r)/y;
 const RE_COMMENT = /;.*/y;
 const RE_LINE_CONT = /\\(\r\n|\n|\r)/y;
 const RE_AT_IDENT = /@+[a-z0-9_]*/iy;
-const RE_IDENT = /((::)?[a-z_][a-z0-9_]*)+/iy;
+// Notably missing from the IDENT is the scope :: qualifier, since this
+// is actually treated as a separate token in ca65. We glue it back together
+// later in the preprocessor with mergeScopePrefix
+const RE_IDENT = /[a-z_][a-z0-9_]*/iy;
 const RE_CS = /\.[a-z][a-z0-9]*/iy;
+const RE_ADDR_SIZE = /[azf]:(?!:)/iy;
+/** Non-sticky as it tests a whole identifier, not a slice of the buffer. */
+const RE_REGISTER = /^[axy]$/i;
 const RE_LOCAL_LABEL = /:([+-]\d+|[-+]+|<+rts|>*rts)/y;
 const RE_NUMBER = /[$%]?[0-9a-z_]+/iy;
-const RE_OPERATOR = /(:=|:|\++|-+|&&?|\|\|?|[#*/,=~!^]|<[<>=]?|>[>=]?)/y;
+const RE_OPERATOR = /(::|:=|:|\++|-+|&&?|\|\|?|[#*/,=~!^]|<[<>=]?|>[>=]?)/y;
 const RE_STRING_START = /["']/y;
 const RE_UNICODE_ESC = /\\u([0-9a-f]{4})/iy;
 const RE_HEX_ESC = /\\x([0-9a-f]{2})/iy;
@@ -101,9 +107,9 @@ export class Tokenizer implements Tokens.Source {
   /** `%` is a binary literal prefix in ca65, but used for special `%O` and `%S` flags in linkercfg. */
   protected numberRegex(): RegExp { return RE_NUMBER; }
 
-  protected operatorRegex(): RegExp {
-    return RE_OPERATOR;
-  }
+  protected operatorRegex(): RegExp { return RE_OPERATOR; }
+  protected addressSizeRegex(): RegExp|undefined { return RE_ADDR_SIZE; }
+  protected registerRegex(): RegExp|undefined { return RE_REGISTER; }
 
   protected token(): Token {
     // skip whitespace
@@ -134,18 +140,21 @@ export class Tokenizer implements Tokens.Source {
 
   protected tokenInternal(): Token {
     if (this.buffer.newline()) return {token: 'eol'};
+    const addrSize = this.addressSizeRegex();
+    if (addrSize && this.buffer.token(addrSize)) {
+      return {token: 'op', str: this.buffer.group()!.toLowerCase()};
+    }
     if (this.buffer.token(RE_AT_IDENT) ||
         this.buffer.token(RE_IDENT)) {
-      return this.strTok('ident');
+      const tok = this.strTok('ident') as Tokens.StringToken;
+      // normalize the case for A/X/Y registers as they can be mixed Upper and lower case.
+      if (this.registerRegex()?.test(tok.str)) tok.str = tok.str.toLowerCase();
+      return tok;
     }
     if (this.buffer.token(RE_CS)) return this.csTok();
     if (this.buffer.token(RE_LOCAL_LABEL)) return this.strTok('ident');
     if (this.buffer.token(this.operatorRegex())) {
-      const op = this.strTok('op');
-      // the := is just like = but it marks it as a label in the dbg file.
-      // which we don't support so just treat it as = for now.
-      if ((op as Tokens.StringToken).str === ':=') return {token: 'op', str: '='};
-      return op;
+      return this.strTok('op');
     }
     if (this.buffer.tokenStr('[')) return {token: 'lb'};
     if (this.buffer.tokenStr('{')) return {token: 'lc'};

--- a/src/util.ts
+++ b/src/util.ts
@@ -519,3 +519,85 @@ export function joinDir(base: string, rel: string): string {
   }
   return root + out.join('/');
 }
+
+/**
+ * Basic wrapper for a Map that stores a cache of the largest key size.
+ * This is intended to be used for charmapping where we need to know what the
+ * largest key size is each time we are writing out a new character.
+ */
+export class MaxKeySizeCacheMap<K, V> {
+  private map: Map<K, V>;
+  private maxKey: K | undefined = undefined;
+  private maxKeySize: number = 0;
+
+  constructor(iterable?: Iterable<readonly [K, V]> | null) {
+    this.map = new Map(iterable);
+    if (iterable instanceof MaxKeySizeCacheMap) {
+      this.maxKey = iterable.getLargestKey();
+      this.maxKeySize = iterable.getLargestKeySize();
+    } else {
+      // Otherwise, evaluate the entries to find the initial maximum
+      this.recalculateMaxKey();
+    }
+  }
+
+  *[Symbol.iterator](): IterableIterator<readonly [K, V]> {
+    yield* this.map.entries();
+  }
+
+  public getLargestKey(): K | undefined { return this.maxKey; }
+
+  public getLargestKeySize(): number { return this.maxKeySize; }
+
+  get(key: K): V|undefined {
+    return this.map.get(key);
+  }
+
+  set(key: K, value: V): this {
+    this.map.set(key, value);
+    this.checkAndUpdateMax(key);
+    return this;
+  }
+
+  delete(key: K): boolean {
+    const wasDeleted = this.map.delete(key);
+    if (wasDeleted && Object.is(key, this.maxKey)) {
+      this.recalculateMaxKey();
+    }
+    return wasDeleted;
+  }
+
+  clear(): void {
+    this.map.clear();
+    this.maxKey = undefined;
+    this.maxKeySize = 0;
+  }
+
+  private checkAndUpdateMax(key: K): void {
+    const size = this.calculateSize(key);
+    if (size > this.maxKeySize) {
+      this.maxKeySize = size;
+      this.maxKey = key;
+    }
+  }
+
+  private recalculateMaxKey(): void {
+    let largestSize = 0;
+    let largestKey: K | undefined = undefined;
+
+    for (const key of this.map.keys()) {
+      const size = this.calculateSize(key);
+      if (size > largestSize) {
+        largestSize = size;
+        largestKey = key;
+      }
+    }
+
+    this.maxKeySize = largestSize;
+    this.maxKey = largestKey;
+  }
+
+  // We could set this up to support other non-string key types but
+  // this will be fine for our case. its not a big deal.
+  private calculateSize(key: K): number { return String(key).length; }
+}

--- a/test/define_test.ts
+++ b/test/define_test.ts
@@ -130,25 +130,25 @@ describe('Define', function() {
     });
 
     it('should not retain a pair of braces in a single arg', function() {
-      testExpand('.define foo(a, b) [a:b]',
+      testExpand('.define foo(p, b) [p:b]',
                  'foo({1}{2}, 3)',
                  '[{1}{2} : 3]');
     });
 
     it('should retain non-single-group braces', function() {
-      testExpand('.define foo(a, b) [a:b]',
+      testExpand('.define foo(p, b) [p:b]',
                  'foo({1} 2, 3)',
                  '[{1} 2 : 3]');
-      testExpand('.define foo(a, b) [a:b]',
+      testExpand('.define foo(p, b) [p:b]',
                  'foo {1} 2, 3',
                  '[{1} 2 : 3]'); 
-      testExpand('.define foo(a, b) [a:b]',
+      testExpand('.define foo(p, b) [p:b]',
                  'foo(1, {2} 3)',
                  '[1 : {2} 3]'); 
     });
 
     it('should fail on parenthesized calls with too many args', async function() {
-      const define = Define.from(await tok('.define foo(a, b) [a:b]'));
+      const define = Define.from(await tok('.define foo(p, b) [p:b]'));
       expect(define.expand(await tok('foo(1, 2, 3)'), 0)).toBeFalsy();
     });
 
@@ -163,72 +163,72 @@ describe('Define', function() {
 
   describe('with TeX-style argument list', function() {
     it('should capture empty last argument', function() {
-      testExpand('.define foo {a b c .eol} [a:b:c]',
+      testExpand('.define foo {p b c .eol} [p:b:c]',
                  'qux foo bar baz',
                  'qux [bar:baz:]');
     });
 
     it('should fail on empty undelimited argument', async function() {
-      const define = Define.from(await tok('.define foo {a b} [a:b]'));
+      const define = Define.from(await tok('.define foo {p b} [p:b]'));
       expect(define.expand(await tok('foo bar'), 0)).toBeFalsy();      
     });
 
     it('should fail on missing delimiter', async function() {
-      const define = Define.from(await tok('.define foo {a,b} [a:b]'));
+      const define = Define.from(await tok('.define foo {p,b} [p:b]'));
       expect(define.expand(await tok('foo bar baz qux'), 0)).toBeFalsy();      
     });
 
     it('should capture entire group for undelimited arg', function() {
-      testExpand('.define foo {a b c} [a:b:c]',
+      testExpand('.define foo {p b c} [p:b:c]',
                  'qux foo {bar baz} qux corge',
                  'qux [bar baz:qux:corge]');
     });
 
     it('should capture entire group for undelimited arg', function() {
-      testExpand('.define foo {a b c} [a:b:c]',
+      testExpand('.define foo {p b c} [p:b:c]',
                  'qux foo {bar baz} qux corge',
                  'qux [bar baz:qux:corge]');
     });
 
     it('should capture delimited arg', function() {
-      testExpand('.define foo {a,b,c} [a:b:c]',
+      testExpand('.define foo {p,b,c} [p:b:c]',
                  'qux foo bar baz, qux, corge',
                  'qux [bar baz:qux:corge]');
     });
 
     it('should retain braces for delimited arg', function() {
-      testExpand('.define foo {a,b,c} [a:b:c]',
+      testExpand('.define foo {p,b,c} [p:b:c]',
                  'qux foo {bar baz}, qux, corge',
                  'qux [{bar baz}:qux:corge]');
     });
 
     it('should skip param delimiter in braces', function() {
-      testExpand('.define foo {a,b,c} [a:b:c]',
+      testExpand('.define foo {p,b,c} [p:b:c]',
                  'qux foo {bar, baz}, qux, corge',
                  'qux [{bar, baz}:qux:corge]');
     });
 
     it('should not gobble to end of line if delimited at end', function() {
-      testExpand('.define foo {a,b,c,} [a:b:c]',
+      testExpand('.define foo {p,b,c,} [p:b:c]',
                  'qux foo bar, baz, qux, corge',
                  'qux [bar:baz:qux] corge');
     });
 
     it('should allow arbitrary tokens as delimiters', function() {
-      testExpand('.define foo {a .d b 1 c ]} [a:b:c]',
+      testExpand('.define foo {p .d b 1 c ]} [p:b:c]',
                  'qux foo bar .d baz 1 qux ] corge',
                  'qux [bar:baz:qux] corge');
     });
 
     it('should expand .eol', function() {
-      testExpand('.define foo {a b c} [a:b:c] .eol a:c .eol b',
+      testExpand('.define foo {p b c} [p:b:c] .eol p:c .eol b',
                  'qux foo bar baz qux',
                  'qux [bar:baz:qux]',
                  'bar:qux\nbaz'); // overflow
     });
 
     it('should not expand .eol if not at end of line', async function() {
-      const define = Define.from(await tok('.define foo {a b c} [a:b:c] .eol a:c'));
+      const define = Define.from(await tok('.define foo {p b c} [p:b:c] .eol p:c'));
       expect(define.expand(await tok('foo bar baz qux not_eol'), 0)).toBeFalsy();      
     });
   });

--- a/test/integration_test.ts
+++ b/test/integration_test.ts
@@ -858,6 +858,43 @@ FOO := 5
       expect(Array.from(result)).toEqual([5]);
     });
 
+    it('builds a scope chain out of `::` a segment at a time', async function() {
+      const source = `
+.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000
+.org $8000
+.scope L1
+  .scope L2
+    .scope L3
+      Val = $61
+    .endscope
+  .endscope
+.endscope
+.define Head L1
+.define Mid L2
+.define Tail L3
+.define Path L1::L2
+  .byte L1::L2::L3::Val
+  .byte ::L1::L2::L3::Val
+  .byte Head::Mid::Tail::Val
+  .byte Path::L3::Val
+  .byte L1::.ident("L2")::L3::Val
+`;
+      const result = await compileSource(source);
+      expect(Array.from(result)).toEqual([0x61, 0x61, 0x61, 0x61, 0x61]);
+    });
+
+    it('reads `::` after an opcode as the global scope, not a chain',
+       async function() {
+      const source = `
+.segment "CODE" :bank $00 :size $8000 :mem $8000 :off $0000
+.org $8000
+Target = $42
+  lda #::Target
+`;
+      const result = await compileSource(source);
+      expect(Array.from(result)).toEqual([0xa9, 0x42]);
+    });
+
     it('accepts zeropage as an alias for the zp segment attribute', async function() {
       const source = `
 .segment "ZP" :bank $00 :size $0100 :mem $0000 :off $0000 : zeropage

--- a/test/integration_test.ts
+++ b/test/integration_test.ts
@@ -492,7 +492,7 @@ TestLabel:
         {binIncludePaths: ['art']}, fs);
       expect(result.messages.filter(m => m.level === 'error')).toEqual([]);
       expect(result.success).toBe(true);
-      const mod = deserializeObjectFile(result.outputs[0].data);
+      const mod = await deserializeObjectFile(result.outputs[0].data);
       // The three bytes should land in one of the module's chunks.
       const found = (mod.chunks ?? []).some(c =>
         Array.from(c.data).join() === [0xAA, 0xBB, 0xCC].join());

--- a/test/validate_test.ts
+++ b/test/validate_test.ts
@@ -170,7 +170,7 @@ loop:
     );
     expect(out.success).toBe(true);
 
-    const chunk = deserializeObjectFile(out.outputs[0].data).chunks![0];
+    const chunk = (await deserializeObjectFile(out.outputs[0].data)).chunks![0];
     expect(chunk.labelIndex).toBeInstanceOf(Map);
     expect(chunk.labelIndex!.get('start')).toBe(0);
     expect(chunk.labelIndex!.get('loop')).toBe(2);
@@ -196,12 +196,12 @@ start:
     const o = out.outputs[0].data;
     expect(isGzip(o)).toBe(true);
 
-    const linked = link([deserializeObjectFile(o)], {}, 'binary');
+    const linked = link([await deserializeObjectFile(o)], {}, 'binary');
     expect(linked.success).toBe(true);
     expect(Array.from(linked.data)).toEqual([0xa9, 0x01, 0x8d, 0x00, 0x20, 0x60]);
   });
 
-  it('round-trips a module handed over in-process with real Maps', () => {
+  it('round-trips a module handed over in-process with real Maps', async () => {
     const m: Module = {
       name: 'inproc',
       chunks: [{
@@ -210,23 +210,23 @@ start:
         sourceMap: new Map([[0, { file: 'a.s', line: 1, column: 0 }]]),
       }],
     };
-    const chunk = deserializeObjectFile(serializeObjectFile(m)).chunks![0];
+    const chunk = (await deserializeObjectFile(await serializeObjectFile(m))).chunks![0];
     expect(chunk.labelIndex!.get('here')).toBe(0);
     expect(chunk.sourceMap!.get(0)).toEqual({ file: 'a.s', line: 1, column: 0 });
   });
 
-  it('reports a useful error for a corrupt .o', () => {
-    const truncated = serializeObjectFile({ name: 'm' }).slice(0, 8);
-    expect(() => deserializeObjectFile(truncated, 'bad.o')).toThrow(/bad\.o: could not decompress/);
+  it('reports a useful error for a corrupt .o', async () => {
+    const truncated = (await serializeObjectFile({ name: 'm' })).slice(0, 8);
+    expect(async () => await deserializeObjectFile(truncated, 'bad.o')).toThrow(/bad\.o: could not decompress/);
 
     // Well-formed gzip, but the payload is not a module.
     const notAModule = gzipSync(strToU8('{"chunks":[{}]}'));
-    expect(() => deserializeObjectFile(notAModule, 'bad.o'))
+    expect(async () => await deserializeObjectFile(notAModule, 'bad.o'))
       .toThrow(/bad\.o: not a valid object file: module\.chunks\[0\]\.data/);
 
     // Plain JSON is no longer an accepted object file.
     expect(isGzip(new TextEncoder().encode('{"name":"m"}'))).toBe(false);
-    expect(() => deserializeObjectFile(new TextEncoder().encode('{"name":"m"}'), 'plain.o'))
+    expect(async () => await deserializeObjectFile(new TextEncoder().encode('{"name":"m"}'), 'plain.o'))
       .toThrow(/plain\.o: could not decompress/);
   });
 


### PR DESCRIPTION
I started trying to tackle building a ca65 source called `smbdisHL` which is a super macro heavy project that pushes the limits of what the ca65 preprocessor can do, and I ran into several small discrepencies with js65 macros vs ca65. This change resolves all of the ones I found there, things like needing to support chunk relative math like `* - Label` and so on.

This also comes with some small performance patches that were showing up in my profile in bun and hermes. 