### PR TITLE
Anonymous Segments

### DIFF
--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -385,11 +385,14 @@ export class Assembler {
 
   private generateAnonSegmentName(memory: number, size: number): string {
     // reuse _segmentOffset for a count of segments used in this file to help make the hash unique.
-    const file = this.opts.moduleName ?? this._source?.file ?? '';
-    const input = [file, String(this._segmentOffset++),
+    // Prefer the tokenizer's file name over the module name
+    // For an `.include`d file that's the file the user actually wrote the `.segment` in.
+    const file = this._source?.file ?? this.opts.moduleName ?? '';
+    const line = this._source?.line;
+    const input = [file, String(line ?? ''), String(this._segmentOffset++),
                    String(memory), String(size)].join('\0');
     const hash = createHash().update(input).digest('hex').slice(0, 12);
-    return `${mod.ANON_SEGMENT_PREFIX}${hash}`;
+    return mod.anonSegmentName(file, line, hash);
   }
 
   /** Sets the current source location for debug info from an external source. */
@@ -1546,6 +1549,11 @@ export class Assembler {
     }
     this._chunk = undefined;
     this._name = undefined;
+    // An anonymous segment's positional address doubles as an implicit `.org`
+    if (segments.length === 1 && typeof segments[0] === 'object' &&
+        mod.Segment.isAnon(segments[0]) && segments[0].memory != null) {
+      this._org = segments[0].memory;
+    }
   }
 
   assert(expr: Expr, _level?: string, message?: string) {

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -11,6 +11,7 @@ import { type Token } from './token.ts'
 import * as Tokens from './token.ts';
 import { Tokenizer } from './tokenizer.ts';
 import { IntervalSet, assertNever, MaxKeySizeCacheMap } from './util.ts';
+import { createHash } from 'sha1-uint8array';
 
 // These used to be declared here; keep them exported from this module so
 // existing importers (including tests) don't have to change.
@@ -42,6 +43,23 @@ function isSizeOfSymbol(name: string): boolean {
  */
 const PREDECLARED_SEGMENTS = new Map<string, mod.Segment>([
   ['ZEROPAGE', {name: 'ZEROPAGE', addressing: 1}],
+]);
+
+const ANON_SEGMENT_ATTR_REASONS = new Map<string, string>([
+  ['off', `output offset is determined by the position in the file`],
+  ['mem', `PC address is determined by the segment value`],
+  ['out', `it always goes to the main output file`],
+  ['load', ''],
+  ['run', ''],
+  ['alignload', ''],
+  ['zp', `cannot write to a ram segment`],
+  ['zeropage', `cannot write to a ram segment`],
+  ['bss', `cannot write to a ram segment`],
+  ['optional', ''],
+  ['dedupe', ''],
+  ['default', `cannot write to a default segment`],
+  ['align', `a segment starts where the previous one ended. Use .align instead`],
+  ['define', ''],
 ]);
 
 /**
@@ -360,7 +378,19 @@ export class Assembler {
    */
   private _segmentOffset = 0;
 
+  /** Returns an early error in assembling if you mix segment modes */
+  private _segmentMode?: 'named'|'anon';
+
   constructor(readonly cpu = Cpu.P02, readonly opts: Options = {}) {}
+
+  private generateAnonSegmentName(memory: number, size: number): string {
+    // reuse _segmentOffset for a count of segments used in this file to help make the hash unique.
+    const file = this.opts.moduleName ?? this._source?.file ?? '';
+    const input = [file, String(this._segmentOffset++),
+                   String(memory), String(size)].join('\0');
+    const hash = createHash().update(input).digest('hex').slice(0, 12);
+    return `${mod.ANON_SEGMENT_PREFIX}${hash}`;
+  }
 
   /** Sets the current source location for debug info from an external source. */
   setSource(source?: Tokens.SourceInfo) {
@@ -863,6 +893,7 @@ export class Assembler {
       if (symbol.export != null) out.export = symbol.export;
       symbols.push(out);
     }
+    // declaration order is important here because anon segments define their output in order
     const segments: mod.Segment[] = [...this.segmentData.values()];
 
     // Collect all symbols from all scopes for debug purposes
@@ -1481,8 +1512,22 @@ export class Assembler {
     this._name = name;
   }
 
+  private setSegmentMode(mode: 'named'|'anon', at?: Token) {
+    if (this._segmentMode && this._segmentMode !== mode) {
+      this.fail(mode === 'anon'
+          ? `Cannot use an anonymous .segment after a named .segment; ` +
+            `a module uses one style or the other`
+          : `Cannot use a named .segment after an anonymous .segment; ` +
+            `a module uses one style or the other`, at);
+    }
+    this._segmentMode = mode;
+  }
+
   segment(...segments: Array<string|mod.Segment>) {
     // Usage: .segment "1a", "1b", ...
+    for (const s of segments) {
+      this.setSegmentMode(mod.Segment.isAnon(s) ? 'anon' : 'named');
+    }
     // A trailing `.align` belongs to the segment it appeared in, so pad it out
     // here rather than letting it leak onto the next segment's chunk.
     this.flushPendingAlign();
@@ -1982,6 +2027,7 @@ export class Assembler {
   }
 
   pushSeg(...segments: Array<string|mod.Segment>) {
+    this.preventInvalidAnonSegChange('.pushseg');
     this.flushPendingAlign();
     this.segmentStack.push([this.segments, this._chunk]);
     // If pushseg was called without any segments, just keep the current segment
@@ -1991,10 +2037,18 @@ export class Assembler {
   }
 
   popSeg() {
+    this.preventInvalidAnonSegChange('.popseg');
     if (!this.segmentStack.length) this.fail(`.popseg without .pushseg`);
     this.flushPendingAlign();
     [this.segments, this._chunk] = this.segmentStack.pop()!;
     this._org = this._chunk?.org;
+  }
+
+  private preventInvalidAnonSegChange(directive: string) {
+    if (this._segmentMode === 'anon') {
+      this.fail(`${directive} cannot be used with anonymous segments; ` +
+                `they are sequential file positions, not a stack`);
+    }
   }
 
   setCpu(name: string) {
@@ -2112,8 +2166,16 @@ export class Assembler {
       }
       this.fail(`Expected a segment list`, tokens[start - 1]);
     }
-    return Tokens.parseArgList(tokens, 1).map(ts => {
+    return Tokens.parseArgList(tokens, 1).map((ts, _i, all) => {
+      // `.segment $8000 :size $4000` - an address rather than a name.
+      if (ts[0]?.token === 'num') return this.parseAnonSegment(ts, all.length);
       const str = this._segmentPrefix + Tokens.expectString(ts[0]);
+      // Check the composed name so `.segmentprefix "@"` can't smuggle one in.
+      if (str.startsWith(mod.RESERVED_SEGMENT_PREFIX)) {
+        this.fail(
+            `Segment name may not start with '${mod.RESERVED_SEGMENT_PREFIX}', which is reserved: ${str}`,
+            ts[0]);
+      }
       if (ts.length === 1) return str;
       if (!Tokens.eq(ts[1], Tokens.COLON)) {
         this.fail(`Expected comma or colon: ${Tokens.name(ts[1])}`, ts[1]);
@@ -2157,6 +2219,59 @@ export class Assembler {
       }
       return seg;
     });
+  }
+
+  /**
+   * Parses an anonymous segment: `.segment $8000 :size $4000 [:fill <$ff>]`.
+   *
+   * The positional address is the segment's `memory`. There is deliberately no
+   * `offset` parameter. Anonymous segments are laid out sequentially by the
+   * linker in module-read order.
+   */
+  parseAnonSegment(ts: Token[], argCount: number): mod.Segment {
+    if (argCount > 1) {
+      this.fail(`An anonymous .segment may not appear in a comma-separated list`,
+                ts[0]);
+    }
+    const colon = Tokens.find(ts, Tokens.COLON, 0);
+    if (colon < 0) {
+      this.fail(`An anonymous .segment requires :size`, ts[0]);
+    }
+    // allow math expressions in the PC address
+    const memory = this.parseConst(ts.slice(0, colon), 0);
+
+    let size: number|undefined;
+    let fill: number|undefined;
+    let bank: number|undefined;
+    for (const [key, val] of Tokens.parseAttrList(ts, colon)) {
+      const rejected = ANON_SEGMENT_ATTR_REASONS.get(key);
+      if (rejected != null) {
+        this.fail(`Segment attr ${key} is not allowed on an anonymous .segment` +
+                  (rejected ? `: ${rejected}` : ''), ts[0]);
+      }
+      switch (key) {
+        case 'size': size = this.parseConst(val, 0); break;
+        // `:fill` with no value fills with zeros, like ld65's `fill = yes`.
+        case 'fill': fill = val.length ? this.parseConst(val, 0) : 0; break;
+        // Pure metadata, for `^` bank-byte exprs and LinkSegment.bank.
+        case 'bank': bank = this.parseConst(val, 0); break;
+        // js65 has no read-only concept, so accept and ignore ld65's types.
+        case 'ro': case 'rw': break;
+        default: this.fail(`Unknown segment attr: ${key}`, ts[0]);
+      }
+    }
+    if (size === undefined) {
+      this.fail(`An anonymous .segment requires :size`, ts[0]);
+    }
+
+    const seg: mod.Segment = {name: this.generateAnonSegmentName(memory, size), memory, size};
+    if (bank !== undefined) seg.bank = bank;
+    if (fill !== undefined) {
+      seg.fill = fill;
+      seg.free = [[memory, memory + size]];
+    }
+
+    return seg;
   }
 
   parseResArgs(tokens: Token[]): [number, number?] {
@@ -2359,6 +2474,7 @@ export interface Options {
   overwriteMode?: mod.OverwriteMode;
   refExtractor?: RefExtractor;
   generateDebugInfo?: boolean;
+  moduleName?: string;
 }
 
 

--- a/src/libassembler.ts
+++ b/src/libassembler.ts
@@ -249,8 +249,9 @@ export async function assemble(
       }
 
       if (input.type === 'actions') {
-        const asm = currentAssembler = new Assembler(Cpu.P02, asmOpts);
         let module_name = input.name ?? `module_${i}`;
+        const asm = currentAssembler =
+            new Assembler(Cpu.P02, {...asmOpts, moduleName: module_name});
         const original_module_name = module_name;
 
         for (const action of input.actions) {
@@ -396,7 +397,8 @@ export async function assemble(
       }
 
       // Process source code
-      const asm = currentAssembler = new Assembler(Cpu.P02, asmOpts);
+      const asm = currentAssembler =
+          new Assembler(Cpu.P02, {...asmOpts, moduleName: input.name});
       const toks = new TokenStream(
         callbacks?.readText,
         callbacks?.readBinary,

--- a/src/linker.ts
+++ b/src/linker.ts
@@ -89,11 +89,13 @@ export class Linker {
     // I don't think its worth trying to sort out using both for now.
     // Maybe at some point we start issuing warnings if they mix the two.
     if (this.opts.linkerConfig != null) {
+      this._link.checkAnonMode('A linker config');
       this._link.setConfig(parseLinkerConfig(this.opts.linkerConfig,
                                              this.opts.linkerConfigName));
     } else {
       const target = Targets.get(this.opts.target?.toLowerCase())
       if (target) {
+        this._link.checkAnonMode(`--target ${this.opts.target}`);
         target.segments.forEach( seg => this._link.addRawSegment(seg) );
       }
     }
@@ -545,6 +547,14 @@ function impossible(msg: string): never {
   throw new Error(msg);
 }
 
+/** User friendly string name for anon segments */
+function anonSegmentLabel(name: string, memory: number): string {
+  const src = Segment.anonSource(name);
+  if (!src) return name;
+  const at = src.line != null ? `${src.file}:${src.line}` : src.file;
+  return `@${at} $${memory.toString(16)}`;
+}
+
 /** Rounds up to the next multiple of `align`, which must be positive. */
 function alignUp(value: number, align: number): number {
   // NOTE: arithmetic rather than bit twiddling, since offsets in RAM segments
@@ -797,6 +807,14 @@ class LinkChunk {
       }
     }
     if (eligibleSegments.length !== 1) {
+      // If the user is in an anon segment but then `.org`s outside of that range
+      if (!eligibleSegments.length && this.segments.length === 1 &&
+          Segment.isAnon(this.segments[0])) {
+        const s = this.linker.segments.get(this.segments[0])!;
+        this.linker.fail(`.org $${this._org.toString(16)} is outside the ${''
+            }anonymous segment ${anonSegmentLabel(s.name, s.memory)} ${''
+            }(size $${s.size.toString(16)})`, this.at());
+      }
       this.linker.fail(`Non-unique segment for ${this.name}:\n${''
           }Segments: ${this.segments.join(',')}, ${''
           }org: $${this.org?.toString(16)}, ${''
@@ -1050,6 +1068,10 @@ class Link {
    * order they are passed into the link command)
    */
   segmentOrder: string[] = [];
+  /** Linker ordering for anon segments. Ordered by files passed in, then top to bottom of each file. */
+  private anonDeclarationOrder: string[] = [];
+  /** True once any named (non-anonymous) segment has been registered. */
+  private hasNamedSegment = false;
   private segmentIndex = new Map<string, number>();
   /** Names of mapped segments that other unmapped segments are written to. */
   private segmentMappings = new Set<string>();
@@ -1202,6 +1224,8 @@ class Link {
   }
 
   link(signal?: { readonly aborted: boolean }): SparseByteArray {
+    // Catch a cross-module named/anon mix before any state is half-built.
+    this.checkAnonMode();
     // Preserve the order that the segments are declared
     for (const name of [...this.segmentOrder, ...this.rawSegments.keys()]) {
       if (this.segmentIndex.has(name)) continue;
@@ -1564,9 +1588,9 @@ class Link {
       const seg = merged.get(name);
       // Skip over unmapped segments here.
       if (!seg || needsLowering(seg) || seg.bss) continue;
-      // Any anything without an output file nor an offset.
-      // These are RAM, which takes no file space.
-      if (seg.out == null && seg.offset == null) continue;
+      // Skip things that aren't getting written out to the file.
+      // Anon segments ARE written to file, and will get :out assigned after this.
+      if (!Segment.isAnon(seg) && seg.out == null && seg.offset == null) continue;
       const file = seg.out || '%O';
       const base = this.fileBase(file);
       let cursor = fileLocations.get(file) ?? 0;
@@ -1769,7 +1793,8 @@ class Link {
    */
   eligibleSegments(chunk: LinkChunk): readonly string[] {
     let segments = chunk.segments;
-    if (!segments.length) {
+    // Don't allow default segment bytes to get placed when anon segments are used.
+    if (!segments.length && !this.anonDeclarationOrder.length) {
       // if this chunk doesn't have a predefined segment, and there is a default segment defined, then use that one
       for (const [name, raw] of this.rawSegments) {
         if (raw.some(s => s.default)) {
@@ -1840,8 +1865,13 @@ class Link {
     }
     if (DEBUG) console.log(`Initial:\n${this.initialReport}`);
     const name = chunk.name ? `${chunk.name} ` : '';
-    const where = segments.length ? segments.join(', ') : '(no segment)';
     const aligned = align > 1 ? `${align}-byte aligned ` : '';
+    if (!segments.length && this.anonDeclarationOrder.length) {
+      this.fail(`${size}-byte chunk ${name}was emitted before the first ` +
+                `.segment. All bytes must be placed in a segment`, chunk.at());
+    }
+    const where = segments.length ?
+        segments.map(n => this.segmentLabel(n)).join(', ') : '(no segment)';
     this.fail(`Could not find space for ${aligned}${size}-byte chunk ${
         name}in ${where}`, chunk.at());
   }
@@ -1928,9 +1958,28 @@ class Link {
   }
 
   addRawSegment(segment: Segment) {
+    if (Segment.isAnon(segment)) {
+      if (this.rawSegments.has(segment.name)) {
+        // Merging them would silently fuse two banks into one, since
+        // Segment.merge is last-wins.
+        this.fail(`Duplicate anonymous segment ${segment.name}; ` +
+                  `this is a js65 bug, please report it`);
+      }
+      this.anonDeclarationOrder.push(segment.name);
+    } else {
+      this.hasNamedSegment = true;
+    }
     let list = this.rawSegments.get(segment.name);
     if (!list) this.rawSegments.set(segment.name, list = []);
     list.push(segment);
+  }
+
+  checkAnonMode(what?: string) {
+    if (!this.anonDeclarationOrder.length) return;
+    if (what) this.fail(`${what} cannot be combined with anonymous segments`);
+    if (this.hasNamedSegment) {
+      this.fail(`Anonymous segments cannot be combined with named segments.`);
+    }
   }
 
   buildExports(): Map<string, Export> {
@@ -1952,6 +2001,12 @@ class Link {
     return map;
   }
 
+  private segmentLabel(name: string): string {
+    if (!Segment.isAnon(name)) return name;
+    const memory = this.segments.get(name)?.memory ?? 0;
+    return anonSegmentLabel(name, memory);
+  }
+
   /**
    * Bare bones segment list report used for comparing against ca65 built projects.
    */
@@ -1968,18 +2023,21 @@ class Link {
       const end = chunk.org + chunk.size - seg.memory;
       used.set(seg.name, Math.max(used.get(seg.name) ?? 0, end));
     }
+    // Chop the name of the anon segment to 20 characters so it fits nicer in the output
+    const rows = this.segmentOrder.filter(n => this.segments.has(n))
+        .map(n => [n, this.segmentLabel(n)] as const);
+    const width = Math.max(20, ...rows.map(([, label]) => label.length));
     let out = 'Segment list:\n-------------\n';
-    out += 'Name                   Start     End    Size    Used  Align  FileOffs  File\n';
-    out += '----------------------------------------------------------------------------\n';
-    for (const name of this.segmentOrder) {
-      const s = this.segments.get(name);
-      if (!s) continue;
+    out += `${'Name'.padEnd(width)}   Start     End    Size    Used  Align  FileOffs  File\n`;
+    out += '-'.repeat(width + 56) + '\n';
+    for (const [name, label] of rows) {
+      const s = this.segments.get(name)!;
       const end = s.memory + Math.max(s.size - 1, 0);
       // A segment that emits nothing has no offset worth printing.
       const file = s.isRam ? '' : (s.out || '%O');
       const offs = s.isRam ?
           '      ' : hex(s.offset - (this.fileBases.get(file) ?? 0));
-      out += `${name.padEnd(20)}  ${hex(s.memory)}  ${hex(end)}  ${
+      out += `${label.padEnd(width)}  ${hex(s.memory)}  ${hex(end)}  ${
              hex(s.size)}  ${hex(used.get(name) ?? 0)}  ${
              hex(this.segmentAlign.get(name) ?? 1, 5)}  ${offs}  ${file}\n`;
     }

--- a/src/module.ts
+++ b/src/module.ts
@@ -131,10 +131,37 @@ export const RESERVED_SEGMENT_PREFIX = '@';
 
 export const ANON_SEGMENT_PREFIX = '@anon@';
 
+/** Where an anonymous segment was declared, recovered from its name. */
+export interface AnonSegmentSource {
+  file: string;
+  /** Undefined when the module was assembled without debug info. */
+  line?: number;
+}
+
+export function anonSegmentName(file: string, line: number|undefined,
+                                hash: string): string {
+  return `${ANON_SEGMENT_PREFIX}${file}:${line ?? ''}:${hash}`;
+}
+
 // deno-lint-ignore no-namespace
 export namespace Segment {
   export function isAnon(s: Segment|string): boolean {
     return (typeof s === 'string' ? s : s.name).startsWith(ANON_SEGMENT_PREFIX);
+  }
+  /** Parses the anonSegmentName into a file:line pair for slightly better error reporting */
+  export function anonSource(s: Segment|string): AnonSegmentSource|undefined {
+    const name = typeof s === 'string' ? s : s.name;
+    if (!isAnon(name)) return undefined;
+    const body = name.substring(ANON_SEGMENT_PREFIX.length);
+    const hashAt = body.lastIndexOf(':');
+    if (hashAt < 0) return undefined;
+    const lineAt = body.lastIndexOf(':', hashAt - 1);
+    if (lineAt < 0) return undefined;
+    const file = body.substring(0, lineAt);
+    const lineStr = body.substring(lineAt + 1, hashAt);
+    if (!file) return undefined;
+    if (lineStr && !/^\d+$/.test(lineStr)) return undefined;
+    return {file, line: lineStr ? Number(lineStr) : undefined};
   }
   export function merge(a: Segment, b: Segment): Segment {
     const seg = {...a, ...b};

--- a/src/module.ts
+++ b/src/module.ts
@@ -127,8 +127,15 @@ export interface Segment {
   free?: number[][];
 }
 
+export const RESERVED_SEGMENT_PREFIX = '@';
+
+export const ANON_SEGMENT_PREFIX = '@anon@';
+
 // deno-lint-ignore no-namespace
 export namespace Segment {
+  export function isAnon(s: Segment|string): boolean {
+    return (typeof s === 'string' ? s : s.name).startsWith(ANON_SEGMENT_PREFIX);
+  }
   export function merge(a: Segment, b: Segment): Segment {
     const seg = {...a, ...b};
     const free = [...(a.free || []), ...(b.free || [])];

--- a/test/assembler_test.ts
+++ b/test/assembler_test.ts
@@ -1312,6 +1312,218 @@ describe('Assembler', function() {
     });
   });
 
+  describe('anonymous .segment', function() {
+    // Assembles under a caller-chosen module name, since that name seeds the
+    // generated segment-name hash.
+    async function assembleNamed(body: string, name: string,
+                                 generateDebugInfo = false): Promise<Module> {
+      const result = await libAssemble(
+          [{type: 'source', code: body, name} as AssemblyInput],
+          {generateDebugInfo});
+      if (!result.success) throw new Error(JSON.stringify(result.messages));
+      return result.modules[0];
+    }
+
+    // @anon@<file>:<line>:<hash>. The line is empty without debug info, which
+    // is how `assembleModule` runs.
+    const ANON = /^@anon@[^\0]+:\d*:[0-9a-f]{12}$/;
+
+    it('should take the address positionally and require :size', async function() {
+      const m = await assembleModule(`.segment $8000 :size $4000\n`);
+      expect(m.segments!.length).toBe(1);
+      const [seg] = m.segments!;
+      expect(seg.name).toMatch(ANON);
+      expect(seg.memory).toBe(0x8000);
+      expect(seg.size).toBe(0x4000);
+      // The linker hands out file offsets, so the module must not carry one.
+      expect(seg.offset).toBeUndefined();
+    });
+
+    it('should carry the file and line in the name', async function() {
+      const m = await assembleNamed(
+          `\n\n.segment $8000 :size $10\n`, 'bank.s', true);
+      expect(m.segments![0].name).toMatch(/^@anon@bank\.s:3:[0-9a-f]{12}$/);
+    });
+
+    it('should leave the line empty without debug info', async function() {
+      const m = await assembleNamed(`.segment $8000 :size $10\n`, 'bank.s');
+      expect(m.segments![0].name).toMatch(/^@anon@bank\.s::[0-9a-f]{12}$/);
+    });
+
+    it('should distinguish two segments on different lines', async function() {
+      // The line is part of the hash, so identical declarations still differ.
+      const m = await assembleNamed(
+          `.segment $8000 :size $10\n.segment $8000 :size $10\n`, 'bank.s', true);
+      expect(m.segments![0].name).toMatch(/^@anon@bank\.s:1:/);
+      expect(m.segments![1].name).toMatch(/^@anon@bank\.s:2:/);
+    });
+
+    it('should generate the same name for the same source twice', async function() {
+      const src = `.segment $8000 :size $4000\n.segment $c000 :size $4000\n`;
+      const a = await assembleModule(src);
+      const b = await assembleModule(src);
+      expect(a.segments!.map(s => s.name)).toEqual(b.segments!.map(s => s.name));
+    });
+
+    it('should generate distinct names for two segments in one module',
+       async function() {
+      const m = await assembleModule(
+          `.segment $8000 :size $4000\n.segment $8000 :size $4000\n`);
+      // Same address and size: only the sequence number distinguishes them.
+      expect(m.segments!.length).toBe(2);
+      expect(m.segments![0].name).not.toBe(m.segments![1].name);
+    });
+
+    it('should generate distinct names for the same source at two paths',
+       async function() {
+      const src = `.segment $8000 :size $4000\n`;
+      const a = await assembleNamed(src, 'a.s');
+      const b = await assembleNamed(src, 'b.s');
+      expect(a.segments![0].name).not.toBe(b.segments![0].name);
+    });
+
+    it('should synthesize a free range for :fill', async function() {
+      const m = await assembleModule(`.segment $8000 :size $4000 :fill $ff\n`);
+      expect(m.segments![0].fill).toBe(0xff);
+      expect(m.segments![0].free).toEqual([[0x8000, 0xc000]]);
+    });
+
+    it('should evaluate the address as an expression', async function() {
+      const m = await assembleModule(`.segment $8000+16 :size $10\n`);
+      expect(m.segments![0].memory).toBe(0x8010);
+    });
+
+    it('should accept :bank as metadata', async function() {
+      const m = await assembleModule(`.segment $8000 :size $10 :bank 3\n`);
+      expect(m.segments![0].bank).toBe(3);
+    });
+
+    it('should ignore ld65 read-only attributes', async function() {
+      const m = await assembleModule(`.segment $8000 :size $10 :ro\n`);
+      expect(m.segments![0]).toEqual(
+          {name: m.segments![0].name, memory: 0x8000, size: 0x10});
+    });
+
+    it('should bind following data to the generated segment', async function() {
+      const m = await assembleModule(`.segment $8000 :size $10\n.byte 1\n`);
+      expect(m.chunks![0].segments).toEqual([m.segments![0].name]);
+    });
+
+    it('should imply .org at the declared address', async function() {
+      // The address is part of the segment, so no explicit `.org` is needed.
+      const m = await assembleModule(`.segment $8000 :size $10\n.byte 1\n`);
+      expect(m.chunks![0].org).toBe(0x8000);
+    });
+
+    it('should re-imply .org for each anonymous segment', async function() {
+      const m = await assembleModule(
+          `.segment $8000 :size $10\n.byte 1\n` +
+          `.segment $9000 :size $10\n.byte 2\n`);
+      expect(m.chunks!.map(c => c.org)).toEqual([0x8000, 0x9000]);
+    });
+
+    it('should resolve labels against the implied .org', async function() {
+      const m = await assembleModule(
+          `.segment $8000 :size $10\nStart:\n  .byte 1\n  .word Start\n`);
+      expect(m.chunks![0].org).toBe(0x8000);
+      expect([...m.chunks![0].data]).toEqual([1, 0x00, 0x80]);
+    });
+
+    it('should let an explicit .org move within the segment', async function() {
+      const m = await assembleModule(
+          `.segment $8000 :size $100\n.byte 1\n.org $8040\n.byte 2\n`);
+      expect(m.chunks!.map(c => c.org)).toEqual([0x8000, 0x8040]);
+    });
+
+    it('should let .reloc drop the implied .org', async function() {
+      const m = await assembleModule(
+          `.segment $8000 :size $100\n.reloc\n.byte 1\n`);
+      expect(m.chunks![0].org).toBeUndefined();
+    });
+
+    it('should let .free carve a range out of the segment', async function() {
+      // `.free` needs a PC, which the segment's implied `.org` supplies.
+      const m = await assembleModule(
+          `.segment $8000 :size $100\n.byte 1\n.free $20\n`);
+      expect(m.segments![0].free).toEqual([[0x8001, 0x8021]]);
+    });
+
+    it('should reject a missing :size', async function() {
+      await expect(assembleModule(`.segment $8000\n`))
+          .rejects.toThrow(/An anonymous \.segment requires :size/);
+      await expect(assembleModule(`.segment $8000 :fill $ff\n`))
+          .rejects.toThrow(/An anonymous \.segment requires :size/);
+    });
+
+    it('should reject a comma-separated list', async function() {
+      await expect(assembleModule(
+              `.segment $8000 :size $10, $9000 :size $10\n`))
+          .rejects.toThrow(
+              /anonymous \.segment may not appear in a comma-separated list/);
+    });
+
+    for (const attr of ['off $0', 'mem $8000', 'out "x.bin"', 'load "A"',
+                        'run "A"', 'alignload $10', 'zp', 'zeropage', 'bss',
+                        'optional', 'dedupe', 'default', 'align $10',
+                        'define']) {
+      const key = attr.split(' ')[0];
+      it(`should reject :${key}`, async function() {
+        await expect(assembleModule(`.segment $8000 :size $10 :${attr}\n`))
+            .rejects.toThrow(new RegExp(
+                `Segment attr ${key} is not allowed on an anonymous \\.segment`));
+      });
+    }
+
+    it('should reject an unknown segment attribute', async function() {
+      await expect(assembleModule(`.segment $8000 :size $10 :overlay "A"\n`))
+          .rejects.toThrow(/Unknown segment attr: overlay/);
+    });
+
+    it('should reject an anonymous segment after a named one', async function() {
+      await expect(assembleModule(
+              `.segment "A" :size $10\n.segment $8000 :size $10\n`))
+          .rejects.toThrow(
+              /Cannot use an anonymous \.segment after a named \.segment/);
+    });
+
+    it('should reject a named segment after an anonymous one', async function() {
+      await expect(assembleModule(
+              `.segment $8000 :size $10\n.segment "A" :size $10\n`))
+          .rejects.toThrow(
+              /Cannot use a named \.segment after an anonymous \.segment/);
+    });
+
+    it('should reject an anonymous segment after .code', async function() {
+      // `.code` bypasses parseSegmentList entirely, so this pins the latch
+      // living in segment() rather than in the parser.
+      await expect(assembleModule(`.code\n.segment $8000 :size $10\n`))
+          .rejects.toThrow(
+              /Cannot use an anonymous \.segment after a named \.segment/);
+    });
+
+    it('should reject .pushseg in anonymous mode', async function() {
+      await expect(assembleModule(`.segment $8000 :size $10\n.pushseg\n`))
+          .rejects.toThrow(/\.pushseg cannot be used with anonymous segments/);
+    });
+
+    it('should reject .popseg in anonymous mode', async function() {
+      await expect(assembleModule(
+              `.segment $8000 :size $10\n.popseg\n`))
+          .rejects.toThrow(/\.popseg cannot be used with anonymous segments/);
+    });
+
+    it('should reject a user segment name starting with @', async function() {
+      await expect(assembleModule(`.segment "@foo"\n`))
+          .rejects.toThrow(/Segment name may not start with '@'/);
+    });
+
+    it('should reject an @ segment prefix', async function() {
+      // The check is on the composed name, so a prefix can't smuggle one in.
+      await expect(assembleModule(`.segmentprefix "@"\n.segment "x"\n`))
+          .rejects.toThrow(/Segment name may not start with '@'.*@x/);
+    });
+  });
+
   describe('predeclared ZEROPAGE segment', function() {
     function chunkIn(m: Module, segment: string) {
       const chunk = (m.chunks ?? []).find(c => c.segments.includes(segment));

--- a/test/cli_test.ts
+++ b/test/cli_test.ts
@@ -390,6 +390,65 @@ describe('CLI', function() {
       return written;
     }
   });
+
+  describe('anonymous segments', function() {
+    const source = `
+.segment $8000 :size $10
+Start:
+  lda #$42
+  rts
+
+.segment $9000 :size $10
+  jsr Start
+  rts
+`;
+
+    it('should survive the .o round trip', async function() {
+      // Anon-ness lives in the segment name, so this also confirms nothing in
+      // the gzip + JSON + validate round trip strips the reserved prefix.
+      const objs = await run({'main.s': source},
+                             ['-c', '-o', 'main.o', 'main.s']);
+      const obj = objs.get('main.o');
+      expect(obj).toBeTruthy();
+
+      const linked = await run({'main.o': obj!}, ['-o', 'out.bin', 'main.o']);
+      const oneStep = await run({'main.s': source},
+                                ['-o', 'out.bin', 'main.s']);
+      expect([...linked.get('out.bin')!]).toEqual([...oneStep.get('out.bin')!]);
+      // Sanity check the layout actually made it through.
+      expect([...oneStep.get('out.bin')!.slice(0, 3)]).toEqual([0xa9, 0x42, 0x60]);
+      expect([...oneStep.get('out.bin')!.slice(0x10, 0x14)])
+          .toEqual([0x20, 0x00, 0x80, 0x60]);
+    });
+
+    /** Runs the CLI over an in-memory filesystem keyed by filename. */
+    async function run(fs: Record<string, string|Uint8Array>, args: string[]) {
+      const written = new Map<string, Uint8Array>();
+      let exitCode = 0;
+      const get = (filename: string) => {
+        const f = fs[filename] ?? fs[joinDir('', filename)];
+        if (f == null) throw new Error(`no such file: ${filename}`);
+        return f;
+      };
+      const cli = new Cli({
+        fsReadString: async (_path, filename) => {
+          const f = get(filename);
+          return typeof f === 'string' ? f : new TextDecoder().decode(f);
+        },
+        fsReadBytes: async (_path, filename) => {
+          const f = get(filename);
+          return typeof f === 'string' ? new TextEncoder().encode(f) : f;
+        },
+        fsWriteString: async () => {},
+        fsWriteBytes: async (_path, filename, data) => { written.set(filename, data); },
+        fsWalk: async () => {},
+        exit: (code: number) => { exitCode = code; },
+      });
+      await cli.run(args);
+      if (exitCode !== 0) throw new Error(`cli exited with code ${exitCode}`);
+      return written;
+    }
+  });
 });
 
 async function make(args: string[], input: string, bytes: Uint8Array|null = null) : Promise<[string, Uint8Array]> {

--- a/test/integration_test.ts
+++ b/test/integration_test.ts
@@ -750,7 +750,9 @@ lbl2:
       expect(result.success).toBe(false);
       const errors = result.messages.filter(m => m.level === 'error');
       expect(errors.map(e => e.message)).toEqual([
-        'Expected constant string: NUM[$3039]',
+        // A numeric `.segment` is the anonymous form, so this is now the
+        // missing-`:size` error rather than "expected a string".
+        'An anonymous .segment requires :size',
         'Missing term',
         'No close paren: (',
         'Bad address mode add for nop',

--- a/test/integration_test.ts
+++ b/test/integration_test.ts
@@ -222,6 +222,116 @@ Relocatable:
       const result = await compileSource(source);
       expect(result).toBeTruthy();
     });
+
+    it('should place anonymous segments sequentially', async function() {
+      const source = `
+.segment $8000 :size $4000
+Bank0Start:
+  lda #$42
+  rts
+
+.segment $C000 :size $4000
+  jsr Bank0Start
+  rts
+`;
+      const result = await compileSource(source);
+      // Bank 0 goes to file offset 0, the fixed bank to $4000.
+      expect([...result.slice(0, 3)]).toEqual([0xa9, 0x42, 0x60]);
+      expect([...result.slice(0x4000, 0x4004)])
+          .toEqual([0x20, 0x00, 0x80, 0x60]);
+    });
+
+    it('should place two modules of anonymous segments in link order',
+       async function() {
+      const first: AssemblyInput = {type: 'source', name: 'first.s', code: `
+.segment $8000 :size $10
+Exported:
+  .byte $11
+.export Exported
+`};
+      const second: AssemblyInput = {type: 'source', name: 'second.s', code: `
+.segment $9000 :size $10
+  .byte $22
+  .word Exported
+.import Exported
+`};
+      const result = await compile([first, second], {lineContinuations: true});
+      if (!result.success) {
+        throw new Error(JSON.stringify(result.messages));
+      }
+      const data = result.outputs[0].data;
+      expect(data[0]).toBe(0x11);
+      // Second module's segment starts at file offset $10, and the cross-module
+      // reference still resolves to the first module's CPU address.
+      expect([...data.slice(0x10, 0x13)]).toEqual([0x22, 0x00, 0x80]);
+    });
+
+    it('should leave base ROM bytes alone without :fill', async function() {
+      const baseRom = new Uint8Array(0x20).fill(0xff);
+      const input: AssemblyInput = {type: 'source', name: 'test.s', code: `
+.segment $8000 :size $20
+.org $8004
+  .byte $11, $22
+`};
+      const result = await compile([input], {lineContinuations: true},
+                                   undefined, baseRom);
+      if (!result.success) throw new Error(JSON.stringify(result.messages));
+      const data = result.outputs[0].data;
+      expect([...data.slice(0x02, 0x08)])
+          .toEqual([0xff, 0xff, 0x11, 0x22, 0xff, 0xff]);
+    });
+
+    it('should blank the whole bank with :fill', async function() {
+      // The documented way to add a new, empty bank when expanding a ROM.
+      const baseRom = new Uint8Array(0x20).fill(0xff);
+      const input: AssemblyInput = {type: 'source', name: 'test.s', code: `
+.segment $8000 :size $20 :fill $00
+.org $8004
+  .byte $11, $22
+`};
+      const result = await compile([input], {lineContinuations: true},
+                                   undefined, baseRom);
+      if (!result.success) throw new Error(JSON.stringify(result.messages));
+      const data = result.outputs[0].data;
+      expect([...data.slice(0x02, 0x08)])
+          .toEqual([0x00, 0x00, 0x11, 0x22, 0x00, 0x00]);
+      expect(data.length).toBe(0x20);
+    });
+
+    it('should pack a later chunk into a .free range', async function() {
+      const source = `
+.segment $8000 :size $20
+  .byte $01, $02, $03, $04
+.free $10
+
+.reloc
+Packed:
+  .byte $aa, $bb
+`;
+      const result = await compileSource(source);
+      expect([...result.slice(0, 6)])
+          .toEqual([0x01, 0x02, 0x03, 0x04, 0xaa, 0xbb]);
+    });
+
+    it('should report anonymous segments in the map file', async function() {
+      const input: AssemblyInput = {type: 'source', name: 'test.s', code: `
+.segment $8000 :size $10
+  .byte $01
+.segment $8000 :size $10
+  .byte $02
+`};
+      const result = await compile(
+          [input], {lineContinuations: true, generateMapFile: true,
+                    generateDebugInfo: true});
+      if (!result.success) throw new Error(JSON.stringify(result.messages));
+      const map = result.outputs.find(o => o.type === 'map');
+      expect(map).toBeTruthy();
+      const text = new TextDecoder().decode(map!.data);
+      // Two banks at the same address, told apart by the line they were
+      // declared on, with sequential file offsets.
+      expect(text).toMatch(/@test\.s:2 \$8000\s+008000\s+00800F\s+000010\s+\S+\s+\S+\s+000000/);
+      expect(text).toMatch(/@test\.s:4 \$8000\s+008000\s+00800F\s+000010\s+\S+\s+\S+\s+000010/);
+    });
   });
 
   describe('ROM patching with base ROM', function() {

--- a/test/linker_test.ts
+++ b/test/linker_test.ts
@@ -4,7 +4,7 @@
 import {describe, it, expect} from 'bun:test';
 import {type Expr} from '../src/expr.ts';
 import {FreeSpace, Linker} from '../src/linker.ts';
-import {type Module} from '../src/module.ts';
+import {type Module, type Segment} from '../src/module.ts';
 import {SourceError} from '../src/token.ts';
 import * as util from '../src/util.ts';
 
@@ -1400,6 +1400,192 @@ describe('Linker with an ld65 config', function() {
     }
     expect(err).toBeInstanceOf(SourceError);
     expect((err as SourceError).source).toMatchObject({file: 'test.cfg'});
+  });
+});
+
+describe('anonymous segments', function() {
+  function anon(hash: string, memory: number, size: number,
+                extra: Partial<Segment> = {}): Segment {
+    return {name: `@anon@bank.s:${LINES[hash] ?? 1}:${hash}`, memory, size, ...extra};
+  }
+  const LINES: Record<string, number> = {aaa: 1, bbb: 2, ccc: 3};
+  const nameOf = (hash: string) => anon(hash, 0, 0).name;
+
+  it('should hand out sequential file offsets within one module', function() {
+    const m = {
+      chunks: [
+        {segments: [nameOf('aaa')], org: 0x8000, data: Uint8Array.of(1, 2)},
+        {segments: [nameOf('bbb')], org: 0x8000, data: Uint8Array.of(3, 4)},
+      ],
+      segments: [anon('aaa', 0x8000, 0x10), anon('bbb', 0x8000, 0x10)],
+    };
+    // Both segments keep memory $8000, but land at file offsets 0 and $10.
+    expect(chunks(link(m))).toEqual([[0, [1, 2]], [0x10, [3, 4]]]);
+  });
+
+  it('should hand out offsets across modules in read order', function() {
+    const a = {
+      chunks: [{segments: [nameOf('aaa')], org: 0x8000, data: Uint8Array.of(1, 2)}],
+      segments: [anon('aaa', 0x8000, 0x10)],
+    };
+    const b = {
+      chunks: [{segments: [nameOf('bbb')], org: 0x9000, data: Uint8Array.of(3, 4)}],
+      segments: [anon('bbb', 0x9000, 0x10)],
+    };
+    expect(chunks(link(a, b))).toEqual([[0, [1, 2]], [0x10, [3, 4]]]);
+  });
+
+  it('should reverse the offsets when the module order reverses', function() {
+    const a = {
+      chunks: [{segments: [nameOf('aaa')], org: 0x8000, data: Uint8Array.of(1, 2)}],
+      segments: [anon('aaa', 0x8000, 0x10)],
+    };
+    const b = {
+      chunks: [{segments: [nameOf('bbb')], org: 0x9000, data: Uint8Array.of(3, 4)}],
+      segments: [anon('bbb', 0x9000, 0x10)],
+    };
+    // Link order is the single source of truth for layout.
+    expect(chunks(link(b, a))).toEqual([[0, [3, 4]], [0x10, [1, 2]]]);
+  });
+
+  it('should keep declaration order when it disagrees with every other key', function() {
+    // Validate that the declaration order for the segments matches the link order
+    // if these got outta sync with a future change, it could cause headaches.
+    const m = {
+      chunks: [
+        {segments: [nameOf('ccc')], org: 0xa000, data: Uint8Array.of(5, 6)},
+        {segments: [nameOf('bbb')], org: 0x9000, data: Uint8Array.of(3, 4)},
+        {segments: [nameOf('aaa')], org: 0x8000, data: Uint8Array.of(1, 2)},
+      ],
+      segments: [anon('ccc', 0xa000, 0x10), anon('bbb', 0x9000, 0x10),
+                 anon('aaa', 0x8000, 0x10)],
+    };
+    // Declared ccc, bbb, aaa -> that is the file order, addresses notwithstanding.
+    expect(chunks(link(m)))
+        .toEqual([[0, [5, 6]], [0x10, [3, 4]], [0x20, [1, 2]]]);
+  });
+
+  it('should reserve file space for an empty segment', function() {
+    const m = {
+      chunks: [
+        {segments: [nameOf('aaa')], org: 0x8000, data: Uint8Array.of(1, 2)},
+        {segments: [nameOf('ccc')], org: 0xa000, data: Uint8Array.of(5, 6)},
+      ],
+      // The middle segment holds no chunks, but still owns its $10 of file.
+      segments: [anon('aaa', 0x8000, 0x10), anon('bbb', 0x9000, 0x10),
+                 anon('ccc', 0xa000, 0x10)],
+    };
+    expect(chunks(link(m))).toEqual([[0, [1, 2]], [0x20, [5, 6]]]);
+  });
+
+  it('should fill the whole range of a :fill segment', function() {
+    const m = {
+      chunks: [{segments: [nameOf('aaa')], org: 0x8002, data: Uint8Array.of(1, 2)}],
+      segments: [anon('aaa', 0x8000, 0x8,
+                      {fill: 0xff, free: [[0x8000, 0x8008]]})],
+    };
+    expect(chunks(link(m)))
+        .toEqual([[0, [0xff, 0xff, 1, 2, 0xff, 0xff, 0xff, 0xff]]]);
+  });
+
+  it('should reject mixing with a named segment', function() {
+    const a = {
+      chunks: [{segments: [nameOf('aaa')], org: 0x8000, data: Uint8Array.of(1, 2)}],
+      segments: [anon('aaa', 0x8000, 0x10)],
+    };
+    const b = {
+      chunks: [{segments: ['code'], org: 0x9000, data: Uint8Array.of(3, 4)}],
+      segments: [{name: 'code', memory: 0x9000, size: 0x10, offset: 0x10}],
+    };
+    expect(() => link(a, b))
+        .toThrow(/Anonymous segments cannot be combined with named segments/);
+  });
+
+  it('should reject mixing with an ld65 config', function() {
+    const m = {
+      chunks: [{segments: [nameOf('aaa')], org: 0x8000, data: Uint8Array.of(1, 2)}],
+      segments: [anon('aaa', 0x8000, 0x10)],
+    };
+    const cfg = `
+      MEMORY { PRG: start = $8000, size = $10, file = %O; }
+      SEGMENTS { CODE: load = PRG; }`;
+    const linker = new Linker({linkerConfig: cfg, linkerConfigName: 'test.cfg'});
+    expect(() => linker.read(m).link())
+        .toThrow(/A linker config cannot be combined with anonymous segments/);
+  });
+
+  it('should reject mixing with a --target', function() {
+    const m = {
+      chunks: [{segments: [nameOf('aaa')], org: 0x8000, data: Uint8Array.of(1, 2)}],
+      segments: [anon('aaa', 0x8000, 0x10)],
+    };
+    const linker = new Linker({target: 'nes-nrom'});
+    expect(() => linker.read(m).link())
+        .toThrow(/--target nes-nrom cannot be combined with anonymous segments/);
+  });
+
+  it('should reject a duplicate anonymous segment name', function() {
+    // Two modules that somehow minted the same hash would otherwise be merged
+    // last-wins, silently fusing two banks into one.
+    const a = {
+      chunks: [{segments: [nameOf('aaa')], org: 0x8000, data: Uint8Array.of(1, 2)}],
+      segments: [anon('aaa', 0x8000, 0x10)],
+    };
+    const b = {
+      chunks: [{segments: [nameOf('aaa')], org: 0x8000, data: Uint8Array.of(3, 4)}],
+      segments: [anon('aaa', 0x8000, 0x10)],
+    };
+    expect(() => link(a, b))
+        .toThrow(/Duplicate anonymous segment @anon@bank\.s:1:aaa/);
+  });
+
+  it('should reject a chunk that named no segment', function() {
+    const m = {
+      chunks: [{segments: [], data: Uint8Array.of(1, 2)},
+               {segments: [nameOf('aaa')], org: 0x8000, data: Uint8Array.of(3, 4)}],
+      segments: [anon('aaa', 0x8000, 0x10)],
+    };
+    expect(() => link(m)).toThrow(/emitted before the first \.segment/);
+  });
+
+  it('should reject an .org outside its segment', function() {
+    const m = {
+      chunks: [{segments: [nameOf('aaa')], org: 0x9000, data: Uint8Array.of(1, 2)}],
+      segments: [anon('aaa', 0x8000, 0x10)],
+    };
+    expect(() => link(m)).toThrow(
+        /\.org \$9000 is outside the anonymous segment @bank\.s:1 \$8000/);
+  });
+
+  it('should label anonymous segments by declaration site in the map',
+     function() {
+    const m = {
+      chunks: [
+        {segments: [nameOf('aaa')], org: 0x8000, data: Uint8Array.of(1, 2)},
+        {segments: [nameOf('bbb')], org: 0x8000, data: Uint8Array.of(3, 4)},
+      ],
+      // Two banks at the same address: only the line tells them apart.
+      segments: [anon('aaa', 0x8000, 0x10), anon('bbb', 0x8000, 0x10)],
+    };
+    const linker = new Linker();
+    linker.read(m).link();
+    const report = linker.report();
+    expect(report).toContain('@bank.s:1 $8000');
+    expect(report).toContain('@bank.s:2 $8000');
+    // The hash never reaches the report.
+    expect(report).not.toContain('@anon@');
+  });
+
+  it('should fall back to the raw name when it has no source', function() {
+    // A hand-built module (or an older object file) whose name isn't in the
+    // generated shape still links, and prints as-is rather than crashing.
+    const m = {
+      chunks: [{segments: ['@anon@bare'], org: 0x8000, data: Uint8Array.of(1, 2)}],
+      segments: [{name: '@anon@bare', memory: 0x8000, size: 0x10}],
+    };
+    const linker = new Linker();
+    expect(chunks(linker.read(m).link())).toEqual([[0, [1, 2]]]);
+    expect(linker.report()).toContain('@anon@bare');
   });
 });
 


### PR DESCRIPTION

Adds a new basic way to define segments similar in style to how assemblers like asm6 works.

Here's an example of the feature:

```
; creates a MEMORY and SEGMENT without a name that functions much like how asm6 users use BASE/PAD for creating banks of data.
; The first param is the BASE address for the data
; :size pads the output to this length (without filling bytes to the file, in case you are patching)
; :fill is an optional flag that turns on fill mode and takes an optional value to fill with
; :bank is the same as ca65 bank = NN attribute
.segment $8000 :size $2000 [:fill [<n>]] [:bank <n>]
MyLabel:
  .byte "Hello World!"
; Segments are output to the final rom in order they are declared
.segment $a000 :size $2000
LabelTwo:
  .byte "I'm here too!"
```